### PR TITLE
Update URLs to OpenAI docs in content-image.R

### DIFF
--- a/R/content-image.R
+++ b/R/content-image.R
@@ -8,7 +8,7 @@
 #'   `data:` URL or a regular URL. Valid image types are PNG, JPEG, WebP, and
 #'   non-animated GIF.
 #' @param detail The [detail
-#'   setting](https://platform.openai.com/docs/guides/vision/low-or-high-fidelity-image-understanding)
+#'   setting](https://platform.openai.com/docs/guides/images/image-input-requirements)
 #'   for this image. Can be `"auto"`, `"low"`, or `"high"`.
 #' @returns An input object suitable for including in the `...` parameter of
 #'   the `chat()`, `stream()`, `chat_async()`, or `stream_async()` methods.
@@ -50,7 +50,7 @@ content_image_url <- function(url, detail = c("auto", "low", "high")) {
 #'   `"auto"`, the content type is inferred from the file extension.
 #' @param resize If `"low"`, resize images to fit within 512x512. If `"high"`,
 #'   resize to fit within 2000x768 or 768x2000. (See the [OpenAI
-#'   docs](https://platform.openai.com/docs/guides/vision/low-or-high-fidelity-image-understanding)
+#'   docs](https://platform.openai.com/docs/guides/images/image-input-requirements)
 #'   for more on why these specific sizes are used.) If `"none"`, do not resize.
 #'
 #'   You can also pass a custom string to resize the image to a specific size,
@@ -74,7 +74,7 @@ content_image_file <- function(path, content_type = "auto", resize = "low") {
 
   if (content_type == "auto") {
     # OpenAI supports .png, .jpeg, .jpg, .webp, .gif
-    # https://platform.openai.com/docs/guides/vision/what-type-of-files-can-i-upload
+    # https://platform.openai.com/docs/guides/images/image-input-requirements
     ext <- tolower(tools::file_ext(path))
     content_type <- switch(
       ext,

--- a/man/content_image_url.Rd
+++ b/man/content_image_url.Rd
@@ -17,7 +17,7 @@ content_image_plot(width = 768, height = 768)
 \verb{data:} URL or a regular URL. Valid image types are PNG, JPEG, WebP, and
 non-animated GIF.}
 
-\item{detail}{The \href{https://platform.openai.com/docs/guides/vision/low-or-high-fidelity-image-understanding}{detail setting}
+\item{detail}{The \href{https://platform.openai.com/docs/guides/images/image-input-requirements}{detail setting}
 for this image. Can be \code{"auto"}, \code{"low"}, or \code{"high"}.}
 
 \item{path}{The path to the image file to include in the chat input. Valid
@@ -28,7 +28,7 @@ file extensions are \code{.png}, \code{.jpeg}, \code{.jpg}, \code{.webp}, and (n
 \code{"auto"}, the content type is inferred from the file extension.}
 
 \item{resize}{If \code{"low"}, resize images to fit within 512x512. If \code{"high"},
-resize to fit within 2000x768 or 768x2000. (See the \href{https://platform.openai.com/docs/guides/vision/low-or-high-fidelity-image-understanding}{OpenAI docs}
+resize to fit within 2000x768 or 768x2000. (See the \href{https://platform.openai.com/docs/guides/images/image-input-requirements}{OpenAI docs}
 for more on why these specific sizes are used.) If \code{"none"}, do not resize.
 
 You can also pass a custom string to resize the image to a specific size,


### PR DESCRIPTION
Some of the URLs pointing to the OpenAI docs are not valid anymore. This PR updates the corresponding URLs.