### PR TITLE
Fix the use of `req_error()` for `chat_azure()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,9 @@
 * `chat_azure()` now picks up credentials from Azure service principals
   automatically (#263, @atheriel).
 
+* `chat_azure()` now reports better error messages when the underlying HTTP
+  requests fail (#269, @atheriel).
+
 # ellmer 0.1.0
 
 * New `chat_vllm()` to chat with models served by vLLM (#140).

--- a/R/provider-azure.R
+++ b/R/provider-azure.R
@@ -121,7 +121,10 @@ method(chat_request, ProviderAzure) <- function(provider,
   }
   req <- req_headers(req, !!!provider@credentials(), .redact = "Authorization")
   req <- req_retry(req, max_tries = 2)
-  req <- req_error(req, body = function(resp) resp_body_json(resp)$message)
+  req <- req_error(req, body = function(resp) {
+    error <- resp_body_json(resp)$error
+    paste0(error$code, ": ", error$message)
+  })
 
   messages <- compact(unlist(as_json(provider, turns), recursive = FALSE))
   tools <- as_json(provider, unname(tools))


### PR DESCRIPTION
Previously we were trying to access a non-existent field in the response. Now we show both the error code and the message. For example:

    Error in `req_perform_connection()` at elmer/R/httr2.R:36:3:
    ! HTTP 401 Unauthorized.
    • PermissionDenied: Principal does not have access to API/Operation.