### PR TITLE
Pick up on SPARK_CONNECT_USER_AGENT in chat_databricks()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@
 * `chat_databricks()` now handles the `DATABRICKS_HOST` environment variable
   correctly whether it includes an HTTPS prefix or not (#252, @atheriel).
 
+* `chat_databricks()` now respects the `SPARK_CONNECT_USER_AGENT` environment
+  variable when making requests (#254, @atheriel).
+
 # ellmer 0.1.0
 
 * New `chat_vllm()` to chat with models served by vLLM (#140).

--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -89,6 +89,7 @@ method(chat_request, ProviderDatabricks) <- function(provider,
   req <- req_auth_bearer_token(req,
     databricks_token(provider@base_url, provider@token)
   )
+  req <- req_user_agent(req, databricks_user_agent())
   req <- req_retry(req, max_tries = 2)
   req <- req_error(req, body = function(resp) {
     if (resp_content_type(resp) == "application/json") {
@@ -172,6 +173,14 @@ databricks_workspace <- function() {
     host <- paste0("https://", host)
   }
   host
+}
+
+databricks_user_agent <- function() {
+  user_agent <- paste0("r-ellmer/", utils::packageVersion("ellmer"))
+  if (nchar(Sys.getenv("SPARK_CONNECT_USER_AGENT")) != 0) {
+    user_agent <- paste(Sys.getenv("SPARK_CONNECT_USER_AGENT"), user_agent)
+  }
+  user_agent
 }
 
 # Try various ways to get Databricks credentials. This implements a subset of

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -100,3 +100,14 @@ test_that("workspace detection handles URLs with and without an https prefix", {
     )
   )
 })
+
+test_that("the user agent respects SPARK_CONNECT_USER_AGENT when set", {
+  withr::with_envvar(
+    c(SPARK_CONNECT_USER_AGENT = NA),
+    expect_match(databricks_user_agent(), "^r-ellmer")
+  )
+  withr::with_envvar(
+    c(SPARK_CONNECT_USER_AGENT = "testing"),
+    expect_match(databricks_user_agent(), "^testing r-ellmer")
+  )
+})


### PR DESCRIPTION
`SPARK_CONNECT_USER_AGENT` is the standard environment variable used to set the user agent in various Databricks and Spark-related projects. This commit adds some detection for when this is set, much like we have in `odbc` and `pysparklyr`.

Unit tests are included.