### PR TITLE
Detect credentials from Azure service principals in `chat_azure()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,9 @@
   API](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-llm-rest-api)
   (#258, @atheriel).
 
+* `chat_azure()` now picks up credentials from Azure service principals
+  automatically (#263, @atheriel).
+
 # ellmer 0.1.0
 
 * New `chat_vllm()` to chat with models served by vLLM (#140).

--- a/man/chat_azure.Rd
+++ b/man/chat_azure.Rd
@@ -65,6 +65,13 @@ A \link{Chat} object.
 The \href{https://azure.microsoft.com/en-us/products/ai-services/openai-service}{Azure OpenAI server}
 hosts a number of open source models as well as proprietary models
 from OpenAI.
+\subsection{Authentication}{
+
+\code{chat_azure()} supports API keys and the \code{credentials} parameter, but it also
+picks up on Azure service principals automatically when the
+\code{AZURE_TENANT_ID}, \code{AZURE_CLIENT_ID}, and \code{AZURE_CLIENT_SECRET} environment
+variables are set.
+}
 }
 \examples{
 \dontrun{

--- a/tests/testthat/_snaps/provider-azure.md
+++ b/tests/testthat/_snaps/provider-azure.md
@@ -56,3 +56,33 @@
       * retry_realm: "ai-hwickhamai260967855527.openai.azure.com"
       * error_body: a function
 
+# service principal authentication requests look correct
+
+    Code
+      list(url = req$url, headers = req$headers, body = req$body$data)
+    Output
+      $url
+      [1] "https://login.microsoftonline.com/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/oauth2/v2.0/token"
+      
+      $headers
+      $headers$Accept
+      [1] "application/json"
+      
+      attr(,"redact")
+      character(0)
+      
+      $body
+      $body$grant_type
+      [1] "client_credentials"
+      
+      $body$scope
+      [1] "https%3A%2F%2Fcognitiveservices.azure.com%2F.default"
+      
+      $body$client_id
+      [1] "id"
+      
+      $body$client_secret
+      [1] "secret"
+      
+      
+

--- a/tests/testthat/test-provider-azure.R
+++ b/tests/testthat/test-provider-azure.R
@@ -54,3 +54,20 @@ test_that("Azure request headers are generated correctly", {
   req <- chat_request(p, FALSE, list(turn))
   expect_snapshot(req)
 })
+
+test_that("service principal authentication requests look correct", {
+  withr::local_envvar(
+    AZURE_TENANT_ID = "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e",
+    AZURE_CLIENT_ID = "id",
+    AZURE_CLIENT_SECRET = "secret"
+  )
+  local_mocked_responses(function(req) {
+    # Snapshot relevant fields of the outgoing request.
+    expect_snapshot(
+      list(url = req$url, headers = req$headers, body = req$body$data)
+    )
+    response_json(body = list(access_token = "token"))
+  })
+  source <- default_azure_credentials()
+  expect_equal(source(), list(Authorization = "Bearer token"))
+})


### PR DESCRIPTION
Inspired by a [recent comment][0], this commit adds support for picking up on Azure service principals, which seem to be a common way to furnish `chat_azure()` with credentials without the need for an API key.

This approach also handles caching and expiry for these tokens, an ongoing source of problems for users.

Unit tests are included. I've also updated the documentation.

[0]: https://github.com/tidyverse/ellmer/issues/262#issuecomment-2606628246