### PR TITLE
feat(Chat): Methods to get a list of tools, register a list of tools

### DIFF
--- a/R/chat.R
+++ b/R/chat.R
@@ -18,8 +18,7 @@ NULL
 #' @examplesIf has_credentials("openai")
 #' chat <- chat_openai(echo = TRUE)
 #' chat$chat("Tell me a funny joke")
-Chat <- R6::R6Class(
-  "Chat",
+Chat <- R6::R6Class("Chat",
   public = list(
     #' @param provider A provider object.
     #' @param turns An unnamed list of turns to start the chat with (i.e.,
@@ -109,34 +108,30 @@ Chat <- R6::R6Class(
       invisible(self)
     },
 
-    #' @description A data frame with a `tokens` column that proides the
-    #'   number of input tokens used by user turns and the number of
+    #' @description A data frame with a `tokens` column that proides the 
+    #'   number of input tokens used by user turns and the number of 
     #'   output tokens used by assistant turns.
-    #' @param include_system_prompt Whether to include the system prompt in
+    #' @param include_system_prompt Whether to include the system prompt in 
     #'   the turns (if any exists).
     tokens = function(include_system_prompt = FALSE) {
       turns <- self$get_turns(include_system_prompt = FALSE)
       assistant_turns <- keep(turns, function(x) x@role == "assistant")
 
       n <- length(assistant_turns)
-      tokens <- t(vapply(
-        assistant_turns,
-        function(turn) turn@tokens,
-        double(2)
-      ))
+      tokens <- t(vapply(assistant_turns, function(turn) turn@tokens, double(2)))
       if (n > 1) {
         # Compute just the new tokens
-        tokens[-1, 1] <- tokens[seq(2, n), 1] -
+        tokens[-1, 1] <- tokens[seq(2, n), 1] - 
           (tokens[seq(1, n - 1), 1] + tokens[seq(1, n - 1), 2])
       }
       # collapse into a single vector
       tokens_v <- c(t(tokens))
-
+      
       tokens_df <- data.frame(
         role = rep(c("user", "assistant"), times = n),
         tokens = tokens_v
       )
-
+      
       if (include_system_prompt && private$has_system_prompt()) {
         # How do we compute this?
         tokens_df <- rbind(data.frame(role = "system", tokens = 0), tokens_df)
@@ -154,8 +149,7 @@ Chat <- R6::R6Class(
       role <- arg_match(role)
 
       n <- length(private$.turns)
-      switch(
-        role,
+      switch(role,
         system = if (private$has_system_prompt()) private$.turns[[1]],
         assistant = if (n > 1) private$.turns[[n]],
         user = if (n > 1) private$.turns[[n - 1]]
@@ -175,11 +169,7 @@ Chat <- R6::R6Class(
 
       # Returns a single turn (the final response from the assistant), even if
       # multiple rounds of back and forth happened.
-      coro::collect(private$chat_impl(
-        turn,
-        stream = echo != "none",
-        echo = echo
-      ))
+      coro::collect(private$chat_impl(turn, stream = echo != "none", echo = echo))
 
       text <- self$last_turn()@text
       if (echo == "none") text else invisible(text)
@@ -287,12 +277,7 @@ Chat <- R6::R6Class(
 
       map(json, function(json) {
         turn <- value_turn(private$provider, json, has_type = TRUE)
-        extract_data(
-          turn,
-          type,
-          convert = convert,
-          needs_wrapper = needs_wrapper
-        )
+        extract_data(turn, type, convert = convert, needs_wrapper = needs_wrapper)
       })
     },
 
@@ -446,29 +431,16 @@ Chat <- R6::R6Class(
       if (private$.turns[[i]]@role != "user") {
         private$.turns[[i + 1]] <- Turn("user", contents)
       } else {
-        private$.turns[[i]]@contents <- c(
-          private$.turns[[i]]@contents,
-          contents
-        )
+        private$.turns[[i]]@contents <- c(private$.turns[[i]]@contents, contents)
       }
       invisible(self)
     },
 
     # If stream = TRUE, yields completion deltas. If stream = FALSE, yields
     # complete assistant turns.
-    chat_impl = generator_method(function(
-      self,
-      private,
-      user_turn,
-      stream,
-      echo
-    ) {
-      while (!is.null(user_turn)) {
-        for (chunk in private$submit_turns(
-          user_turn,
-          stream = stream,
-          echo = echo
-        )) {
+    chat_impl = generator_method(function(self, private, user_turn, stream, echo) {
+      while(!is.null(user_turn)) {
+        for (chunk in private$submit_turns(user_turn, stream = stream, echo = echo)) {
           yield(chunk)
         }
         user_turn <- private$invoke_tools()
@@ -477,19 +449,9 @@ Chat <- R6::R6Class(
 
     # If stream = TRUE, yields completion deltas. If stream = FALSE, yields
     # complete assistant turns.
-    chat_impl_async = async_generator_method(function(
-      self,
-      private,
-      user_turn,
-      stream,
-      echo
-    ) {
-      while (!is.null(user_turn)) {
-        for (chunk in await_each(private$submit_turns_async(
-          user_turn,
-          stream = stream,
-          echo = echo
-        ))) {
+    chat_impl_async = async_generator_method(function(self, private, user_turn, stream, echo) {
+      while(!is.null(user_turn)) {
+        for (chunk in await_each(private$submit_turns_async(user_turn, stream = stream, echo = echo))) {
           yield(chunk)
         }
         user_turn <- await(private$invoke_tools_async())
@@ -501,14 +463,8 @@ Chat <- R6::R6Class(
 
     # If stream = TRUE, yields completion deltas. If stream = FALSE, yields
     # complete assistant turns.
-    submit_turns = generator_method(function(
-      self,
-      private,
-      user_turn,
-      stream,
-      echo,
-      type = NULL
-    ) {
+    submit_turns = generator_method(function(self, private, user_turn, stream, echo, type = NULL) {
+
       if (echo == "all") {
         cat_line(format(user_turn), prefix = "> ")
       }
@@ -550,11 +506,7 @@ Chat <- R6::R6Class(
           cat_line(formatted, prefix = "< ")
         }
       } else {
-        turn <- value_turn(
-          private$provider,
-          response,
-          has_type = !is.null(type)
-        )
+        turn <- value_turn(private$provider, response, has_type = !is.null(type))
         text <- turn@text
         if (!is.null(text)) {
           text <- paste0(text, "\n")
@@ -572,14 +524,7 @@ Chat <- R6::R6Class(
 
     # If stream = TRUE, yields completion deltas. If stream = FALSE, yields
     # complete assistant turns.
-    submit_turns_async = async_generator_method(function(
-      self,
-      private,
-      user_turn,
-      stream,
-      echo,
-      type = NULL
-    ) {
+    submit_turns_async = async_generator_method(function(self, private, user_turn, stream, echo, type = NULL) {
       response <- chat_perform(
         provider = private$provider,
         mode = if (stream) "async-stream" else "async-value",
@@ -653,36 +598,29 @@ is_chat <- function(x) {
 #' @export
 print.Chat <- function(x, ...) {
   turns <- x$get_turns(include_system_prompt = TRUE)
-
+  
   tokens <- x$tokens(include_system_prompt = TRUE)
   tokens_user <- sum(tokens$tokens[tokens$role == "user"])
   tokens_assistant <- sum(tokens$tokens[tokens$role == "assistant"])
 
   cat(paste0(
-    "<Chat",
-    " turns=",
-    length(turns),
-    " tokens=",
-    tokens_user,
-    "/",
-    tokens_assistant,
+    "<Chat", 
+    " turns=", length(turns), 
+    " tokens=", tokens_user, "/", tokens_assistant, 
     ">\n"
   ))
-
+  
   for (i in seq_along(turns)) {
     turn <- turns[[i]]
-
-    color <- switch(
-      turn@role,
+    
+    color <- switch(turn@role,
       user = cli::col_blue,
       assistant = cli::col_green,
       system = cli::col_br_white,
       identity
     )
 
-    cli::cat_rule(cli::format_inline(
-      "{color(turn@role)} [{tokens$tokens[[i]]}]"
-    ))
+    cli::cat_rule(cli::format_inline("{color(turn@role)} [{tokens$tokens[[i]]}]"))
     for (content in turn@contents) {
       cat_line(format(content))
     }
@@ -691,10 +629,7 @@ print.Chat <- function(x, ...) {
   invisible(x)
 }
 
-method(contents_markdown, new_S3_class("Chat")) <- function(
-  content,
-  heading_level = 2
-) {
+method(contents_markdown, new_S3_class("Chat")) <- function(content, heading_level = 2) {
   turns <- content$get_turns()
   if (length(turns) == 0) {
     return("")
@@ -709,7 +644,7 @@ method(contents_markdown, new_S3_class("Chat")) <- function(
     res[i] <- glue::glue("{hh} {role}\n\n{contents_markdown(turns[[i]])}")
   }
 
-  paste(res, collapse = "\n\n")
+  paste(res, collapse="\n\n")
 }
 
 extract_data <- function(turn, type, convert = TRUE, needs_wrapper = FALSE) {

--- a/R/chat.R
+++ b/R/chat.R
@@ -390,18 +390,35 @@ Chat <- R6::R6Class(
       private$tools
     },
 
-    #' @description Registers multiple tools for the chatbot by iterating
-    #'   through a list of `tools` and calling `register_tool()` for each entry.
-    #'   Tools are indexed by their `@name` property, overwriting any existing
-    #'   tools with matching names.
-    #' @param tools A list of tools defined by [ellmer::tool()].
-    register_tools = function(tools) {
+    #' @description Sets the available tools for the chatbot by managing a
+    #'   collection of tool definitions. This method allows either replacing all
+    #'   existing tools or merging new tools with existing ones, and is designed
+    #'   for programmatic interaction with chat tools. To register a single tool
+    #'   with a `Chat`, use `register_tool()`.
+    #'
+    #' @param tools A list of tool definitions created with [ellmer::tool()].
+    #' @param action Character string specifying how to handle the new tools:
+    #'   * `"replace"`: Removes all existing tools and sets only the provided
+    #'     tools
+    #'   * `"merge"`: Adds the new tools to existing ones, replacing any tools
+    #'     with matching names
+    #'
+    #' @details When merging tools (`action = "merge"`), any existing tool with
+    #'   the same name as a new tool will be overwritten by the new definition.
+    #'   This allows for updating specific tools while preserving others.
+    set_tools = function(tools, action = c("replace", "merge")) {
       if (!is_list(tools)) {
         msg <- "{.arg tools} must be a list of tools created with {.fn ellmer::tool}."
         if (S7_inherits(tools, ToolDef)) {
           msg <- c(msg, "i" = "Did you mean to call {.code $register_tool()}?")
         }
         cli::cli_abort(msg)
+      }
+
+      action = arg_match(action)
+
+      if (action == "replace") {
+        private$tools <- list()
       }
 
       for (tool_def in tools) {

--- a/R/chat.R
+++ b/R/chat.R
@@ -368,6 +368,11 @@ Chat <- R6::R6Class("Chat",
 
       private$tools[[tool_def@name]] <- tool_def
       invisible(self)
+    },
+
+    #' @description Retrieve the list of registered tools.
+    get_tools = function() {
+      private$tools
     }
   ),
   private = list(

--- a/R/chat.R
+++ b/R/chat.R
@@ -375,24 +375,12 @@ Chat <- R6::R6Class("Chat",
       private$tools
     },
 
-    #' @description Sets the available tools for the chatbot by managing a
-    #'   collection of tool definitions. This method allows either replacing all
-    #'   existing tools or merging new tools with existing ones, and is designed
-    #'   for programmatic interaction with chat tools. To register a single tool
-    #'   with a `Chat`, use `register_tool()`.
+    #' @description Sets the available tools. For expert use only; most users
+    #'   should use `register_tool()`.
     #'
     #' @param tools A list of tool definitions created with [ellmer::tool()].
-    #' @param action Character string specifying how to handle the new tools:
-    #'   * `"replace"`: Removes all existing tools and sets only the provided
-    #'     tools
-    #'   * `"merge"`: Adds the new tools to existing ones, replacing any tools
-    #'     with matching names
-    #'
-    #' @details When merging tools (`action = "merge"`), any existing tool with
-    #'   the same name as a new tool will be overwritten by the new definition.
-    #'   This allows for updating specific tools while preserving others.
-    set_tools = function(tools, action = c("replace", "merge")) {
-      if (!is_list(tools)) {
+    set_tools = function(tools) {
+      if (!is_list(tools) || !all(map_lgl(tools, S7_inherits, ToolDef))) {
         msg <- "{.arg tools} must be a list of tools created with {.fn ellmer::tool}."
         if (S7_inherits(tools, ToolDef)) {
           msg <- c(msg, "i" = "Did you mean to call {.code $register_tool()}?")
@@ -400,12 +388,8 @@ Chat <- R6::R6Class("Chat",
         cli::cli_abort(msg)
       }
 
-      action = arg_match(action)
-
-      if (action == "replace") {
-        private$tools <- list()
-      }
-
+      private$tools <- list()
+      
       for (tool_def in tools) {
         self$register_tool(tool_def)
       }

--- a/R/chat.R
+++ b/R/chat.R
@@ -18,7 +18,8 @@ NULL
 #' @examplesIf has_credentials("openai")
 #' chat <- chat_openai(echo = TRUE)
 #' chat$chat("Tell me a funny joke")
-Chat <- R6::R6Class("Chat",
+Chat <- R6::R6Class(
+  "Chat",
   public = list(
     #' @param provider A provider object.
     #' @param turns An unnamed list of turns to start the chat with (i.e.,
@@ -108,30 +109,34 @@ Chat <- R6::R6Class("Chat",
       invisible(self)
     },
 
-    #' @description A data frame with a `tokens` column that proides the 
-    #'   number of input tokens used by user turns and the number of 
+    #' @description A data frame with a `tokens` column that proides the
+    #'   number of input tokens used by user turns and the number of
     #'   output tokens used by assistant turns.
-    #' @param include_system_prompt Whether to include the system prompt in 
+    #' @param include_system_prompt Whether to include the system prompt in
     #'   the turns (if any exists).
     tokens = function(include_system_prompt = FALSE) {
       turns <- self$get_turns(include_system_prompt = FALSE)
       assistant_turns <- keep(turns, function(x) x@role == "assistant")
 
       n <- length(assistant_turns)
-      tokens <- t(vapply(assistant_turns, function(turn) turn@tokens, double(2)))
+      tokens <- t(vapply(
+        assistant_turns,
+        function(turn) turn@tokens,
+        double(2)
+      ))
       if (n > 1) {
         # Compute just the new tokens
-        tokens[-1, 1] <- tokens[seq(2, n), 1] - 
+        tokens[-1, 1] <- tokens[seq(2, n), 1] -
           (tokens[seq(1, n - 1), 1] + tokens[seq(1, n - 1), 2])
       }
       # collapse into a single vector
       tokens_v <- c(t(tokens))
-      
+
       tokens_df <- data.frame(
         role = rep(c("user", "assistant"), times = n),
         tokens = tokens_v
       )
-      
+
       if (include_system_prompt && private$has_system_prompt()) {
         # How do we compute this?
         tokens_df <- rbind(data.frame(role = "system", tokens = 0), tokens_df)
@@ -149,7 +154,8 @@ Chat <- R6::R6Class("Chat",
       role <- arg_match(role)
 
       n <- length(private$.turns)
-      switch(role,
+      switch(
+        role,
         system = if (private$has_system_prompt()) private$.turns[[1]],
         assistant = if (n > 1) private$.turns[[n]],
         user = if (n > 1) private$.turns[[n - 1]]
@@ -169,7 +175,11 @@ Chat <- R6::R6Class("Chat",
 
       # Returns a single turn (the final response from the assistant), even if
       # multiple rounds of back and forth happened.
-      coro::collect(private$chat_impl(turn, stream = echo != "none", echo = echo))
+      coro::collect(private$chat_impl(
+        turn,
+        stream = echo != "none",
+        echo = echo
+      ))
 
       text <- self$last_turn()@text
       if (echo == "none") text else invisible(text)
@@ -277,7 +287,12 @@ Chat <- R6::R6Class("Chat",
 
       map(json, function(json) {
         turn <- value_turn(private$provider, json, has_type = TRUE)
-        extract_data(turn, type, convert = convert, needs_wrapper = needs_wrapper)
+        extract_data(
+          turn,
+          type,
+          convert = convert,
+          needs_wrapper = needs_wrapper
+        )
       })
     },
 
@@ -352,7 +367,7 @@ Chat <- R6::R6Class("Chat",
     },
 
     #' @description Register a tool (an R function) that the chatbot can use.
-    #'   If the chatbot decides to use the function,  ellmer will automatically
+    #'   If the chatbot decides to use the function, ellmer will automatically
     #'   call it and submit the results back.
     #'
     #'   The return value of the function. Generally, this should either be a
@@ -373,6 +388,27 @@ Chat <- R6::R6Class("Chat",
     #' @description Retrieve the list of registered tools.
     get_tools = function() {
       private$tools
+    },
+
+    #' @description Registers multiple tools for the chatbot by iterating
+    #'   through a list of `tools` and calling `register_tool()` for each entry.
+    #'   Tools are indexed by their `@name` property, overwriting any existing
+    #'   tools with matching names.
+    #' @param tools A list of tools defined by [ellmer::tool()].
+    register_tools = function(tools) {
+      if (!is_list(tools)) {
+        msg <- "{.arg tools} must be a list of tools created with {.fn ellmer::tool}."
+        if (S7_inherits(tools, ToolDef)) {
+          msg <- c(msg, "i" = "Did you mean to call {.code $register_tool()}?")
+        }
+        cli::cli_abort(msg)
+      }
+
+      for (tool_def in tools) {
+        self$register_tool(tool_def)
+      }
+
+      invisible(self)
     }
   ),
   private = list(
@@ -393,16 +429,29 @@ Chat <- R6::R6Class("Chat",
       if (private$.turns[[i]]@role != "user") {
         private$.turns[[i + 1]] <- Turn("user", contents)
       } else {
-        private$.turns[[i]]@contents <- c(private$.turns[[i]]@contents, contents)
+        private$.turns[[i]]@contents <- c(
+          private$.turns[[i]]@contents,
+          contents
+        )
       }
       invisible(self)
     },
 
     # If stream = TRUE, yields completion deltas. If stream = FALSE, yields
     # complete assistant turns.
-    chat_impl = generator_method(function(self, private, user_turn, stream, echo) {
-      while(!is.null(user_turn)) {
-        for (chunk in private$submit_turns(user_turn, stream = stream, echo = echo)) {
+    chat_impl = generator_method(function(
+      self,
+      private,
+      user_turn,
+      stream,
+      echo
+    ) {
+      while (!is.null(user_turn)) {
+        for (chunk in private$submit_turns(
+          user_turn,
+          stream = stream,
+          echo = echo
+        )) {
           yield(chunk)
         }
         user_turn <- private$invoke_tools()
@@ -411,9 +460,19 @@ Chat <- R6::R6Class("Chat",
 
     # If stream = TRUE, yields completion deltas. If stream = FALSE, yields
     # complete assistant turns.
-    chat_impl_async = async_generator_method(function(self, private, user_turn, stream, echo) {
-      while(!is.null(user_turn)) {
-        for (chunk in await_each(private$submit_turns_async(user_turn, stream = stream, echo = echo))) {
+    chat_impl_async = async_generator_method(function(
+      self,
+      private,
+      user_turn,
+      stream,
+      echo
+    ) {
+      while (!is.null(user_turn)) {
+        for (chunk in await_each(private$submit_turns_async(
+          user_turn,
+          stream = stream,
+          echo = echo
+        ))) {
           yield(chunk)
         }
         user_turn <- await(private$invoke_tools_async())
@@ -425,8 +484,14 @@ Chat <- R6::R6Class("Chat",
 
     # If stream = TRUE, yields completion deltas. If stream = FALSE, yields
     # complete assistant turns.
-    submit_turns = generator_method(function(self, private, user_turn, stream, echo, type = NULL) {
-
+    submit_turns = generator_method(function(
+      self,
+      private,
+      user_turn,
+      stream,
+      echo,
+      type = NULL
+    ) {
       if (echo == "all") {
         cat_line(format(user_turn), prefix = "> ")
       }
@@ -468,7 +533,11 @@ Chat <- R6::R6Class("Chat",
           cat_line(formatted, prefix = "< ")
         }
       } else {
-        turn <- value_turn(private$provider, response, has_type = !is.null(type))
+        turn <- value_turn(
+          private$provider,
+          response,
+          has_type = !is.null(type)
+        )
         text <- turn@text
         if (!is.null(text)) {
           text <- paste0(text, "\n")
@@ -486,7 +555,14 @@ Chat <- R6::R6Class("Chat",
 
     # If stream = TRUE, yields completion deltas. If stream = FALSE, yields
     # complete assistant turns.
-    submit_turns_async = async_generator_method(function(self, private, user_turn, stream, echo, type = NULL) {
+    submit_turns_async = async_generator_method(function(
+      self,
+      private,
+      user_turn,
+      stream,
+      echo,
+      type = NULL
+    ) {
       response <- chat_perform(
         provider = private$provider,
         mode = if (stream) "async-stream" else "async-value",
@@ -560,29 +636,36 @@ is_chat <- function(x) {
 #' @export
 print.Chat <- function(x, ...) {
   turns <- x$get_turns(include_system_prompt = TRUE)
-  
+
   tokens <- x$tokens(include_system_prompt = TRUE)
   tokens_user <- sum(tokens$tokens[tokens$role == "user"])
   tokens_assistant <- sum(tokens$tokens[tokens$role == "assistant"])
 
   cat(paste0(
-    "<Chat", 
-    " turns=", length(turns), 
-    " tokens=", tokens_user, "/", tokens_assistant, 
+    "<Chat",
+    " turns=",
+    length(turns),
+    " tokens=",
+    tokens_user,
+    "/",
+    tokens_assistant,
     ">\n"
   ))
-  
+
   for (i in seq_along(turns)) {
     turn <- turns[[i]]
-    
-    color <- switch(turn@role,
+
+    color <- switch(
+      turn@role,
       user = cli::col_blue,
       assistant = cli::col_green,
       system = cli::col_br_white,
       identity
     )
 
-    cli::cat_rule(cli::format_inline("{color(turn@role)} [{tokens$tokens[[i]]}]"))
+    cli::cat_rule(cli::format_inline(
+      "{color(turn@role)} [{tokens$tokens[[i]]}]"
+    ))
     for (content in turn@contents) {
       cat_line(format(content))
     }
@@ -591,7 +674,10 @@ print.Chat <- function(x, ...) {
   invisible(x)
 }
 
-method(contents_markdown, new_S3_class("Chat")) <- function(content, heading_level = 2) {
+method(contents_markdown, new_S3_class("Chat")) <- function(
+  content,
+  heading_level = 2
+) {
   turns <- content$get_turns()
   if (length(turns) == 0) {
     return("")
@@ -606,7 +692,7 @@ method(contents_markdown, new_S3_class("Chat")) <- function(content, heading_lev
     res[i] <- glue::glue("{hh} {role}\n\n{contents_markdown(turns[[i]])}")
   }
 
-  paste(res, collapse="\n\n")
+  paste(res, collapse = "\n\n")
 }
 
 extract_data <- function(turn, type, convert = TRUE, needs_wrapper = FALSE) {

--- a/man/Chat.Rd
+++ b/man/Chat.Rd
@@ -452,36 +452,19 @@ Retrieve the list of registered tools.
 \if{html}{\out{<a id="method-Chat-set_tools"></a>}}
 \if{latex}{\out{\hypertarget{method-Chat-set_tools}{}}}
 \subsection{Method \code{set_tools()}}{
-Sets the available tools for the chatbot by managing a
-collection of tool definitions. This method allows either replacing all
-existing tools or merging new tools with existing ones, and is designed
-for programmatic interaction with chat tools. To register a single tool
-with a \code{Chat}, use \code{register_tool()}.
+Sets the available tools. For expert use only; most users
+should use \code{register_tool()}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Chat$set_tools(tools, action = c("replace", "merge"))}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Chat$set_tools(tools)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{tools}}{A list of tool definitions created with \code{\link[=tool]{tool()}}.}
-
-\item{\code{action}}{Character string specifying how to handle the new tools:
-\itemize{
-\item \code{"replace"}: Removes all existing tools and sets only the provided
-tools
-\item \code{"merge"}: Adds the new tools to existing ones, replacing any tools
-with matching names
-}}
 }
 \if{html}{\out{</div>}}
 }
-\subsection{Details}{
-When merging tools (\code{action = "merge"}), any existing tool with
-the same name as a new tool will be overwritten by the new definition.
-This allows for updating specific tools while preserving others.
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Chat-clone"></a>}}

--- a/man/Chat.Rd
+++ b/man/Chat.Rd
@@ -44,6 +44,7 @@ chat$chat("Tell me a funny joke")
 \item \href{#method-Chat-stream}{\code{Chat$stream()}}
 \item \href{#method-Chat-stream_async}{\code{Chat$stream_async()}}
 \item \href{#method-Chat-register_tool}{\code{Chat$register_tool()}}
+\item \href{#method-Chat-get_tools}{\code{Chat$get_tools()}}
 \item \href{#method-Chat-clone}{\code{Chat$clone()}}
 }
 }
@@ -435,6 +436,16 @@ alone until the entire request is JSON-serialized.
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Chat-get_tools"></a>}}
+\if{latex}{\out{\hypertarget{method-Chat-get_tools}{}}}
+\subsection{Method \code{get_tools()}}{
+Retrieve the list of registered tools.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Chat$get_tools()}\if{html}{\out{</div>}}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Chat-clone"></a>}}

--- a/man/Chat.Rd
+++ b/man/Chat.Rd
@@ -45,6 +45,7 @@ chat$chat("Tell me a funny joke")
 \item \href{#method-Chat-stream_async}{\code{Chat$stream_async()}}
 \item \href{#method-Chat-register_tool}{\code{Chat$register_tool()}}
 \item \href{#method-Chat-get_tools}{\code{Chat$get_tools()}}
+\item \href{#method-Chat-register_tools}{\code{Chat$register_tools()}}
 \item \href{#method-Chat-clone}{\code{Chat$clone()}}
 }
 }
@@ -417,7 +418,7 @@ yields string promises.
 \if{latex}{\out{\hypertarget{method-Chat-register_tool}{}}}
 \subsection{Method \code{register_tool()}}{
 Register a tool (an R function) that the chatbot can use.
-If the chatbot decides to use the function,  ellmer will automatically
+If the chatbot decides to use the function, ellmer will automatically
 call it and submit the results back.
 
 The return value of the function. Generally, this should either be a
@@ -446,6 +447,26 @@ Retrieve the list of registered tools.
 \if{html}{\out{<div class="r">}}\preformatted{Chat$get_tools()}\if{html}{\out{</div>}}
 }
 
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Chat-register_tools"></a>}}
+\if{latex}{\out{\hypertarget{method-Chat-register_tools}{}}}
+\subsection{Method \code{register_tools()}}{
+Registers multiple tools for the chatbot by iterating
+through a list of \code{tools} and calling \code{register_tool()} for each entry.
+Tools are indexed by their \verb{@name} property, overwriting any existing
+tools with matching names.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Chat$register_tools(tools)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{tools}}{A list of tools defined by \code{\link[=tool]{tool()}}.}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Chat-clone"></a>}}

--- a/man/Chat.Rd
+++ b/man/Chat.Rd
@@ -45,7 +45,7 @@ chat$chat("Tell me a funny joke")
 \item \href{#method-Chat-stream_async}{\code{Chat$stream_async()}}
 \item \href{#method-Chat-register_tool}{\code{Chat$register_tool()}}
 \item \href{#method-Chat-get_tools}{\code{Chat$get_tools()}}
-\item \href{#method-Chat-register_tools}{\code{Chat$register_tools()}}
+\item \href{#method-Chat-set_tools}{\code{Chat$set_tools()}}
 \item \href{#method-Chat-clone}{\code{Chat$clone()}}
 }
 }
@@ -449,24 +449,39 @@ Retrieve the list of registered tools.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Chat-register_tools"></a>}}
-\if{latex}{\out{\hypertarget{method-Chat-register_tools}{}}}
-\subsection{Method \code{register_tools()}}{
-Registers multiple tools for the chatbot by iterating
-through a list of \code{tools} and calling \code{register_tool()} for each entry.
-Tools are indexed by their \verb{@name} property, overwriting any existing
-tools with matching names.
+\if{html}{\out{<a id="method-Chat-set_tools"></a>}}
+\if{latex}{\out{\hypertarget{method-Chat-set_tools}{}}}
+\subsection{Method \code{set_tools()}}{
+Sets the available tools for the chatbot by managing a
+collection of tool definitions. This method allows either replacing all
+existing tools or merging new tools with existing ones, and is designed
+for programmatic interaction with chat tools. To register a single tool
+with a \code{Chat}, use \code{register_tool()}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Chat$register_tools(tools)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Chat$set_tools(tools, action = c("replace", "merge"))}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{tools}}{A list of tools defined by \code{\link[=tool]{tool()}}.}
+\item{\code{tools}}{A list of tool definitions created with \code{\link[=tool]{tool()}}.}
+
+\item{\code{action}}{Character string specifying how to handle the new tools:
+\itemize{
+\item \code{"replace"}: Removes all existing tools and sets only the provided
+tools
+\item \code{"merge"}: Adds the new tools to existing ones, replacing any tools
+with matching names
+}}
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Details}{
+When merging tools (\code{action = "merge"}), any existing tool with
+the same name as a new tool will be overwritten by the new definition.
+This allows for updating specific tools while preserving others.
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Chat-clone"></a>}}

--- a/tests/testthat/_snaps/chat.md
+++ b/tests/testthat/_snaps/chat.md
@@ -17,9 +17,9 @@
 # chat can get and register a list of tools
 
     Code
-      chat$register_tools(tools[[1]])
+      chat$set_tools(tools[[1]])
     Condition
-      Error in `chat$register_tools()`:
+      Error in `chat$set_tools()`:
       ! `tools` must be a list of tools created with `ellmer::tool()`.
       i Did you mean to call `$register_tool()`?
 

--- a/tests/testthat/_snaps/chat.md
+++ b/tests/testthat/_snaps/chat.md
@@ -23,3 +23,11 @@
       ! `tools` must be a list of tools created with `ellmer::tool()`.
       i Did you mean to call `$register_tool()`?
 
+---
+
+    Code
+      chat$set_tools(c(tools, list("foo")))
+    Condition
+      Error in `chat$set_tools()`:
+      ! `tools` must be a list of tools created with `ellmer::tool()`.
+

--- a/tests/testthat/_snaps/chat.md
+++ b/tests/testthat/_snaps/chat.md
@@ -14,3 +14,12 @@
       
       3
 
+# chat can get and register a list of tools
+
+    Code
+      chat$register_tools(tools[[1]])
+    Condition
+      Error in `chat$register_tools()`:
+      ! `tools` must be a list of tools created with `ellmer::tool()`.
+      i Did you mean to call `$register_tool()`?
+

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -269,29 +269,28 @@ test_that("chat can get and register a list of tools", {
     chat$register_tool(tool)
   }
 
-  chat2$register_tools(tools)
+  chat2$set_tools(tools)
 
   expect_equal(chat$get_tools(), tools)
   expect_equal(chat2$get_tools(), chat$get_tools())
 
-  # replacing a tool by name overwrites existing tools
-  tool_r_version_2 <- tool(
+  # action = "replace" overwrites existing tools
+  tool_r_major <- tool(
     function() R.version$major,
     .description = "Get the major version of R",
-    .name = "r_version"
+    .name = "r_version_major"
   )
-  new_tools <- tools
-  new_tools[[2]] <- tool_r_version_2
-
-  chat$register_tool(tool_r_version_2)
-  chat2$register_tools(new_tools)
-
+  new_tools <- list("r_version_major" = tool_r_major)
+  chat$set_tools(new_tools)
   expect_equal(chat$get_tools(), new_tools)
-  expect_equal(chat2$get_tools(), chat$get_tools())
 
-  # register_tools() throws with helpful message if given just a tool
+  # action = "merge" merges new tools with old tools
+  chat2$set_tools(new_tools, action = "merge")
+  expect_equal(chat2$get_tools(), c(tools, new_tools))
+
+  # set_tools() throws with helpful message if given just a tool
   expect_snapshot(
     error = TRUE,
-    chat$register_tools(tools[[1]])
+    chat$set_tools(tools[[1]])
   )
 })

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -247,3 +247,51 @@ test_that("async chat messages get timestamped in sequence", {
   expect_true(turns[[1]]@completed <= turns[[2]]@completed)
   expect_true(turns[[2]]@completed <= after_receive)
 })
+
+test_that("chat can get and register a list of tools", {
+  chat <- chat_openai(api_key = "not required")
+  chat2 <- chat_openai(api_key = "not required")
+
+  tools <- list(
+    "sys_time" = tool(
+      function() strftime(Sys.time(), "%F %T"),
+      .description = "Get the current system time",
+      .name = "sys_time"
+    ),
+    "r_version" = tool(
+      function() R.version.string,
+      .description = "Get the R version of the current session",
+      .name = "r_version"
+    )
+  )
+
+  for (tool in tools) {
+    chat$register_tool(tool)
+  }
+
+  chat2$register_tools(tools)
+
+  expect_equal(chat$get_tools(), tools)
+  expect_equal(chat2$get_tools(), chat$get_tools())
+
+  # replacing a tool by name overwrites existing tools
+  tool_r_version_2 <- tool(
+    function() R.version$major,
+    .description = "Get the major version of R",
+    .name = "r_version"
+  )
+  new_tools <- tools
+  new_tools[[2]] <- tool_r_version_2
+
+  chat$register_tool(tool_r_version_2)
+  chat2$register_tools(new_tools)
+
+  expect_equal(chat$get_tools(), new_tools)
+  expect_equal(chat2$get_tools(), chat$get_tools())
+
+  # register_tools() throws with helpful message if given just a tool
+  expect_snapshot(
+    error = TRUE,
+    chat$register_tools(tools[[1]])
+  )
+})

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -284,13 +284,15 @@ test_that("chat can get and register a list of tools", {
   chat$set_tools(new_tools)
   expect_equal(chat$get_tools(), new_tools)
 
-  # action = "merge" merges new tools with old tools
-  chat2$set_tools(new_tools, action = "merge")
-  expect_equal(chat2$get_tools(), c(tools, new_tools))
-
   # set_tools() throws with helpful message if given just a tool
   expect_snapshot(
     error = TRUE,
     chat$set_tools(tools[[1]])
+  )
+
+  # set_tools() throws with helpful message if not all items are tools
+  expect_snapshot(
+    error = TRUE,
+    chat$set_tools(c(tools, list("foo")))
   )
 })


### PR DESCRIPTION
Adds two new methods to `Chat`:

* `get_tools()` returns the list of registered tools
* `set_tools()` sets (registers) a list of tools, replacing the existing tools.

These function support a few use cases:

1. Retrieving the list of available tools, e.g to list which tools are enabled in the chat

   ```r
   chat$get_tools()
   ```

3. Modify the existing tools, e.g. for wrapping tool calls with (hypothetical) decorator functions

   ```r
   tools <- chat$get_tools()
   chat$set_tools(modify_tools(tools))
   ```

4. Removing tools from the list

   ```r
   old_tools <- chat$get_tools()
   new_tools <- keep(old_tools, \(tool) tool@name != "read_files")
   chat$set_tools(new_tools)
   ```