### PR TITLE
Add support for token object for ProviderAzure. Fixes #195

### DIFF
--- a/R/utils-S7.R
+++ b/R/utils-S7.R
@@ -94,3 +94,25 @@ prop_number_whole <- function(default = NULL, min = NULL, max = NULL, allow_null
     }
   )
 }
+
+prop_azure_token <- function(allow_null = FALSE) {
+  force(allow_null)
+  ## The call to AzureAuth ensures that the class name of the Azure Token does not change
+  class_name = AzureAuth::AzureToken$self$classname
+  ## The returned token object is R6 - not currently supported by the S7::as_class()
+  ## so I made a new S3 class to use validator
+  AzureToken_class <- new_S3_class(class_name)
+
+  new_property(
+    class = if (allow_null) NULL | AzureToken_class else AzureToken_class,
+    validator = function(value) {
+      if (allow_null && is.null(value)) {
+        return()
+      }
+
+      if (!inherits(value, class_name)) {
+        paste0("must be an object of class <", class_name, ">, not ", obj_type_friendly(value), ".")
+      }
+    }
+  )
+}

--- a/R/utils-S7.R
+++ b/R/utils-S7.R
@@ -95,24 +95,3 @@ prop_number_whole <- function(default = NULL, min = NULL, max = NULL, allow_null
   )
 }
 
-prop_azure_token <- function(allow_null = FALSE) {
-  force(allow_null)
-  ## The call to AzureAuth ensures that the class name of the Azure Token does not change
-  class_name = AzureAuth::AzureToken$self$classname
-  ## The returned token object is R6 - not currently supported by the S7::as_class()
-  ## so I made a new S3 class to use validator
-  AzureToken_class <- new_S3_class(class_name)
-
-  new_property(
-    class = if (allow_null) NULL | AzureToken_class else AzureToken_class,
-    validator = function(value) {
-      if (allow_null && is.null(value)) {
-        return()
-      }
-
-      if (!inherits(value, class_name)) {
-        paste0("must be an object of class <", class_name, ">, not ", obj_type_friendly(value), ".")
-      }
-    }
-  )
-}

--- a/R/utils.R
+++ b/R/utils.R
@@ -80,3 +80,11 @@ dots_named <- function(...) {
   x[[length(x) + 1]] <- value
   x
 }
+
+is_azure_token <- function (object)
+{
+  R6::is.R6(object) && inherits(object, "AzureToken")
+}
+
+
+

--- a/man/chat_azure.Rd
+++ b/man/chat_azure.Rd
@@ -35,8 +35,8 @@ scratch.}
 not supply this directly, but instead set the \code{AZURE_OPENAI_API_KEY} environment
 variable.}
 
-\item{token}{Azure token for authentication. This is typically not required for
-Azure OpenAI API calls, but can be used if your setup requires it.}
+\item{token}{Azure token object of class AzureToken for authentication. This is typically not required for
+Azure OpenAI API calls, but can be used if your setup requires it. The token object is retrieved using the AzureAuth package.#' Using the token object ensures a refresh method is available for the token.}
 
 \item{api_args}{Named list of arbitrary extra arguments appended to the body
 of every chat API call.}

--- a/man/chat_azure.Rd
+++ b/man/chat_azure.Rd
@@ -11,7 +11,7 @@ chat_azure(
   system_prompt = NULL,
   turns = NULL,
   api_key = azure_key(),
-  token = NULL,
+  azure_token = NULL,
   api_args = list(),
   echo = c("none", "text", "all")
 )
@@ -35,8 +35,8 @@ scratch.}
 not supply this directly, but instead set the \code{AZURE_OPENAI_API_KEY} environment
 variable.}
 
-\item{token}{Azure token object of class AzureToken for authentication. This is typically not required for
-Azure OpenAI API calls, but can be used if your setup requires it. The token object is retrieved using the AzureAuth package.#' Using the token object ensures a refresh method is available for the token.}
+\item{azure_token}{token object of class AzureToken for authentication. This is typically not required for
+Azure OpenAI API calls, but can be used if your setup requires it. The azure_token object is retrieved using the AzureAuth package.#' Using the azure_token object ensures a refresh method is available for the token.}
 
 \item{api_args}{Named list of arbitrary extra arguments appended to the body
 of every chat API call.}


### PR DESCRIPTION
This pull request addresses issue #195. The problem solved is that the token passed to the chat object can expire, and then the chat can no longer be continued. 

I propose that the AzureAuth token object be passed instead, which allows for the validate method to determine if the token is expired and the refresh method to refresh the token.

Help is requested on the `prop_azure_token()` function, to eliminate the dependency on the AzureAuth package.