### PR TITLE
feat: Initialize shinychat UI with messages from current chat

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ellmer (development version)
 
+* `live_browser()` now initializes `shinychat::chat_ui()` with the messages from
+  the chat turns, rather than replaying the turns server-side (#381).
+
 * `Chat$tokens()` now returns a data frame of tokens, correctly aligned to the
   individual turn. The print method now uses this to show how many input/output
   tokens each turn used (#354).


### PR DESCRIPTION
Small refactor to `live_browser()` to initialize the `shinychat::chat_ui()` with the messages from `chat$get_turns()` rather than replaying the chat server-side.

I think this approach is an improvement in general, but it also fixes a bug with ellmer and dev shinychat caused by the default value of the `chunk` argument of `shinychat::chat_append_message()` changing from `TRUE` to `FALSE`. (Whether or not we revisit that change, initializing the chat with `messages` is guaranteed to be stable.)