### PR TITLE
Mention `chat_snowflake()` in the README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -49,7 +49,7 @@ ellmer supports a wide variety of model providers:
 * OpenAI: `chat_openai()`.
 * OpenRouter: `chat_openrouter()`.
 * perplexity.ai: `chat_perplexity()`.
-* Snowflake Cortex: `chat_cortex()`.
+* Snowflake Cortex: `chat_snowflake()` and `chat_cortex_analyst()`.
 * VLLM: `chat_vllm()`.
 
 ## Model choice

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ellmer supports a wide variety of model providers:
 - OpenAI: `chat_openai()`.
 - OpenRouter: `chat_openrouter()`.
 - perplexity.ai: `chat_perplexity()`.
-- Snowflake Cortex: `chat_cortex()`.
+- Snowflake Cortex: `chat_snowflake()` and `chat_cortex_analyst()`.
 - VLLM: `chat_vllm()`.
 
 ## Model choice


### PR DESCRIPTION
Plus, make sure we refer to the renamed `chat_cortex_analyst()` function rather than the deprecated `chat_cortex()`.