### PR TITLE
Add support for interactive Entra ID authentication to `chat_azure()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,9 @@
 * The `token` argument to `chat_azure()` has been deprecated. Use ambient
   credentials or the `credentials` argument instead (#257, @atheriel).
 
+* `chat_azure()` attempts to use interactive Entra ID authentication if no other
+  credentials are available (#273, @atheriel).
+
 # ellmer 0.1.0
 
 * New `chat_vllm()` to chat with models served by vLLM (#140).

--- a/man/chat_azure.Rd
+++ b/man/chat_azure.Rd
@@ -73,6 +73,10 @@ from OpenAI.
 picks up on Azure service principals automatically when the
 \code{AZURE_TENANT_ID}, \code{AZURE_CLIENT_ID}, and \code{AZURE_CLIENT_SECRET} environment
 variables are set.
+
+Finally, in interactive sessions it will also attempt to use Microsoft Entra
+ID authentication -- much like the Azure CLI -- if no API key has been
+provided.
 }
 }
 \examples{


### PR DESCRIPTION
This commit adds support for another major Azure authentication approach: the OAuth authorization code flow, as used by the Azure CLI.

This is a good choice for authentiation during development on desktop, and Microsoft recommends it for Azure OpenAI because it doesn't require storing sensitive long-lived secrets like API keys.

All of this is pretty stock httr2 OAuth stuff, despite the fact that Entra ID has its own... idiosyncrasies. I also went out of the way to add a really specific error message for what I believe to be a common source of problems: misconfiguration of Azure's RBAC. It looks as follows:

    Error in `req_perform_connection()` at elmer/R/httr2.R:36:3:
    ! HTTP 401 Unauthorized.
    • PermissionDenied: Principal does not have access to API/Operation.
    ℹ Your user or service principal likely needs one of the following
      roles: Cognitive Services OpenAI User, Cognitive Services OpenAI
      Contributor, or Cognitive Services Contributor.

I haven't added any unit tests (I don't know how to do so for this kind of interactive OAuth flow), but at least the help documentation has been updated.