### PR TITLE
Switch to using `req_dry_run()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     cli,
     coro (>= 1.1.0),
     glue,
-    httr2 (>= 1.1.0),
+    httr2 (>= 1.1.0.9000),
     jsonlite,
     later (>= 1.4.0),
     lifecycle,
@@ -93,3 +93,5 @@ Collate:
     'utils-merge.R'
     'utils.R'
     'zzz.R'
+Remotes:  
+    r-lib/httr2

--- a/tests/testthat/_snaps/provider-azure.md
+++ b/tests/testthat/_snaps/provider-azure.md
@@ -17,66 +17,84 @@
 # Azure request headers are generated correctly
 
     Code
-      req
-    Message
-      <httr2_request>
-      POST
-      https://ai-hwickhamai260967855527.openai.azure.com/openai/deployments/gpt-4o-mini/chat/completions?api-version=2024-06-01
-      Headers:
-      * api-key: "<REDACTED>"
-      Body: json encoded data
-      Options:
-      * timeout: 60
-      Policies:
-      * retry_max_tries: 2
-      * retry_on_failure: FALSE
-      * retry_failure_threshold: Inf
-      * retry_failure_timeout: 30
-      * retry_realm: "ai-hwickhamai260967855527.openai.azure.com"
-      * error_body: a function
+      req_dry_run(req)
+    Output
+      POST /openai/deployments/gpt-4o-mini/chat/completions HTTP/1.1
+      accept: */*
+      api-key: <REDACTED>
+      content-type: application/json
+      user-agent: <httr2 user agent>
+      
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "text",
+                "text": "What is 1 + 1?"
+              }
+            ]
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "stream": false
+      }
 
 ---
 
     Code
-      req
-    Message
-      <httr2_request>
-      POST
-      https://ai-hwickhamai260967855527.openai.azure.com/openai/deployments/gpt-4o-mini/chat/completions?api-version=2024-06-01
-      Headers:
-      * Authorization: "<REDACTED>"
-      Body: json encoded data
-      Options:
-      * timeout: 60
-      Policies:
-      * retry_max_tries: 2
-      * retry_on_failure: FALSE
-      * retry_failure_threshold: Inf
-      * retry_failure_timeout: 30
-      * retry_realm: "ai-hwickhamai260967855527.openai.azure.com"
-      * error_body: a function
+      req_dry_run(req)
+    Output
+      POST /openai/deployments/gpt-4o-mini/chat/completions HTTP/1.1
+      accept: */*
+      authorization: <REDACTED>
+      content-type: application/json
+      user-agent: <httr2 user agent>
+      
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "text",
+                "text": "What is 1 + 1?"
+              }
+            ]
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "stream": false
+      }
 
 ---
 
     Code
-      req
-    Message
-      <httr2_request>
-      POST
-      https://ai-hwickhamai260967855527.openai.azure.com/openai/deployments/gpt-4o-mini/chat/completions?api-version=2024-06-01
-      Headers:
-      * api-key: "<REDACTED>"
-      * Authorization: "<REDACTED>"
-      Body: json encoded data
-      Options:
-      * timeout: 60
-      Policies:
-      * retry_max_tries: 2
-      * retry_on_failure: FALSE
-      * retry_failure_threshold: Inf
-      * retry_failure_timeout: 30
-      * retry_realm: "ai-hwickhamai260967855527.openai.azure.com"
-      * error_body: a function
+      req_dry_run(req)
+    Output
+      POST /openai/deployments/gpt-4o-mini/chat/completions HTTP/1.1
+      accept: */*
+      api-key: <REDACTED>
+      authorization: <REDACTED>
+      content-type: application/json
+      user-agent: <httr2 user agent>
+      
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "text",
+                "text": "What is 1 + 1?"
+              }
+            ]
+          }
+        ],
+        "model": "gpt-4o-mini",
+        "stream": false
+      }
 
 # service principal authentication requests look correct
 

--- a/tests/testthat/_snaps/provider-cortex.md
+++ b/tests/testthat/_snaps/provider-cortex.md
@@ -30,52 +30,28 @@
 # Cortex API requests are generated correctly
 
     Code
-      req
-    Message
-      <httr2_request>
-      POST
-      https://testorg-test_account.snowflakecomputing.com/api/v2/cortex/analyst/message
-      Headers:
-      * Authorization: "<REDACTED>"
-      * X-Snowflake-Authorization-Token-Type: "OAUTH"
-      Body: json encoded data
-      Options:
-      * timeout: 60
-      * useragent: "<ellmer_user_agent>"
-      Policies:
-      * retry_max_tries: 2
-      * retry_on_failure: FALSE
-      * retry_failure_threshold: Inf
-      * retry_failure_timeout: 30
-      * retry_realm: "testorg-test_account.snowflakecomputing.com"
-      * error_body: a function
-
----
-
-    Code
-      req$body$data
+      req_dry_run(req)
     Output
-      $messages
-      $messages[[1]]
-      $messages[[1]]$role
-      [1] "user"
+      POST /api/v2/cortex/analyst/message HTTP/1.1
+      accept: */*
+      authorization: <REDACTED>
+      content-type: application/json
+      user-agent: <ellmer_user_agent>
+      x-snowflake-authorization-token-type: OAUTH
       
-      $messages[[1]]$content
-      $messages[[1]]$content[[1]]
-      $messages[[1]]$content[[1]]$type
-      [1] "text"
-      
-      $messages[[1]]$content[[1]]$text
-      [1] "Tell me about my data."
-      
-      
-      
-      
-      
-      $stream
-      [1] FALSE
-      
-      $semantic_model_file
-      [1] "@my_db.my_schema.my_stage/model.yaml"
-      
+      {
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "text",
+                "text": "Tell me about my data."
+              }
+            ]
+          }
+        ],
+        "stream": false,
+        "semantic_model_file": "@my_db.my_schema.my_stage/model.yaml"
+      }
 

--- a/tests/testthat/test-provider-azure.R
+++ b/tests/testthat/test-provider-azure.R
@@ -68,7 +68,7 @@ test_that("Azure request headers are generated correctly", {
     credentials = default_azure_credentials("key")
   )
   req <- chat_request(p, FALSE, list(turn))
-  expect_snapshot(req)
+  expect_snapshot(req_dry_run(req))
 
   # Token.
   p <- ProviderAzure(
@@ -79,7 +79,7 @@ test_that("Azure request headers are generated correctly", {
     credentials = default_azure_credentials("", "token")
   )
   req <- chat_request(p, FALSE, list(turn))
-  expect_snapshot(req)
+  expect_snapshot(req_dry_run(req))
 
   # Both.
   p <- ProviderAzure(
@@ -90,7 +90,7 @@ test_that("Azure request headers are generated correctly", {
     credentials = default_azure_credentials("key", "token")
   )
   req <- chat_request(p, FALSE, list(turn))
-  expect_snapshot(req)
+  expect_snapshot(req_dry_run(req))
 })
 
 test_that("service principal authentication requests look correct", {

--- a/tests/testthat/test-provider-cortex.R
+++ b/tests/testthat/test-provider-cortex.R
@@ -123,10 +123,9 @@ test_that("Cortex API requests are generated correctly", {
   )
   req <- chat_request(p, FALSE, list(turn))
   expect_snapshot(
-    req,
+    req_dry_run(req),
     transform = function(x) gsub(snowflake_user_agent(), "<ellmer_user_agent>", x, fixed = TRUE)
   )
-  expect_snapshot(req$body$data)
 })
 
 test_that("a simple Cortex chatbot works", {


### PR DESCRIPTION
Tests won't pass until https://github.com/r-lib/httr2/pull/678 is merged.

@atheriel how does this look to you?