### PR TITLE
Rename `Chat$tokens()` to `Chat$get_tokens()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,9 +52,9 @@
 * `live_browser()` now initializes `shinychat::chat_ui()` with the messages from
   the chat turns, rather than replaying the turns server-side (#381).
 
-* `Chat$tokens()` now returns a data frame of tokens, correctly aligned to the
-  individual turn. The print method now uses this to show how many input/output
-  tokens each turn used (#354).
+* `Chat$tokens()` is now called `Chat$get_tokens()` and returns a data frame of 
+  tokens, correctly aligned to the individual turn. The print method now uses 
+  this to show how many input/output tokens each turn used (#354).
 
 * All requests now set a custom User-Agent that identifies that the requests
   comes from ellmer (#341).

--- a/R/chat.R
+++ b/R/chat.R
@@ -114,7 +114,7 @@ Chat <- R6::R6Class(
     #'   output tokens used by assistant turns.
     #' @param include_system_prompt Whether to include the system prompt in
     #'   the turns (if any exists).
-    tokens = function(include_system_prompt = FALSE) {
+    get_tokens = function(include_system_prompt = FALSE) {
       turns <- self$get_turns(include_system_prompt = FALSE)
       assistant_turns <- keep(turns, function(x) x@role == "assistant")
 
@@ -679,7 +679,7 @@ print.Chat <- function(x, ...) {
   provider <- x$get_provider()
   turns <- x$get_turns(include_system_prompt = TRUE)
 
-  tokens <- x$tokens(include_system_prompt = TRUE)
+  tokens <- x$get_tokens(include_system_prompt = TRUE)
 
   tokens_user <- sum(tokens$tokens_total[tokens$role == "user"])
   tokens_assistant <- sum(tokens$tokens_total[tokens$role == "assistant"])

--- a/man/Chat.Rd
+++ b/man/Chat.Rd
@@ -33,7 +33,7 @@ chat$chat("Tell me a funny joke")
 \item \href{#method-Chat-get_system_prompt}{\code{Chat$get_system_prompt()}}
 \item \href{#method-Chat-get_model}{\code{Chat$get_model()}}
 \item \href{#method-Chat-set_system_prompt}{\code{Chat$set_system_prompt()}}
-\item \href{#method-Chat-tokens}{\code{Chat$tokens()}}
+\item \href{#method-Chat-get_tokens}{\code{Chat$get_tokens()}}
 \item \href{#method-Chat-get_cost}{\code{Chat$get_cost()}}
 \item \href{#method-Chat-last_turn}{\code{Chat$last_turn()}}
 \item \href{#method-Chat-chat}{\code{Chat$chat()}}
@@ -177,14 +177,14 @@ Update the system prompt
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Chat-tokens"></a>}}
-\if{latex}{\out{\hypertarget{method-Chat-tokens}{}}}
-\subsection{Method \code{tokens()}}{
+\if{html}{\out{<a id="method-Chat-get_tokens"></a>}}
+\if{latex}{\out{\hypertarget{method-Chat-get_tokens}{}}}
+\subsection{Method \code{get_tokens()}}{
 A data frame with a \code{tokens} column that proides the
 number of input tokens used by user turns and the number of
 output tokens used by assistant turns.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Chat$tokens(include_system_prompt = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Chat$get_tokens(include_system_prompt = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/tests/testthat/_snaps/tools-def-auto.new.md
+++ b/tests/testthat/_snaps/tools-def-auto.new.md
@@ -1,0 +1,57 @@
+# roxygen2 comment extraction works
+
+    Code
+      extract_comments_and_signature(has_roxygen_comments)
+    Output
+      [1] "function (x, y, z = pi - 3.14)  ..."
+
+---
+
+    Code
+      extract_comments_and_signature(aliased_function)
+    Output
+      [1] "function (x, y, z = pi - 3.14)  ..."
+
+---
+
+    Code
+      extract_comments_and_signature(indented_comments)
+    Output
+      [1] "function (x, y, z = pi - 3.14)  ..."
+
+---
+
+    Code
+      extract_comments_and_signature(no_srcfile)
+    Output
+      [1] "function (a, b, c = pi - 3.14)  ..."
+
+# basic signature extraction works
+
+    Code
+      extract_comments_and_signature(no_roxygen_comments)
+    Output
+      [1] "function (i, j, k = pi - 3.14)  ..."
+
+# checks its inputs
+
+    Code
+      create_tool_def(print, model = "gpt-4", chat = chat_google_gemini())
+    Condition
+      Error in `create_tool_def()`:
+      ! Exactly one of `model` or `chat` must be supplied.
+    Code
+      create_tool_def(print, chat = 1)
+    Condition
+      Error in `create_tool_def()`:
+      ! `chat` must be a <Chat> object or `NULL`, not the number 1.
+
+# model is deprecated
+
+    Code
+      . <- create_tool_def(print, model = "gpt-4", echo = FALSE)
+    Condition
+      Warning:
+      The `model` argument of `create_tool_def()` is deprecated as of ellmer 1.0.0.
+      i Please use the `chat` argument instead.
+

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -179,12 +179,12 @@ test_that("can extract structured data (async)", {
 
 test_that("can retrieve tokens with or without system prompt", {
   chat <- chat_openai_test("abc")
-  expect_equal(nrow(chat$tokens(FALSE)), 0)
-  expect_equal(nrow(chat$tokens(TRUE)), 1)
+  expect_equal(nrow(chat$get_tokens(FALSE)), 0)
+  expect_equal(nrow(chat$get_tokens(TRUE)), 1)
 
   chat <- chat_openai()
-  expect_equal(nrow(chat$tokens(FALSE)), 0)
-  expect_equal(nrow(chat$tokens(TRUE)), 0)
+  expect_equal(nrow(chat$get_tokens(FALSE)), 0)
+  expect_equal(nrow(chat$get_tokens(TRUE)), 0)
 })
 
 test_that("has a basic print method", {


### PR DESCRIPTION
Fixes #425

@simonpcouch Decided to not bother with deprecation as I think it's rarely used in everyday operation. If it causes other packages to fail, I'll make patches for them.