### PR TITLE
fix: Ollama tool calls with empty properties

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@
 * `chat_gemini()` now detects viewer-based credentials when running on Posit
   Connect (#320, @atheriel).
 
-* `chat_ollama()` now works with `tool()` definitions with optional arguments (#342, @gadenbuie).
+* `chat_ollama()` now works with `tool()` definitions with optional arguments or empty properties (#342, #348, @gadenbuie).
 
 # ellmer 0.1.1
 

--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -117,11 +117,11 @@ method(as_json, list(ProviderOllama, TypeObject)) <- function(provider, x) {
   # Unlike OpenAI, Ollama uses the `required` field to list required tool args
   required <- map_lgl(x@properties, function(prop) prop@required)
 
-  list(
+  compact(list(
     type = "object",
     description = x@description %||% "",
     properties = as_json(provider, x@properties),
     required = as.list(names2(x@properties)[required]),
     additionalProperties = FALSE
-  )
+  ))
 }

--- a/tests/testthat/test-provider-ollama.R
+++ b/tests/testthat/test-provider-ollama.R
@@ -28,6 +28,10 @@ test_that("can chat with tool request", {
     )
   )
 
+  # Tool with no properties
+  current_time <- function() Sys.time()
+  chat$register_tool(tool(current_time, "Current system time"))
+
   # Ollama tool calling is very inconsistent, esp. with small models, so we
   # just test that the model still works when a tool call is registered.
   expect_no_error(


### PR DESCRIPTION
Simple fix to avoid sending `properties:[]` in the tool definition to Ollama. If present, Ollama throws.