### PR TITLE
Restore the ability to use both API keys and tokens in chat_azure()

### DIFF
--- a/tests/testthat/_snaps/provider-azure.md
+++ b/tests/testthat/_snaps/provider-azure.md
@@ -30,3 +30,20 @@
       * retry_on_failure: FALSE
       * error_body: a function
 
+---
+
+    Code
+      req
+    Message
+      <httr2_request>
+      POST
+      https://ai-hwickhamai260967855527.openai.azure.com/openai/deployments/gpt-4o-mini/chat/completions?api-version=2024-06-01
+      Headers:
+      * api-key: '<REDACTED>'
+      * Authorization: '<REDACTED>'
+      Body: json encoded data
+      Policies:
+      * retry_max_tries: 2
+      * retry_on_failure: FALSE
+      * error_body: a function
+

--- a/tests/testthat/test-provider-azure.R
+++ b/tests/testthat/test-provider-azure.R
@@ -26,6 +26,7 @@ test_that("Azure request headers are generated correctly", {
     endpoint = endpoint,
     deployment_id = deployment_id,
     api_version = "2024-06-01",
+    api_key = "key",
     credentials = default_azure_credentials("key")
   )
   req <- chat_request(p, FALSE, list(turn))
@@ -36,7 +37,19 @@ test_that("Azure request headers are generated correctly", {
     endpoint = endpoint,
     deployment_id = deployment_id,
     api_version = "2024-06-01",
+    api_key = "",
     credentials = default_azure_credentials("", "token")
+  )
+  req <- chat_request(p, FALSE, list(turn))
+  expect_snapshot(req)
+
+  # Both.
+  p <- ProviderAzure(
+    endpoint = endpoint,
+    deployment_id = deployment_id,
+    api_version = "2024-06-01",
+    api_key = "key",
+    credentials = default_azure_credentials("key", "token")
   )
   req <- chat_request(p, FALSE, list(turn))
   expect_snapshot(req)


### PR DESCRIPTION
This implements the suggestion from testers of #248, who rightly pointed out that my assumption that API keys and Entra ID credentials are mutually exclusive was incorrect.

Unit tests are included.