### PR TITLE
Provider a default role for OpenAI messages

### DIFF
--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -257,7 +257,7 @@ method(value_turn, ProviderOpenAI) <- function(
     tokens
   )
 
-  Turn(message$role, content, json = result, tokens = tokens)
+  Turn(message$role %||% "assistant", content, json = result, tokens = tokens)
 }
 
 # ellmer -> OpenAI --------------------------------------------------------------

--- a/R/provider-snowflake.R
+++ b/R/provider-snowflake.R
@@ -144,27 +144,6 @@ method(stream_parse, ProviderSnowflake) <- function(provider, event) {
   jsonlite::parse_json(event$data)
 }
 
-method(value_turn, ProviderSnowflake) <- function(
-  provider,
-  result,
-  has_type = FALSE
-) {
-  deltas <- compact(sapply(result$choices, function(x) x$delta$content))
-  content <- list(as_content(paste(deltas, collapse = "")))
-  tokens <- c(
-    result$usage$prompt_tokens %||% NA_integer_,
-    result$usage$completion_tokens %||% NA_integer_
-  )
-  tokens_log(paste0("Snowflake-", provider@account), tokens)
-  Turn(
-    # Snowflake's response format seems to omit the role.
-    "assistant",
-    content,
-    json = result,
-    tokens = tokens
-  )
-}
-
 # ellmer -> Snowflake --------------------------------------------------------
 
 # Snowflake only supports simple textual messages.


### PR DESCRIPTION
Part of #161

@atheriel this brings ellmer closer in line with the ChatGPT sdk, but can you please double check it still works for snowflake?