### PR TITLE
Improve the internal consistency of credential handling

### DIFF
--- a/man/chat_cortex.Rd
+++ b/man/chat_cortex.Rd
@@ -19,8 +19,8 @@ e.g. \code{"testorg-test_account"}. Defaults to the value of the
 \code{SNOWFLAKE_ACCOUNT} environment variable.}
 
 \item{credentials}{A list of authentication headers to pass into
-\code{\link[httr2:req_headers]{httr2::req_headers()}}, a function that returns them when passed
-\code{account} as a parameter, or \code{NULL} to use ambient credentials.}
+\code{\link[httr2:req_headers]{httr2::req_headers()}}, a function that returns them when called, or
+\code{NULL} to use ambient credentials.}
 
 \item{model_spec}{A semantic model specification, or \code{NULL} when
 using \code{model_file} instead.}

--- a/man/chat_cortex_analyst.Rd
+++ b/man/chat_cortex_analyst.Rd
@@ -19,8 +19,8 @@ e.g. \code{"testorg-test_account"}. Defaults to the value of the
 \code{SNOWFLAKE_ACCOUNT} environment variable.}
 
 \item{credentials}{A list of authentication headers to pass into
-\code{\link[httr2:req_headers]{httr2::req_headers()}}, a function that returns them when passed
-\code{account} as a parameter, or \code{NULL} to use ambient credentials.}
+\code{\link[httr2:req_headers]{httr2::req_headers()}}, a function that returns them when called, or
+\code{NULL} to use ambient credentials.}
 
 \item{model_spec}{A semantic model specification, or \code{NULL} when
 using \code{model_file} instead.}

--- a/man/chat_snowflake.Rd
+++ b/man/chat_snowflake.Rd
@@ -26,8 +26,8 @@ e.g. \code{"testorg-test_account"}. Defaults to the value of the
 \code{SNOWFLAKE_ACCOUNT} environment variable.}
 
 \item{credentials}{A list of authentication headers to pass into
-\code{\link[httr2:req_headers]{httr2::req_headers()}}, a function that returns them when passed
-\code{account} as a parameter, or \code{NULL} to use ambient credentials.}
+\code{\link[httr2:req_headers]{httr2::req_headers()}}, a function that returns them when called, or
+\code{NULL} to use ambient credentials.}
 
 \item{model}{The model to use for the chat. The default, \code{NULL}, will pick
 a reasonable default, and tell you about. We strongly recommend explicitly

--- a/tests/testthat/_snaps/provider-snowflake.md
+++ b/tests/testthat/_snaps/provider-snowflake.md
@@ -1,7 +1,7 @@
 # defaults are reported
 
     Code
-      . <- chat_snowflake(credentials = credentials)
+      . <- chat_snowflake()
     Message
       Using model = "llama3.1-70b".
 

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -64,8 +64,20 @@ test_that("Databricks PATs are detected correctly", {
     DATABRICKS_HOST = "https://example.cloud.databricks.com",
     DATABRICKS_TOKEN = "token"
   )
-  expect_equal(databricks_token(), "token")
-  expect_equal(databricks_token(token = "another token"), "another token")
+  credentials <- default_databricks_credentials()
+  expect_equal(credentials(), list(Authorization = "Bearer token"))
+})
+
+test_that("Databricks CLI tokens are detected correctly", {
+  withr::local_envvar(
+    DATABRICKS_HOST = "https://example.cloud.databricks.com",
+    DATABRICKS_CLI_PATH = "echo"
+  )
+  local_mocked_bindings(
+    databricks_cli_token = function(path, host) "token"
+  )
+  credentials <- default_databricks_credentials()
+  expect_equal(credentials(), list(Authorization = "Bearer token"))
 })
 
 test_that("M2M authentication requests look correct", {
@@ -81,7 +93,8 @@ test_that("M2M authentication requests look correct", {
     )
     response_json(body = list(access_token = "token"))
   })
-  expect_equal(databricks_token(), "token")
+  credentials <- default_databricks_credentials()
+  expect_equal(credentials(), list(Authorization = "Bearer token"))
 })
 
 test_that("workspace detection handles URLs with and without an https prefix", {


### PR DESCRIPTION
This commit adopts the pattern used in `chat_azure()` to `chat_databricks()` and `chat_snowflake()`. That is: these providers now have a single `credentials` property that returns a list of headers when called.

In addition, there is now consistent internal usage of a `default_x_credentials()` function that itself returns a `credentials` function.

(Through experimenting with various designs, I decided that a simple function factory approach was preferable to the heavyweight S7 classes and generics approach I thought we could use initially.)

Finally, I've added several new unit tests for Databricks and Snowflake authentication.

Closes #262.