### PR TITLE
Bump `provider_claude()` to use Sonnet 3.7

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # ellmer (development version)
 
-* `Turn` objects now include a POSIXct timestamp in the `completed` slot that 
+* `provider_claude()` now defaults to Sonnet 3.7 and displays the default
+  model (336).
+
+* `Turn` objects now include a POSIXct timestamp in the `completed` slot that
   records when the turn was completed (#337, @simonpcouch).
 
 * `create_tool_def()` can now use any Chat instance (#118, @pedrobtz).

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -42,7 +42,6 @@ chat_claude <- function(system_prompt = NULL,
   turns <- normalize_turns(turns, system_prompt)
   echo <- check_echo(echo)
 
-
   model <- set_default(model, "claude-3-7-sonnet-latest")
 
   provider <- ProviderClaude(

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -42,7 +42,8 @@ chat_claude <- function(system_prompt = NULL,
   turns <- normalize_turns(turns, system_prompt)
   echo <- check_echo(echo)
 
-  model <- model %||% "claude-3-5-sonnet-latest"
+
+  model <- set_default(model, "claude-3-7-sonnet-latest")
 
   provider <- ProviderClaude(
     model = model,
@@ -53,6 +54,10 @@ chat_claude <- function(system_prompt = NULL,
   )
 
   Chat$new(provider = provider, turns = turns, echo = echo)
+}
+
+chat_claude_test <- function(..., model = "claude-3-5-sonnet-latest") {
+  chat_claude(model = model, ...)
 }
 
 ProviderClaude <- new_class(

--- a/tests/testthat/_snaps/provider-claude.md
+++ b/tests/testthat/_snaps/provider-claude.md
@@ -2,6 +2,8 @@
 
     Code
       . <- chat_claude()
+    Message
+      Using model = "claude-3-7-sonnet-latest".
 
 # all tool variations work
 

--- a/tests/testthat/test-provider-claude.R
+++ b/tests/testthat/test-provider-claude.R
@@ -1,12 +1,12 @@
 test_that("can make simple batch request", {
-  chat <- chat_claude("Be as terse as possible; no punctuation")
+  chat <- chat_claude_test("Be as terse as possible; no punctuation")
   resp <- chat$chat("What is 1 + 1?", echo = FALSE)
   expect_match(resp, "2")
   expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {
-  chat <- chat_claude("Be as terse as possible; no punctuation")
+  chat <- chat_claude_test("Be as terse as possible; no punctuation")
   resp <- coro::collect(chat$stream("What is 1 + 1?"))
   expect_match(paste0(unlist(resp), collapse = ""), "2")
 })
@@ -18,14 +18,14 @@ test_that("defaults are reported", {
 })
 
 test_that("respects turns interface", {
-  chat_fun <- chat_claude
+  chat_fun <- chat_claude_test
 
   test_turns_system(chat_fun)
   test_turns_existing(chat_fun)
 })
 
 test_that("all tool variations work", {
-  chat_fun <- chat_claude
+  chat_fun <- chat_claude_test
 
   retry_test(test_tools_simple(chat_fun))
   test_tools_async(chat_fun)
@@ -35,20 +35,20 @@ test_that("all tool variations work", {
 })
 
 test_that("can extract data", {
-  chat_fun <- chat_claude
+  chat_fun <- chat_claude_test
 
   test_data_extraction(chat_fun)
 })
 
 test_that("can use images", {
-  chat_fun <- chat_claude
+  chat_fun <- chat_claude_test
 
   test_images_inline(chat_fun)
   test_images_remote_error(chat_fun)
 })
 
 test_that("can use pdfs", {
-  chat_fun <- chat_claude
+  chat_fun <- chat_claude_test
 
   test_pdf_local(chat_fun)
 })


### PR DESCRIPTION
Fixes #338