### PR TITLE
Break up `chat_request()` into smaller generics

### DIFF
--- a/R/provider-azure.R
+++ b/R/provider-azure.R
@@ -133,24 +133,20 @@ azure_endpoint <- function() {
 }
 
 # https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions
-method(chat_request, ProviderAzureOpenAI) <- function(
-  provider,
-  stream = TRUE,
-  turns = list(),
-  tools = list(),
-  type = NULL
-) {
-  req <- request(provider@base_url)
-  req <- req_url_path_append(req, "/chat/completions")
+method(base_request, ProviderAzureOpenAI) <- function(provider) {
+  req <- base_request(super(provider, ProviderOpenAI))
+  req <- req_headers(req, Authorization = NULL)
+
   req <- req_url_query(req, `api-version` = provider@api_version)
   if (nchar(provider@api_key)) {
     req <- req_headers_redacted(req, `api-key` = provider@api_key)
   }
   req <- ellmer_req_credentials(req, provider@credentials)
-  req <- req_retry(req, max_tries = 2)
-  req <- ellmer_req_timeout(req, stream)
-  req <- ellmer_req_user_agent(req)
-  req <- req_error(req, body = function(resp) {
+  req
+}
+
+method(base_request_error, ProviderAzureOpenAI) <- function(provider, req) {
+  req_error(req, body = function(resp) {
     error <- resp_body_json(resp)$error
     msg <- paste0(error$code, ": ", error$message)
     # Try to be helpful in the (common) case that the user or service
@@ -174,37 +170,6 @@ method(chat_request, ProviderAzureOpenAI) <- function(
     }
     msg
   })
-
-  messages <- compact(unlist(as_json(provider, turns), recursive = FALSE))
-  tools <- as_json(provider, unname(tools))
-
-  if (!is.null(type)) {
-    response_format <- list(
-      type = "json_schema",
-      json_schema = list(
-        name = "structured_data",
-        schema = as_json(provider, type),
-        strict = TRUE
-      )
-    )
-  } else {
-    response_format <- NULL
-  }
-
-  params <- chat_params(provider, provider@params)
-  body <- compact(list2(
-    messages = messages,
-    model = provider@model,
-    stream = stream,
-    stream_options = if (stream) list(include_usage = TRUE),
-    tools = tools,
-    response_format = response_format,
-    !!!params
-  ))
-  body <- modify_list(body, provider@extra_args)
-  req <- req_body_json(req, body)
-
-  req
 }
 
 default_azure_credentials <- function(api_key = NULL, token = NULL) {

--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -95,6 +95,27 @@ method(base_request, ProviderDatabricks) <- function(provider) {
   req
 }
 
+method(chat_body, ProviderDatabricks) <- function(
+  provider,
+  stream = TRUE,
+  turns = list(),
+  tools = list(),
+  type = NULL
+) {
+  body <- chat_body(
+    super(provider, ProviderOpenAI),
+    stream = stream,
+    turns = turns,
+    tools = tools,
+    type = type
+  )
+
+  # Databricks doensn't support stream options
+  body$stream_options <- NULL
+
+  body
+}
+
 method(chat_path, ProviderDatabricks) <- function(provider) {
   # Note: this API endpoint is undocumented and seems to exist primarily for
   # compatibility with the OpenAI Python SDK. The documented endpoint is

--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -87,57 +87,31 @@ ProviderDatabricks <- new_class(
   properties = list(credentials = class_function)
 )
 
-method(chat_request, ProviderDatabricks) <- function(
-  provider,
-  stream = TRUE,
-  turns = list(),
-  tools = list(),
-  type = NULL
-) {
+method(base_request, ProviderDatabricks) <- function(provider) {
   req <- request(provider@base_url)
+  req <- ellmer_req_credentials(req, provider@credentials)
+  req <- req_retry(req, max_tries = 2)
+  req <- ellmer_req_timeout(req, stream)
+  req <- ellmer_req_user_agent(req, databricks_user_agent())
+  req <- base_request_error(provider, req)
+  req
+}
+
+method(chat_path, ProviderDatabricks) <- function(provider) {
   # Note: this API endpoint is undocumented and seems to exist primarily for
   # compatibility with the OpenAI Python SDK. The documented endpoint is
   # `/serving-endpoints/<model>/invocations`.
-  req <- req_url_path_append(req, "/serving-endpoints/chat/completions")
-  req <- ellmer_req_credentials(req, provider@credentials)
-  req <- ellmer_req_user_agent(req, databricks_user_agent())
-  req <- req_retry(req, max_tries = 2)
-  req <- ellmer_req_timeout(req, stream)
-  req <- req_error(req, body = function(resp) {
+  "/serving-endpoints/chat/completions"
+}
+
+method(base_request_error, ProviderDatabricks) <- function(provider, req) {
+  req_error(req, body = function(resp) {
     if (resp_content_type(resp) == "application/json") {
       # Databrick's "OpenAI-compatible" API has a slightly incompatible error
       # response format, which we account for here.
       resp_body_json(resp)$message
     }
   })
-
-  messages <- compact(unlist(as_json(provider, turns), recursive = FALSE))
-  tools <- as_json(provider, unname(tools))
-
-  if (!is.null(type)) {
-    response_format <- list(
-      type = "json_schema",
-      json_schema = list(
-        name = "structured_data",
-        schema = as_json(provider, type),
-        strict = TRUE
-      )
-    )
-  } else {
-    response_format <- NULL
-  }
-
-  body <- compact(list(
-    messages = messages,
-    model = provider@model,
-    stream = stream,
-    tools = tools,
-    response_format = response_format
-  ))
-  body <- modify_list(body, provider@extra_args)
-  req <- req_body_json(req, body)
-
-  req
 }
 
 method(as_json, list(ProviderDatabricks, Turn)) <- function(provider, x) {

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -110,29 +110,42 @@ openai_key <- function() {
   key_get("OPENAI_API_KEY")
 }
 
-# https://platform.openai.com/docs/api-reference/chat/create
-method(chat_request, ProviderOpenAI) <- function(
-  provider,
-  stream = TRUE,
-  turns = list(),
-  tools = list(),
-  type = NULL
-) {
+# Base request -----------------------------------------------------------------
+
+method(base_request, ProviderOpenAI) <- function(provider) {
   req <- request(provider@base_url)
-  req <- req_url_path_append(req, "/chat/completions")
   req <- req_auth_bearer_token(req, provider@api_key)
   req <- req_retry(req, max_tries = 2)
   req <- ellmer_req_timeout(req, stream)
   req <- ellmer_req_user_agent(req)
+  req <- base_request_error(provider, req)
+  req
+}
 
-  req <- req_error(req, body = function(resp) {
+method(base_request_error, ProviderOpenAI) <- function(provider, req) {
+  req_error(req, body = function(resp) {
     if (resp_content_type(resp) == "application/json") {
       resp_body_json(resp)$error$message
     } else if (resp_content_type(resp) == "text/plain") {
       resp_body_string(resp)
     }
   })
+}
 
+# Chat endpoint ----------------------------------------------------------------
+
+method(chat_path, ProviderOpenAI) <- function(provider) {
+  "/chat/completions"
+}
+
+# https://platform.openai.com/docs/api-reference/chat/create
+method(chat_body, ProviderOpenAI) <- function(
+  provider,
+  stream = TRUE,
+  turns = list(),
+  tools = list(),
+  type = NULL
+) {
   messages <- compact(unlist(as_json(provider, turns), recursive = FALSE))
   tools <- as_json(provider, unname(tools))
 
@@ -152,7 +165,7 @@ method(chat_request, ProviderOpenAI) <- function(
   params <- chat_params(provider, provider@params)
   params$seed <- params$seed %||% provider@seed
 
-  body <- compact(list2(
+  compact(list2(
     messages = messages,
     model = provider@model,
     !!!params,
@@ -161,11 +174,8 @@ method(chat_request, ProviderOpenAI) <- function(
     tools = tools,
     response_format = response_format
   ))
-  body <- utils::modifyList(body, provider@extra_args)
-  req <- req_body_json(req, body)
-
-  req
 }
+
 
 method(chat_params, ProviderOpenAI) <- function(provider, params) {
   standardise_params(

--- a/R/provider-openrouter.R
+++ b/R/provider-openrouter.R
@@ -60,21 +60,8 @@ openrouter_key <- function() {
   key_get("OPENROUTER_API_KEY")
 }
 
-method(chat_request, ProviderOpenRouter) <- function(
-  provider,
-  stream = TRUE,
-  turns = list(),
-  tools = list(),
-  type = NULL
-) {
-  req <- chat_request(
-    super(provider, ProviderOpenAI),
-    stream = stream,
-    turns = turns,
-    tools = tools,
-    type = type
-  )
-
+method(base_request, ProviderOpenRouter) <- function(provider) {
+  req <- base_request(super(provider, ProviderOpenAI))
   # https://openrouter.ai/docs/api-keys
   req <- req_headers(
     req,

--- a/R/provider-snowflake.R
+++ b/R/provider-snowflake.R
@@ -80,7 +80,6 @@ ProviderSnowflakeCortex <- new_class(
 
 method(base_request, ProviderSnowflakeCortex) <- function(provider) {
   req <- request(provider@base_url)
-  req <- req_url_path_append(req, "/api/v2/cortex/inference:complete")
   req <- ellmer_req_credentials(req, provider@credentials)
   req <- req_retry(req, max_tries = 2)
   req <- ellmer_req_timeout(req, stream)
@@ -93,6 +92,10 @@ method(base_request, ProviderSnowflakeCortex) <- function(provider) {
   req <- req_error(req, body = function(resp) resp_body_json(resp)$message)
 
   req
+}
+
+method(chat_path, ProviderSnowflakeCortex) <- function(provider) {
+  "/api/v2/cortex/inference:complete"
 }
 
 # See: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-llm-rest-api#api-reference

--- a/R/provider.R
+++ b/R/provider.R
@@ -42,6 +42,18 @@ test_provider <- function(name = "", model = "", base_url = "", ...) {
 
 # Create a request------------------------------------
 
+base_request <- new_generic("base_request", "provider", function(provider) {
+  S7_dispatch()
+})
+
+base_request_error <- new_generic(
+  "base_request_error",
+  "provider",
+  function(provider, req) {
+    S7_dispatch()
+  }
+)
+
 chat_request <- new_generic(
   "chat_request",
   "provider",
@@ -55,6 +67,47 @@ chat_request <- new_generic(
     S7_dispatch()
   }
 )
+
+method(chat_request, Provider) <- function(
+  provider,
+  stream = TRUE,
+  turns = list(),
+  tools = list(),
+  type = NULL
+) {
+  req <- base_request(provider)
+  req <- req_url_path_append(req, chat_path(provider))
+
+  body <- chat_body(
+    provider = provider,
+    stream = stream,
+    turns = turns,
+    tools = tools,
+    type = type
+  )
+  body <- modify_list(body, provider@extra_args)
+  req <- req_body_json(req, body)
+
+  req
+}
+
+chat_body <- new_generic(
+  "chat_body",
+  "provider",
+  function(
+    provider,
+    stream = TRUE,
+    turns = list(),
+    tools = list(),
+    type = NULL
+  ) {
+    S7_dispatch()
+  }
+)
+
+chat_path <- new_generic("chat_path", "provider", function(provider) {
+  S7_dispatch()
+})
 
 chat_resp_stream <- new_generic(
   "chat_resp_stream",

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -68,13 +68,14 @@ test_that("Databricks PATs are detected correctly", {
 test_that("Databricks CLI tokens are detected correctly", {
   withr::local_envvar(
     DATABRICKS_HOST = "https://example.cloud.databricks.com",
-    DATABRICKS_CLI_PATH = "echo"
+    DATABRICKS_CLI_PATH = "echo",
+    DATABRICKS_CLIENT_ID = NA,
+    DATABRICKS_CLIENT_SECRET = NA
   )
-  local_mocked_bindings(
-    databricks_cli_token = function(path, host) "token"
-  )
+  local_mocked_bindings(databricks_cli_token = function(path, host) "cli_token")
+
   credentials <- default_databricks_credentials()
-  expect_equal(credentials(), list(Authorization = "Bearer token"))
+  expect_equal(credentials(), list(Authorization = "Bearer cli_token"))
 })
 
 test_that("M2M authentication requests look correct", {


### PR DESCRIPTION
Starting with `chat_openai()` and backends.