### PR TITLE
fix: Ollama tool property types must be scalar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 * `chat_gemini()` now detects viewer-based credentials when running on Posit
   Connect (#320, @atheriel).
 
+* `chat_ollama()` now works with `tool()` definitions with optional arguments (#342, @gadenbuie).
+
 # ellmer 0.1.1
 
 ## Lifecycle changes

--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -77,6 +77,11 @@ chat_ollama_test <- function(..., model = "llama3.2:1b") {
     testthat::skip("ollama not found")
   }
 
+  testthat::skip_if_not(
+    model %in% ollama_models(),
+    sprintf("Ollama: model '%s' is not installed", model)
+  )
+
   chat_ollama(..., model = model)
 }
 

--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -47,19 +47,30 @@ chat_ollama <- function(system_prompt = NULL,
       i = "Locally installed models: {.str {models}}."
     ))
   }
+
+  turns <- normalize_turns(turns, system_prompt)
   echo <- check_echo(echo)
 
-  chat_openai(
-    system_prompt = system_prompt,
-    turns = turns,
+  provider <- ProviderOllama(
     base_url = file.path(base_url, "v1"), ## the v1 portion of the path is added for openAI compatible API
-    api_key = "ollama", # ignored
     model = model,
     seed = seed,
-    api_args = api_args,
-    echo = echo
+    extra_args = api_args,
+    api_key = "ollama" # ignored
   )
+
+  Chat$new(provider = provider, turns = turns, echo = echo)
 }
+
+ProviderOllama <- new_class(
+  "ProviderOllama",
+  parent = ProviderOpenAI,
+  properties = list(
+    api_key = prop_string(),
+    model = prop_string(),
+    seed = prop_number_whole(allow_null = TRUE)
+  )
+)
 
 chat_ollama_test <- function(..., model = "llama3.3") {
   if (!has_ollama()) {
@@ -88,5 +99,31 @@ has_ollama <- function(base_url = "http://localhost:11434") {
       TRUE
     },
     httr2_error = function(cnd) FALSE
+  )
+}
+
+method(as_json, list(ProviderOllama, TypeObject)) <- function(provider, x) {
+  if (x@additional_properties) {
+    cli::cli_abort("{.arg .additional_properties} not supported for OpenAI.")
+  }
+
+  names <- names2(x@properties)
+  properties <- lapply(x@properties, function(x) {
+    out <- as_json(provider, x)
+    # Ollama with OpenAPI-compat API doesn't support arrays for type (ollama/ollama#5990)
+    # if (!x@required) {
+    #   out$type <- c(out$type, "null")
+    # }
+    out
+  })
+
+  names(properties) <- names
+
+  list(
+    type = "object",
+    description = x@description %||% "",
+    properties = properties,
+    required = as.list(names),
+    additionalProperties = FALSE
   )
 }

--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -114,20 +114,14 @@ method(as_json, list(ProviderOllama, TypeObject)) <- function(provider, x) {
     cli::cli_abort("{.arg .additional_properties} not supported for Ollama.")
   }
 
-  names <- names2(x@properties)
-
-  properties <- lapply(x@properties, as_json, provider = provider)
-
   # Unlike OpenAI, Ollama uses the `required` field to list required tool args
-  is_required <- vapply(x@properties, function(t) t@required, logical(1))
-
-  names(properties) <- names
+  required <- map_lgl(x@properties, function(prop) prop@required)
 
   list(
     type = "object",
     description = x@description %||% "",
-    properties = properties,
-    required = as.list(names[is_required]),
+    properties = as_json(provider, x@properties),
+    required = as.list(names2(x@properties)[required]),
     additionalProperties = FALSE
   )
 }

--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -73,6 +73,8 @@ ProviderOllama <- new_class(
 )
 
 chat_ollama_test <- function(..., model = "llama3.2:1b") {
+  # model: Note that tests require a model with tool capabilities
+  
   if (!has_ollama()) {
     testthat::skip("ollama not found")
   }

--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -72,7 +72,7 @@ ProviderOllama <- new_class(
   )
 )
 
-chat_ollama_test <- function(..., model = "llama3.3") {
+chat_ollama_test <- function(..., model = "llama3.2:1b") {
   if (!has_ollama()) {
     testthat::skip("ollama not found")
   }

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -290,7 +290,8 @@ method(as_json, list(ProviderOpenAI, TypeObject)) <- function(provider, x) {
   names <- names2(x@properties)
   properties <- lapply(x@properties, function(x) {
     out <- as_json(provider, x)
-    if (!x@required) {
+    if (!x@required && provider@api_key != "ollama") {
+      # Ollama doesn't support arrays for type (ollama/ollama#5990)
       out$type <- c(out$type, "null")
     }
     out

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -290,8 +290,7 @@ method(as_json, list(ProviderOpenAI, TypeObject)) <- function(provider, x) {
   names <- names2(x@properties)
   properties <- lapply(x@properties, function(x) {
     out <- as_json(provider, x)
-    if (!x@required && provider@api_key != "ollama") {
-      # Ollama doesn't support arrays for type (ollama/ollama#5990)
+    if (!x@required) {
       out$type <- c(out$type, "null")
     }
     out

--- a/tests/testthat/_snaps/provider-ollama.md
+++ b/tests/testthat/_snaps/provider-ollama.md
@@ -1,0 +1,8 @@
+# as_json specialised for Ollama
+
+    Code
+      as_json(stub, type_object(.additional_properties = TRUE))
+    Condition
+      Error in `method(as_json, list(ellmer::ProviderOllama, ellmer::TypeObject))`:
+      ! `.additional_properties` not supported for Ollama.
+


### PR DESCRIPTION
## Problem

Ollama currently doesn't support arrays in the `tools.function.parameters.properties.type` field, instead it expects a scalar. https://github.com/ollama/ollama/issues/5990

In ellmer, this means that using `type_*(required = FALSE)` results in the following warning:

``` r
pkgload::load_all()
#> ℹ Loading ellmer

tool_current_time <- tool(
  \(tz = "UTC") strftime(Sys.time(), "%F %T", tz = tz),
  .name = "get_current_time",
  .description = "Get the current date and time.",
  tz = type_string(
    "The IANA-recognized timezone, defaults to 'UTC'",
    required = FALSE
  ),
)

chat <- chat_ollama(model="qwen2.5:7b", echo="all")
chat$register_tool(tool_current_time)

chat$chat("Where was R invented?")
#> > Where was R invented?
#> Error in `req_perform_connection()` at ellmer/R/httr2.R:34:3:
#> ! HTTP 400 Bad Request.
#> • json: cannot unmarshal array into Go struct field .tools.function.parameters.properties.type of type string
```

Edit: This behavior happens in the OpenAI-compatible API, Ollama's API supports [`required` as a separate field](https://github.com/ollama/ollama/blob/main/docs/api.md#chat-request-with-tools).

## After

This PR updates the `as_json` method for `ProviderOpenAI, TypeObject` to avoid add `"null"` to the `property.type` when the provider is an Ollama model.

``` r
pkgload::load_all()
#> ℹ Loading ellmer

tool_current_time <- tool(
  \(tz = "UTC") strftime(Sys.time(), "%F %T", tz = tz),
  .name = "get_current_time",
  .description = "Get the current date and time.",
  tz = type_string(
    "The IANA-recognized timezone, defaults to 'UTC'",
    required = FALSE
  ),
)

chat <- chat_ollama(model="qwen2.5:7b", echo="all")
chat$register_tool(tool_current_time)

chat$chat("Where was R invented?")
#> > Where was R invented?
#> < R was primarily developed at the University of Auckland in New Zealand by 
#> < Ross Ihaka and Robert Gentleman in the late 1990s. However, it has since 
#> < grown to be a widely used language and environment for statistical computing 
#> < and graphics, with contributions from around the world.
#> <
chat$chat("What's the current time in the place where the R language was invented?")
#> > What's the current time in the place where the R language was invented?
#> < 
#> < [tool request (call_ynzxn614)]: get_current_time(tz = "Pacific/Auckland")
#> > [tool result  (call_ynzxn614)]: 2025-02-28 02:22:02
#> < The current time in Auckland, New Zealand (which we're approximating as the 
#> < place where R was invented) is February 28, 2025, at 02:22:02 UTC. If you 
#> < need the time in a different timezone or specific date format, let me know!
#> <
```
