### PR TITLE
Hoist `extra` field up to `Content` class

### DIFF
--- a/R/provider-cortex.R
+++ b/R/provider-cortex.R
@@ -356,7 +356,10 @@ method(as_json, list(ProviderSnowflakeCortexAnalyst, ContentText)) <- function(
 ContentSuggestions <- new_class(
   "ContentSuggestions",
   parent = Content,
-  properties = list(suggestions = class_character)
+  properties = list(suggestions = class_character),
+  constructor = function(suggestions, extra = list()) {
+    new_object(Content(extra = extra), suggestions = suggestions)
+  }
 )
 
 method(
@@ -393,7 +396,10 @@ method(format, ContentSuggestions) <- function(x, ...) {
 ContentSql <- new_class(
   "ContentSql",
   parent = Content,
-  properties = list(statement = prop_string())
+  properties = list(statement = prop_string()),
+  constructor = function(statement, extra = list()) {
+    new_object(Content(extra = extra), statement = statement)
+  }
 )
 
 method(as_json, list(ProviderSnowflakeCortexAnalyst, ContentSql)) <- function(

--- a/man/Content.Rd
+++ b/man/Content.Rd
@@ -12,30 +12,30 @@
 \alias{ContentPDF}
 \title{Content types received from and sent to a chatbot}
 \usage{
-Content()
+Content(extra = list())
 
-ContentText(text = stop("Required"))
+ContentText(text, extra = list())
 
-ContentImage()
+ContentImage(extra = list())
 
-ContentImageRemote(url = stop("Required"), detail = "")
+ContentImageRemote(url, detail = "", extra = list())
 
-ContentImageInline(type = stop("Required"), data = NULL)
+ContentImageInline(type, data = NULL, extra = list())
 
-ContentToolRequest(
-  id = stop("Required"),
-  name = stop("Required"),
-  arguments = list(),
-  tool = NULL
-)
+ContentToolRequest(id, name, arguments = list(), tool = NULL, extra = list())
 
-ContentToolResult(value = NULL, error = NULL, extra = list(), request = NULL)
+ContentToolResult(value = NULL, error = NULL, request = NULL, extra = list())
 
-ContentThinking(thinking = stop("Required"), extra = list())
+ContentThinking(thinking, extra = list())
 
-ContentPDF(type = stop("Required"), data = stop("Required"))
+ContentPDF(extra = list(), type = stop("Required"), data = stop("Required"))
 }
 \arguments{
+\item{extra}{Optional, provider-specific, data associated with the content.
+For \code{ContentToolResult}, this can be used to include additional data in the
+result that isn't included in the \code{value} that's shown to the LLM, but is
+shown to the user in a client, like a Shiny app.}
+
 \item{text}{A single string.}
 
 \item{url}{URL to a remote image.}
@@ -61,8 +61,6 @@ for the chatbot. If \code{NULL}, the request did not match a defined tool.}
 \item{error}{The error message, as a string, or the error condition thrown
 as a result of a failure when calling the tool function. Must be \code{NULL}
 when the tool call is successful.}
-
-\item{extra}{Additional data.}
 
 \item{request}{The \link{ContentToolRequest} associated with the tool result,
 automatically added by \pkg{ellmer} when evaluating the tool call.}


### PR DESCRIPTION
Probably reasonable that every content type has a way to attach arbitrary metadata, and the most obvious way to support Claude's caching. But it's pretty unappealing that I need to adjust the constructor of every subclass in order to preserve the existing behaviour.