### PR TITLE
Set connecttimeout with user option (Fixes #318)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# ellmer (development version)
+
+* All providers now allow for up to 60s for the connection phase to take. You can
+  increase this with, e.g., `option(ellmer_connecttimeout_s = 120)` (#318, @CorradoLanera).
+
 # ellmer 0.1.1
 
 ## Lifecycle changes

--- a/R/httr2.R
+++ b/R/httr2.R
@@ -76,5 +76,9 @@ on_load(chat_perform_async_stream <- coro::async_generator(function(provider, re
 # Request helpers --------------------------------------------------------------
 
 ellmer_req_timeout <- function(req, stream) {
-  req_options(req, timeout = getOption("ellmer_timeout_s", 60))
+  req_options(
+    req,
+    timeout = getOption("ellmer_timeout_s", 60),
+    connecttimeout = getOption("ellmer_connecttimeout_s", 60),
+  )
 }


### PR DESCRIPTION
The suggestion in https://github.com/tidyverse/ellmer/issues/318#issuecomment-2651431086 by @hadley solves #318, and my reported query (including all the others I have that failed) succeeded.

I've:
- added the corresponding code in the same place with `timeout`
- included the corresponding NEWS item.