### PR TITLE
docs(tool_annotations): Add example, link to `tool()`

### DIFF
--- a/R/tools-def.R
+++ b/R/tools-def.R
@@ -10,7 +10,6 @@ NULL
 #'
 #' Learn more in `vignette("tool-calling")`.
 #'
-#' @export
 #' @param .fun The function to be invoked when the tool is called. The return
 #'   value of the function is sent back to the chatbot.
 #'
@@ -26,7 +25,6 @@ NULL
 #' @param ... Name-type pairs that define the arguments accepted by the
 #'   function. Each element should be created by a [`type_*()`][type_boolean]
 #'   function.
-#' @export
 #' @return An S7 `ToolDef` object.
 #' @examplesIf has_credentials("openai")
 #'
@@ -51,6 +49,9 @@ NULL
 #' # Look at the chat history to see how tool calling works:
 #' # Assistant sends a tool request which is evaluated locally and
 #' # results are send back in a tool result.
+#'
+#' @family tool calling helpers
+#' @export
 tool <- function(.fun, .description, ..., .name = NULL, .annotations = list()) {
   if (is.null(.name)) {
     fun_expr <- enexpr(.fun)
@@ -96,6 +97,7 @@ tool <- function(.fun, .description, ..., .name = NULL, .annotations = list()) {
 #'
 #' @return A list of tool annotations.
 #'
+#' @family tool calling helpers
 #' @export
 tool_annotations <- function(
   title = NULL,

--- a/R/tools-def.R
+++ b/R/tools-def.R
@@ -35,7 +35,12 @@ NULL
 #'   "Drawn numbers from a random normal distribution",
 #'   n = type_integer("The number of observations. Must be a positive integer."),
 #'   mean = type_number("The mean value of the distribution."),
-#'   sd = type_number("The standard deviation of the distribution. Must be a non-negative number.")
+#'   sd = type_number("The standard deviation of the distribution. Must be a non-negative number."),
+#'   .annotations = tool_annotations(
+#'     title = "Draw Random Normal Numbers",
+#'     read_only_hint = TRUE,
+#'     open_world_hint = FALSE
+#'   )
 #' )
 #' chat <- chat_openai()
 #' # Then register it
@@ -73,13 +78,35 @@ tool <- function(.fun, .description, ..., .name = NULL, .annotations = list()) {
 #' Tool annotations
 #'
 #' @description
-#' Tool annotations are additional properties that can be used to describe a
-#' tool to clients, for example a Shiny app or another user interface.
+#' Tool annotations are additional properties that, when passed to the
+#' `.annotations` argument of [tool()], provide additional information about the
+#' tool and its behavior. This information can be used for display to users, for
+#' example in a Shiny app or another user interface.
 #'
 #' The annotations in `tool_annotations()` are drawn from the [Model Context
 #' Protocol](https://modelcontextprotocol.io/introduction) and are considered
 #' *hints*. Tool authors should use these annotations to communicate tool
 #' properties, but users should note that these annotations are not guaranteed.
+#'
+#' @examples
+#' # See ?tool() for a full example using this function.
+#' # We're creating a tool around R's `rnorm()` function to allow the chatbot to
+#' # generate random numbers from a normal distribution.
+#' tool_rnorm <- tool(
+#'   rnorm,
+#'   # Describe the tool function to the LLM
+#'   .description = "Drawn numbers from a random normal distribution",
+#'   # Describe the parameters used by the tool function
+#'   n = type_integer("The number of observations. Must be a positive integer."),
+#'   mean = type_number("The mean value of the distribution."),
+#'   sd = type_number("The standard deviation of the distribution. Must be a non-negative number."),
+#'   # Tool annotations optionally provide additional context to the LLM
+#'   .annotations = tool_annotations(
+#'     title = "Draw Random Normal Numbers",
+#'     read_only_hint = TRUE, # the tool does not modify any state
+#'     open_world_hint = FALSE # the tool does not interact with the outside world
+#'   )
+#' )
 #'
 #' @param title A human-readable title for the tool.
 #' @param read_only_hint If `TRUE`, the tool does not modify its environment.

--- a/man/chat_cloudflare.Rd
+++ b/man/chat_cloudflare.Rd
@@ -76,6 +76,7 @@ Other chatbots:
 \code{\link{chat_github}()},
 \code{\link{chat_google_gemini}()},
 \code{\link{chat_groq}()},
+\code{\link{chat_huggingface}()},
 \code{\link{chat_mistral}()},
 \code{\link{chat_ollama}()},
 \code{\link{chat_openai}()},

--- a/man/chat_huggingface.Rd
+++ b/man/chat_huggingface.Rd
@@ -78,6 +78,7 @@ Other chatbots:
 \code{\link{chat_anthropic}()},
 \code{\link{chat_aws_bedrock}()},
 \code{\link{chat_azure_openai}()},
+\code{\link{chat_cloudflare}()},
 \code{\link{chat_cortex_analyst}()},
 \code{\link{chat_databricks}()},
 \code{\link{chat_deepseek}()},

--- a/man/tool.Rd
+++ b/man/tool.Rd
@@ -45,7 +45,12 @@ tool_rnorm <- tool(
   "Drawn numbers from a random normal distribution",
   n = type_integer("The number of observations. Must be a positive integer."),
   mean = type_number("The mean value of the distribution."),
-  sd = type_number("The standard deviation of the distribution. Must be a non-negative number.")
+  sd = type_number("The standard deviation of the distribution. Must be a non-negative number."),
+  .annotations = tool_annotations(
+    title = "Draw Random Normal Numbers",
+    read_only_hint = TRUE,
+    open_world_hint = FALSE
+  )
 )
 chat <- chat_openai()
 # Then register it

--- a/man/tool.Rd
+++ b/man/tool.Rd
@@ -61,3 +61,8 @@ chat$chat("
 # results are send back in a tool result.
 \dontshow{\}) # examplesIf}
 }
+\seealso{
+Other tool calling helpers: 
+\code{\link{tool_annotations}()}
+}
+\concept{tool calling helpers}

--- a/man/tool_annotations.Rd
+++ b/man/tool_annotations.Rd
@@ -44,3 +44,8 @@ The annotations in \code{tool_annotations()} are drawn from the \href{https://mo
 \emph{hints}. Tool authors should use these annotations to communicate tool
 properties, but users should note that these annotations are not guaranteed.
 }
+\seealso{
+Other tool calling helpers: 
+\code{\link{tool}()}
+}
+\concept{tool calling helpers}

--- a/man/tool_annotations.Rd
+++ b/man/tool_annotations.Rd
@@ -37,12 +37,35 @@ meaningful when \code{read_only_hint} is \code{FALSE}.)}
 A list of tool annotations.
 }
 \description{
-Tool annotations are additional properties that can be used to describe a
-tool to clients, for example a Shiny app or another user interface.
+Tool annotations are additional properties that, when passed to the
+\code{.annotations} argument of \code{\link[=tool]{tool()}}, provide additional information about the
+tool and its behavior. This information can be used for display to users, for
+example in a Shiny app or another user interface.
 
 The annotations in \code{tool_annotations()} are drawn from the \href{https://modelcontextprotocol.io/introduction}{Model Context Protocol} and are considered
 \emph{hints}. Tool authors should use these annotations to communicate tool
 properties, but users should note that these annotations are not guaranteed.
+}
+\examples{
+# See ?tool() for a full example using this function.
+# We're creating a tool around R's `rnorm()` function to allow the chatbot to
+# generate random numbers from a normal distribution.
+tool_rnorm <- tool(
+  rnorm,
+  # Describe the tool function to the LLM
+  .description = "Drawn numbers from a random normal distribution",
+  # Describe the parameters used by the tool function
+  n = type_integer("The number of observations. Must be a positive integer."),
+  mean = type_number("The mean value of the distribution."),
+  sd = type_number("The standard deviation of the distribution. Must be a non-negative number."),
+  # Tool annotations optionally provide additional context to the LLM
+  .annotations = tool_annotations(
+    title = "Draw Random Normal Numbers",
+    read_only_hint = TRUE, # the tool does not modify any state
+    open_world_hint = FALSE # the tool does not interact with the outside world
+  )
+)
+
 }
 \seealso{
 Other tool calling helpers: 


### PR DESCRIPTION
Improves the documentation of `tool_annotation()` to link back to `tool()` and to include an example tool definition.

Also adds `@family` to link tool calling helpers