### PR TITLE
Improve support for temporary IAM credentials in chat_bedrock()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,9 @@
   disambiguate it from `chat_snowflake()` (which *also* uses "Cortex") (#275,
   @atheriel).
 
+* `chat_bedrock()` now handles temporary IAM credentials better (#261,
+  @atheriel).
+
 # ellmer 0.1.0
 
 * New `chat_vllm()` to chat with models served by vLLM (#140).


### PR DESCRIPTION
Many AWS IAM credentials expire, but previously we ignored this by looking up credentials only once, in `chat_bedrock()`. This commit introduces a caching layer that handles expiry and moves credential retrieval closer to request time, instead.

The design is almost identical to httr2's OAuth token caching mechanism, but I had to re-implement various pieces because not all of that API is exported.

(We could probably introduce a `req_aws_credentials()` function to `httr2` itself that would handle this, but that might tie us too closely to the semantics of `paws.common`.)

Unit tests are included.

Closes #261.