### PR TITLE
fix(tools): Avoid double escaping when echoing tool result

### DIFF
--- a/R/content-tools.R
+++ b/R/content-tools.R
@@ -182,9 +182,9 @@ maybe_echo_tool <- function(x, echo = "output") {
       if (length(lines) > 5) cli::symbol$ellipsis
     )
     lines <- cli::style_italic(lines)
-    cli::cli_text("{icon} #> {header}{cli_escape(lines[1])}")
+    cli::cli_text("{icon} #> {header}{lines[1]}")
     for (line in lines[-1]) {
-      cli::cli_text("\u00a0\u00a0#> {cli_escape(line)}")
+      cli::cli_text("\u00a0\u00a0#> {line}")
     }
   } else {
     max_width <- cli::console_width() - 7
@@ -193,7 +193,7 @@ maybe_echo_tool <- function(x, echo = "output") {
       value <- paste0(value, cli::symbol$ellipsis)
     }
     value <- cli::style_italic(value)
-    cli::cli_text("{icon} #> {header}{cli_escape(value)}")
+    cli::cli_text("{icon} #> {header}{value}")
   }
 
   invisible(x)

--- a/tests/testthat/_snaps/content-tools.md
+++ b/tests/testthat/_snaps/content-tools.md
@@ -8,7 +8,7 @@
       ( ) [tool call] my_tool(x = 1)
       # #> Error: unused argument (x = 1)
       ( ) [tool call] tool_list()
-      o #> {{"a":1,"b":2}}
+      o #> {"a":1,"b":2}
       ( ) [tool call] tool_chr()
       o #> a
         #> b
@@ -31,7 +31,7 @@
       # #> Error: Unexpected input
         #> i Please revise and try again.
       o #> 1
-      o #> {{"a":1,"b":2}}
+      o #> {"a":1,"b":2}
       o #> a
         #> b
         #> c


### PR DESCRIPTION
Turns out I was unnecessarily escaping the tool result because I called `cli_text("{cli_escape(line)}")`, where `"{line}"` would already avoid the issue with braces.

Small reprex demonstrating the behavior we're avoiding:

``` r
pkgload::load_all()
#> ℹ Loading ellmer
```

In `cli_text()`, interpolated vars don’t need to be escaped.

``` r
foo <- "{bar}"
cli::cli_text(foo)
#> Error in "cli::cli_text(foo)": ! Could not evaluate cli `{}` expression: `bar`.
#> Caused by error in `eval(expr, envir = envir)`:
#> ! object 'bar' not found

cli::cli_text("{foo}")
#> {bar}
```

But for this reason we can’t just pass the result of `format_inline()` to `cli_text()`.

``` r
cli::cli_text(cli::format_inline("{foo}"))
#> Error in "cli::cli_text(cli::format_inline(\"{foo}\"))": ! Could not evaluate cli `{}` expression: `bar`.
#> Caused by error in `eval(expr, envir = envir)`:
#> ! object 'bar' not found

cli::cli_text(cli::format_inline("{cli_escape(foo)}"))
#> {bar}

# or...
cli::cli_text(cli_escape(cli::format_inline("{foo}")))
#> {bar}
```