### PR TITLE
Drop tests for common turns interface

### DIFF
--- a/tests/testthat/_snaps/provider-deepseek.md
+++ b/tests/testthat/_snaps/provider-deepseek.md
@@ -5,12 +5,3 @@
     Message
       Using model = "deepseek-chat".
 
-# all tool variations work
-
-    Code
-      chat$chat("Great. Do it again.")
-    Condition
-      Error in `FUN()`:
-      ! Can't use async tools with `$chat()` or `$stream()`.
-      i Async tools are supported, but you must use `$chat_async()` or `$stream_async()`.
-

--- a/tests/testthat/helper-provider.R
+++ b/tests/testthat/helper-provider.R
@@ -25,40 +25,6 @@ test_params_stop <- function(chat_fun) {
   expect_equal(out, "Dogs are ")
 }
 
-# Turns ------------------------------------------------------------------
-
-test_turns_system <- function(chat_fun) {
-  system_prompt <- "Return very minimal output, AND ONLY USE UPPERCASE."
-
-  chat <- chat_fun(system_prompt = system_prompt)
-  resp <- chat$chat("What is the name of Winnie the Pooh's human friend?")
-  expect_match(resp, "CHRISTOPHER ROBIN")
-  expect_length(chat$get_turns(), 2)
-
-  chat <- chat_fun()
-  chat$set_turns(list(Turn("system", system_prompt)))
-  resp <- chat$chat("What is the name of Winnie the Pooh's human friend?")
-  expect_match(resp, "CHRISTOPHER ROBIN")
-  expect_length(chat$get_turns(), 2)
-}
-
-test_turns_existing <- function(chat_fun) {
-  chat <- chat_fun()
-  chat$set_turns(list(
-    Turn("system", "Return very minimal output; no punctuation."),
-    Turn("user", "List the names of any 8 of Santa's 9 reindeer."),
-    Turn(
-      "assistant",
-      "Dasher, Dancer, Vixen, Comet, Cupid, Donner, Blitzen, and Rudolph."
-    )
-  ))
-  expect_length(chat$get_turns(), 2)
-
-  resp <- chat$chat("Who is the remaining one? Just give the name")
-  expect_match(resp, "Prancer")
-  expect_length(chat$get_turns(), 4)
-}
-
 # Tool calls -------------------------------------------------------------
 
 test_tools_simple <- function(chat_fun) {

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -71,6 +71,7 @@ test_that("setting turns usually preserves, but can set system prompt", {
   expect_equal(chat$get_system_prompt(), "You're a cool guy")
 })
 
+
 test_that("can perform a simple batch chat", {
   chat <- chat_openai_test()
 

--- a/tests/testthat/test-provider-azure.R
+++ b/tests/testthat/test-provider-azure.R
@@ -25,13 +25,6 @@ test_that("supports standard parameters", {
   test_params_stop(chat_fun)
 })
 
-test_that("respects turns interface", {
-  chat_fun <- chat_azure_openai_test
-
-  test_turns_system(chat_fun)
-  test_turns_existing(chat_fun)
-})
-
 test_that("all tool variations work", {
   chat_fun <- chat_azure_openai_test
 

--- a/tests/testthat/test-provider-bedrock.R
+++ b/tests/testthat/test-provider-bedrock.R
@@ -37,13 +37,6 @@ test_that("defaults are reported", {
   expect_snapshot(. <- chat_aws_bedrock())
 })
 
-test_that("respects turns interface", {
-  chat_fun <- chat_aws_bedrock
-
-  test_turns_system(chat_fun)
-  test_turns_existing(chat_fun)
-})
-
 test_that("all tool variations work", {
   chat_fun <- chat_aws_bedrock
 

--- a/tests/testthat/test-provider-claude.R
+++ b/tests/testthat/test-provider-claude.R
@@ -23,13 +23,6 @@ test_that("supports standard parameters", {
   test_params_stop(chat_fun)
 })
 
-test_that("respects turns interface", {
-  chat_fun <- chat_anthropic_test
-
-  test_turns_system(chat_fun)
-  test_turns_existing(chat_fun)
-})
-
 test_that("all tool variations work", {
   chat_fun <- chat_anthropic_test
 

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -24,13 +24,6 @@ test_that("defaults are reported", {
   expect_snapshot(. <- chat_databricks())
 })
 
-test_that("respects turns interface", {
-  # Note: Databricks models cannot handle the prompt for uppercase response,
-  # so skip test_turn_system().
-  # test_turns_system(chat_databricks)
-  test_turns_existing(chat_databricks)
-})
-
 test_that("all tool variations work", {
   # Note: Databricks models cannot yet handle "continuing past the first tool
   # call", which causes issues with how ellmer implements tool calling. Nor do

--- a/tests/testthat/test-provider-deepseek.R
+++ b/tests/testthat/test-provider-deepseek.R
@@ -19,13 +19,6 @@ test_that("defaults are reported", {
   expect_snapshot(. <- chat_deepseek())
 })
 
-test_that("respects turns interface", {
-  chat_fun <- chat_deepseek
-
-  test_turns_system(chat_fun)
-  test_turns_existing(chat_fun)
-})
-
 test_that("all tool variations work", {
   chat_fun <- chat_deepseek
 

--- a/tests/testthat/test-provider-gemini.R
+++ b/tests/testthat/test-provider-gemini.R
@@ -25,13 +25,6 @@ test_that("supports standard parameters", {
   test_params_stop(chat_fun)
 })
 
-test_that("respects turns interface", {
-  chat_fun <- chat_google_gemini
-
-  test_turns_system(chat_fun)
-  test_turns_existing(chat_fun)
-})
-
 test_that("all tool variations work", {
   chat_fun <- chat_google_gemini
 

--- a/tests/testthat/test-provider-groq.R
+++ b/tests/testthat/test-provider-groq.R
@@ -4,13 +4,6 @@ test_that("defaults are reported", {
   expect_snapshot(. <- chat_groq())
 })
 
-test_that("respects turns interface", {
-  chat_fun <- function(...) chat_groq(..., model = "Llama-3.3-70b-Versatile")
-
-  test_turns_system(chat_fun)
-  test_turns_existing(chat_fun)
-})
-
 test_that("all tool variations work", {
   chat_fun <- function(...) chat_groq(..., model = "Llama-3.3-70b-Versatile")
 

--- a/tests/testthat/test-provider-mistral.R
+++ b/tests/testthat/test-provider-mistral.R
@@ -30,13 +30,6 @@ test_that("supports standard parameters", {
   test_params_stop(chat_fun)
 })
 
-test_that("respects turns interface", {
-  chat_fun <- chat_mistral_test
-
-  test_turns_system(chat_fun)
-  test_turns_existing(chat_fun)
-})
-
 # Tool calling is poorly supported
 # test_that("all tool variations work", {
 #   chat_fun <- chat_mistral_test

--- a/tests/testthat/test-provider-openai.R
+++ b/tests/testthat/test-provider-openai.R
@@ -25,13 +25,6 @@ test_that("supports standard parameters", {
   test_params_stop(chat_fun)
 })
 
-test_that("respects turns interface", {
-  chat_fun <- chat_openai_test
-
-  test_turns_system(chat_fun)
-  test_turns_existing(chat_fun)
-})
-
 test_that("all tool variations work", {
   chat_fun <- chat_openai_test
 

--- a/tests/testthat/test-provider-openrouter.R
+++ b/tests/testthat/test-provider-openrouter.R
@@ -23,13 +23,6 @@ test_that("handles errors", {
 
 # Common provider interface -----------------------------------------------
 
-test_that("respects turns interface", {
-  chat_fun <- chat_openrouter_test
-
-  test_turns_system(chat_fun)
-  test_turns_existing(chat_fun)
-})
-
 test_that("all tool variations work", {
   chat_fun <- chat_openrouter_test
 

--- a/tests/testthat/test-provider-snowflake.R
+++ b/tests/testthat/test-provider-snowflake.R
@@ -28,14 +28,6 @@ test_that("defaults are reported", {
   expect_snapshot(. <- chat_snowflake())
 })
 
-test_that("respects turns interface", {
-  # Snowflake models don't support non-streaming responses, so these tests do
-  # not yet work.
-  #
-  # test_turns_system(chat_snowflake)
-  # test_turns_existing(chat_snowflake)
-})
-
 test_that("all tool variations work", {
   # Snowflake models don't support tool calling.
   #

--- a/tests/testthat/test-provider-vllm.R
+++ b/tests/testthat/test-provider-vllm.R
@@ -12,12 +12,3 @@ test_that("can make simple streaming request", {
   resp <- coro::collect(chat$stream("What is 1 + 1?"))
   expect_match(paste0(unlist(resp), collapse = ""), "2")
 })
-
-# Common provider interface -----------------------------------------------
-
-test_that("respects turns interface", {
-  chat_fun <- chat_vllm_test
-
-  test_turns_system(chat_fun)
-  test_turns_existing(chat_fun)
-})


### PR DESCRIPTION
Now that `provider_()` no long has a turns argument, this is just repeatedly testing the properties of the Chat object.

Fixes #442