### PR TITLE
Add viewer-based credential support for Azure, Databricks & Snowflake

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Imports:
 Suggests:
     base64enc,
     bslib,
+    connectcreds,
     curl (>= 6.0.1),
     gitcreds,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,10 @@
 * `chat_bedrock()` now handles temporary IAM credentials better (#261,
   @atheriel).
 
+* `chat_azure()`, `chat_databricks()`, `chat_snowflake()`, and
+  `chat_cortex_analyst()` now detect viewer-based credentials when running on
+  Posit Connect (#285, @atheriel).
+
 # ellmer 0.1.0
 
 * New `chat_vllm()` to chat with models served by vLLM (#140).

--- a/R/provider-cortex.R
+++ b/R/provider-cortex.R
@@ -21,6 +21,8 @@ NULL
 #'   to one) environment variables.
 #' - Posit Workbench-managed Snowflake credentials for the corresponding
 #'   `account`.
+#' - Viewer-based credentials on Posit Connect. Requires the \pkg{connectcreds}
+#'   package.
 #'
 #' ## Known limitations
 #'

--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -17,6 +17,8 @@
 #' - User account via OAuth (OAuth U2M)
 #' - Authentication via the Databricks CLI
 #' - Posit Workbench-managed credentials
+#' - Viewer-based credentials on Posit Connect. Requires the \pkg{connectcreds}
+#'   package.
 #'
 #' ## Known limitations
 #'
@@ -192,6 +194,14 @@ databricks_user_agent <- function() {
 # the "Databricks client unified authentication" model.
 default_databricks_credentials <- function(workspace = databricks_workspace()) {
   host <- gsub("https://|/$", "", workspace)
+
+  # Detect viewer-based credentials from Posit Connect.
+  if (has_connect_viewer_token(resource = workspace)) {
+    return(function() {
+      token <- connectcreds::connect_viewer_token(workspace)
+      list(Authorization = paste("Bearer", token$access_token))
+    })
+  }
 
   # An explicit PAT takes precedence over everything else.
   token <- Sys.getenv("DATABRICKS_TOKEN")

--- a/R/utils.R
+++ b/R/utils.R
@@ -114,3 +114,10 @@ credentials_cache <- function(key) {
     clear = function() env_unbind(the$credentials_cache, key)
   )
 }
+
+has_connect_viewer_token <- function(...) {
+  if (!is_installed("connectcreds")) {
+    return(FALSE)
+  }
+  connectcreds::has_viewer_token(...)
+}

--- a/man/chat_azure.Rd
+++ b/man/chat_azure.Rd
@@ -70,13 +70,14 @@ from OpenAI.
 \subsection{Authentication}{
 
 \code{chat_azure()} supports API keys and the \code{credentials} parameter, but it also
-picks up on Azure service principals automatically when the
-\code{AZURE_TENANT_ID}, \code{AZURE_CLIENT_ID}, and \code{AZURE_CLIENT_SECRET} environment
-variables are set.
-
-Finally, in interactive sessions it will also attempt to use Microsoft Entra
-ID authentication -- much like the Azure CLI -- if no API key has been
-provided.
+makes use of:
+\itemize{
+\item Azure service principals (when the \code{AZURE_TENANT_ID}, \code{AZURE_CLIENT_ID},
+and \code{AZURE_CLIENT_SECRET} environment variables are set).
+\item Interactive Entra ID authentication, like the Azure CLI.
+\item Viewer-based credentials on Posit Connect. Requires the \pkg{connectcreds}
+package.
+}
 }
 }
 \examples{

--- a/man/chat_cortex.Rd
+++ b/man/chat_cortex.Rd
@@ -20,7 +20,7 @@ e.g. \code{"testorg-test_account"}. Defaults to the value of the
 
 \item{credentials}{A list of authentication headers to pass into
 \code{\link[httr2:req_headers]{httr2::req_headers()}}, a function that returns them when called, or
-\code{NULL} to use ambient credentials.}
+\code{NULL}, the default, to use ambient credentials.}
 
 \item{model_spec}{A semantic model specification, or \code{NULL} when
 using \code{model_file} instead.}

--- a/man/chat_cortex_analyst.Rd
+++ b/man/chat_cortex_analyst.Rd
@@ -20,7 +20,7 @@ e.g. \code{"testorg-test_account"}. Defaults to the value of the
 
 \item{credentials}{A list of authentication headers to pass into
 \code{\link[httr2:req_headers]{httr2::req_headers()}}, a function that returns them when called, or
-\code{NULL} to use ambient credentials.}
+\code{NULL}, the default, to use ambient credentials.}
 
 \item{model_spec}{A semantic model specification, or \code{NULL} when
 using \code{model_file} instead.}
@@ -57,6 +57,8 @@ variable.
 to one) environment variables.
 \item Posit Workbench-managed Snowflake credentials for the corresponding
 \code{account}.
+\item Viewer-based credentials on Posit Connect. Requires the \pkg{connectcreds}
+package.
 }
 }
 

--- a/man/chat_databricks.Rd
+++ b/man/chat_databricks.Rd
@@ -69,6 +69,8 @@ model. Specifically, it supports:
 \item User account via OAuth (OAuth U2M)
 \item Authentication via the Databricks CLI
 \item Posit Workbench-managed credentials
+\item Viewer-based credentials on Posit Connect. Requires the \pkg{connectcreds}
+package.
 }
 }
 

--- a/man/chat_snowflake.Rd
+++ b/man/chat_snowflake.Rd
@@ -27,7 +27,7 @@ e.g. \code{"testorg-test_account"}. Defaults to the value of the
 
 \item{credentials}{A list of authentication headers to pass into
 \code{\link[httr2:req_headers]{httr2::req_headers()}}, a function that returns them when called, or
-\code{NULL} to use ambient credentials.}
+\code{NULL}, the default, to use ambient credentials.}
 
 \item{model}{The model to use for the chat. The default, \code{NULL}, will pick
 a reasonable default, and tell you about. We strongly recommend explicitly
@@ -63,6 +63,8 @@ variable.
 to one) environment variables.
 \item Posit Workbench-managed Snowflake credentials for the corresponding
 \code{account}.
+\item Viewer-based credentials on Posit Connect. Requires the \pkg{connectcreds}
+package.
 }
 }
 

--- a/tests/testthat/test-provider-azure.R
+++ b/tests/testthat/test-provider-azure.R
@@ -109,3 +109,11 @@ test_that("service principal authentication requests look correct", {
   source <- default_azure_credentials()
   expect_equal(source(), list(Authorization = "Bearer token"))
 })
+
+test_that("tokens can be requested from a Connect server", {
+  skip_if_not_installed("connectcreds")
+
+  connectcreds::local_mocked_connect_responses(token = "token")
+  credentials <- default_azure_credentials()
+  expect_equal(credentials(), list(Authorization = "Bearer token"))
+})

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -124,3 +124,15 @@ test_that("the user agent respects SPARK_CONNECT_USER_AGENT when set", {
     expect_match(databricks_user_agent(), "^testing r-ellmer")
   )
 })
+
+test_that("tokens can be requested from a Connect server", {
+  skip_if_not_installed("connectcreds")
+
+  withr::local_envvar(
+    DATABRICKS_HOST = "https://example.cloud.databricks.com",
+    DATABRICKS_TOKEN = "token"
+  )
+  connectcreds::local_mocked_connect_responses(token = "token")
+  credentials <- default_databricks_credentials()
+  expect_equal(credentials(), list(Authorization = "Bearer token"))
+})

--- a/tests/testthat/test-provider-snowflake.R
+++ b/tests/testthat/test-provider-snowflake.R
@@ -164,3 +164,18 @@ test_that("Snowflake key-pair credentials are detected correctly", {
     )
   )
 })
+
+test_that("tokens can be requested from a Connect server", {
+  skip_if_not_installed("connectcreds")
+
+  withr::local_envvar(SNOWFLAKE_ACCOUNT = "testorg-test_account")
+  connectcreds::local_mocked_connect_responses(token = "token")
+  credentials <- default_snowflake_credentials()
+  expect_identical(
+    credentials(),
+    list(
+      Authorization = "Bearer token",
+      `X-Snowflake-Authorization-Token-Type` = "OAUTH"
+    )
+  )
+})


### PR DESCRIPTION
This commit brings support for Posit Connect's ["viewer-based credentials" feature][0] to Azure, Databricks, and Snowflake chatbots.

Checks for viewer-based credentials are designed to fall back gracefully to existing authentication methods. This is intended to allow users to -- for example -- develop and test a Shiny app that uses Azure, Databricks, or Snowflake credentials in desktop Positron/RStudio or Posit Workbench and deploy it with no code changes to Connect.

Most of the actual work is outsourced to a new shared package, [`connectcreds`][1]. In this latest version, the API of that package has been dramatically simplified, meaning the changes to `ellmer` are far less invasive than in previous patches.

Unit tests are included. They make use of the mocking features of the `connectcreds` package to emulate a Connect environment.

Supersedes #183.

[0]: https://docs.posit.co/connect/user/oauth-integrations/
[1]: https://github.com/posit-dev/connectcreds/