### PR TITLE
Add api args and verbose parameters to Bedrock provider

### DIFF
--- a/R/provider-bedrock.R
+++ b/R/provider-bedrock.R
@@ -119,7 +119,7 @@ chat_bedrock <- function(system_prompt = NULL,
   }
 
   turns <- normalize_turns(turns, system_prompt)
-  model <- set_default(model, "us.anthropic.claude-3-5-sonnet-20240620-v1:0")
+  model <- set_default(model, "anthropic.claude-3-5-sonnet-20240620-v1:0")
   echo <- check_echo(echo)
 
   provider <- ProviderBedrock(

--- a/man/chat_bedrock.Rd
+++ b/man/chat_bedrock.Rd
@@ -9,7 +9,9 @@ chat_bedrock(
   turns = NULL,
   model = NULL,
   profile = NULL,
-  echo = NULL
+  echo = NULL,
+  api_args = NULL,
+  verbose = FALSE
 )
 }
 \arguments{
@@ -34,17 +36,41 @@ the console).
 }
 
 Note this only affects the \code{chat()} method.}
+
+\item{api_args}{Optional list of arguments passed to the Bedrock API. Use
+this to customize model behavior. Valid arguments are: \code{temperature},
+\code{top_p}, \code{top_k}, \code{stop_sequences}, and \code{max_tokens}, though certain
+models may not support every parameter. Check the AWS Bedrock model
+documentation for specifics. Note that different model families
+(Claude, Nova, Llama, etc.) may natively use different parameter
+names for the same concept, e.g., max_tokens, max_new_tokens, or
+max_gen_len. However, Ellmer uses the parameter names above
+for consistency across all models, and the Converse API conveniently
+handles the mapping from these to the model-specific native
+parameter names.}
+
+\item{verbose}{Logical. When TRUE, prints AWS credentials,
+request and response headers/bodies for debugging.}
 }
 \value{
 A \link{Chat} object.
 }
 \description{
-\href{https://aws.amazon.com/bedrock/}{AWS Bedrock} provides a number of chat
-based models, including those Anthropic's
-\href{https://aws.amazon.com/bedrock/claude/}{Claude}.
+\href{https://aws.amazon.com/bedrock/}{AWS Bedrock} provides a number of
+language models, including those from Anthropic's
+\href{https://aws.amazon.com/bedrock/claude/}{Claude}, using the Bedrock
+\href{https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html}{Converse API}.
+Although Ellmer provides a default model, you'll need to
+specify a model that you actually have access to using the \code{model} argument.
+If using \href{https://aws.amazon.com/blogs/machine-learning/getting-started-with-cross-region-inference-in-amazon-bedrock/}{cross-region inference},
+you'll need to use the inference profile ID for
+any model argument, e.g., \code{model="us.anthropic.claude-3-5-sonnet-20240620-v1:0"}.
+For examples of tool usage, asynchronous input, and other advanced features,
+visit the \href{https://posit-dev.github.io/ellmer/vignettes/}{vignettes} section
+of the repo.
 \subsection{Authentication}{
 
-Authenthication is handled through \{paws.common\}, so if authenthication
+Authentication is handled through \{paws.common\}, so if authentication
 does not work for you automatically, you'll need to follow the advice
 at \url{https://www.paws-r-sdk.com/#credentials}. In particular, if your
 org uses AWS SSO, you'll need to run \verb{aws sso login} at the terminal.
@@ -52,8 +78,59 @@ org uses AWS SSO, you'll need to run \verb{aws sso login} at the terminal.
 }
 \examples{
 \dontrun{
+# Basic usage
 chat <- chat_bedrock()
 chat$chat("Tell me three jokes about statisticians")
+
+# Using custom API parameters
+chat <- chat_bedrock(
+  model = "us.meta.llama3-2-3b-instruct-v1:0",
+  api_args = list(
+    temperature = 0.7,
+    max_tokens = 2000
+  )
+)
+
+# Enable verbose output for debugging requests and responses
+chat <- chat_bedrock(verbose = TRUE)
+
+# Custom system prompt with API parameters
+chat <- chat_bedrock(
+  system_prompt = "You are a helpful data science assistant",
+  api_args = list(temperature = 0.5)
+)
+
+# Use a non-default AWS profile in ~/.aws/credentials
+chat <- chat_bedrock(profile = "my_profile_name")
+
+# Image interpretation when using a vision capable model
+chat <- chat_bedrock(
+  model = "us.meta.llama3-2-11b-instruct-v1:0"
+)
+chat$chat(
+  "What's in this image?",
+  content_image_file("path/to/image.jpg")
+)
+
+# The echo argument, "none", "text", and "all" determines whether
+# input and/or output is echoed to the console. Also of note, "none" uses a
+# non-streaming endpoint, whereas "text", "all", or TRUE uses a streaming endpoint.
+# You can use verbose=TRUE to verify which endpoint is used.
+chat <- chat_bedrock(verbose = TRUE) 
+chat$chat("What is 1 + 1?")  # Streaming response
+resp <- chat$chat("What is 1 + 1?", echo = "none")  # Non-streaming response
+resp  # View response
+
+# Use echo = "none" in the client constructor to suppress streaming response
+chat <- chat_bedrock(echo = "none")
+resp <- chat$chat("What is 1 + 1?")  # Non-streaming response
+resp  # View response
+chat$chat("What is 1 + 1?", echo=TRUE)  # Overrides client echo arg, uses streaming
+
+# $stream returns a generator, requiring concatentation of the streamed responses.
+resp <- chat$stream("What is the capital of France?")  # resp is a generator object
+chunks <- coro::collect(resp)  # returns list of partial text responses
+complete_response <- paste(chunks, collapse="")  # Full text response, no echo
 }
 }
 \seealso{


### PR DESCRIPTION
Added api_args and verbose parameters to the Bedrock provider. api_args is a list for parameters such as temperature, top_p, top_k, max_tokens, and stop_sequences. Added validation for each of these parameters. The verbose parameter adds useful information for developers and end users to inspect request and response headers and payloads. Updated the Roxygen documentation.