### PR TITLE
docs(params): Fix typo

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -1,4 +1,4 @@
-#' Standard model parmeters
+#' Standard model parameters
 #'
 #' @description
 #' This helper function makes it easier to create a list of parameters used

--- a/man/params.Rd
+++ b/man/params.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/params.R
 \name{params}
 \alias{params}
-\title{Standard model parmeters}
+\title{Standard model parameters}
 \usage{
 params(
   temperature = NULL,


### PR DESCRIPTION
Fixes a small typo in the `params()` title.