### PR TITLE
tests(test_tools_simple): Don't echo when calling tool

### DIFF
--- a/tests/testthat/helper-provider.R
+++ b/tests/testthat/helper-provider.R
@@ -62,8 +62,6 @@ test_turns_existing <- function(chat_fun) {
 # Tool calls -------------------------------------------------------------
 
 test_tools_simple <- function(chat_fun) {
-  local_reproducible_output()
-
   chat <- chat_fun(system_prompt = "Be very terse, not even punctuation.")
   chat$register_tool(tool(function() "2024-01-01", "Return the current date"))
 

--- a/tests/testthat/helper-provider.R
+++ b/tests/testthat/helper-provider.R
@@ -62,16 +62,12 @@ test_turns_existing <- function(chat_fun) {
 # Tool calls -------------------------------------------------------------
 
 test_tools_simple <- function(chat_fun) {
+  local_reproducible_output()
+
   chat <- chat_fun(system_prompt = "Be very terse, not even punctuation.")
   chat$register_tool(tool(function() "2024-01-01", "Return the current date"))
 
-  expect_output(
-    result <- chat$chat(
-      "What's the current date in Y-M-D format?",
-      echo = TRUE
-    ),
-    "2024-01-01"
-  )
+  result <- chat$chat("What's the current date in Y-M-D format?")
   expect_match(result, "2024-01-01")
 
   result <- chat$chat("What month is it? Provide the full name")


### PR DESCRIPTION
Switches to `echo = "none"` (default) for `test_tools_simple()`. I think this is okay because we test tool output in other ways.