### PR TITLE
refactor: Use generators for tool invocation

### DIFF
--- a/R/chat-parallel.R
+++ b/R/chat-parallel.R
@@ -51,10 +51,11 @@ parallel_chat <- function(chat, prompts, max_active = 10, rpm = 500) {
       assistant_turns,
       \(turn) match_tools(turn, tools = chat$get_tools())
     )
-    user_turns <- map(
+    tool_results <- map(
       assistant_turns,
-      \(turn) tool_results_as_turn(invoke_tools(turn))
+      \(turn) coro::collect(invoke_tools(turn))
     )
+    user_turns <- map(tool_results, tool_results_as_turn)
     needs_iter <- !map_lgl(user_turns, is.null)
     if (!any(needs_iter)) {
       break

--- a/R/chat.R
+++ b/R/chat.R
@@ -510,7 +510,9 @@ Chat <- R6::R6Class(
           yield(chunk)
         }
 
-        tool_results <- invoke_tools(self$last_turn(), echo = echo)
+        tool_results <- coro::collect(
+          invoke_tools(self$last_turn(), echo = echo)
+        )
         user_turn <- tool_results_as_turn(tool_results)
 
         if (echo == "all") {
@@ -539,7 +541,9 @@ Chat <- R6::R6Class(
           yield(chunk)
         }
 
-        tool_results <- await(invoke_tools_async(self$last_turn(), echo = echo))
+        tool_results <- await(gen_async_promise_all(
+          invoke_tools_async(self$last_turn(), echo = echo)
+        ))
         user_turn <- tool_results_as_turn(tool_results)
 
         if (echo == "all") {

--- a/R/content-tools.R
+++ b/R/content-tools.R
@@ -15,49 +15,50 @@ match_tools <- function(turn, tools) {
   turn
 }
 
-invoke_tools <- function(turn, echo = "none") {
-  tool_requests <- extract_tool_requests(turn)
-
-  if (length(tool_requests) == 0) {
-    return(NULL)
-  }
-
-  lapply(tool_requests, function(request) {
-    maybe_echo_tool(request, echo = echo)
-    result <- invoke_tool(request)
-
-    if (promises::is.promise(result@value)) {
-      cli::cli_abort(c(
-        "Can't use async tools with `$chat()` or `$stream()`.",
-        i = "Async tools are supported, but you must use `$chat_async()` or `$stream_async()`."
-      ))
-    }
-
-    maybe_echo_tool(result, echo = echo)
-    result
-  })
-}
-
-on_load(
-  invoke_tools_async <- coro::async(function(turn, tools, echo = "none") {
+on_load({
+  invoke_tools <- coro::generator(function(turn, echo = "none") {
     tool_requests <- extract_tool_requests(turn)
 
-    # We call it this way instead of a more natural for + await_each() because
-    # we want to run all the async tool calls in parallel
-    result_promises <- lapply(tool_requests, function(request) {
+    for (request in tool_requests) {
       maybe_echo_tool(request, echo = echo)
+      result <- invoke_tool(request)
 
-      invoke_tool_async(request)
-    })
+      if (promises::is.promise(result@value)) {
+        cli::cli_abort(c(
+          "Can't use async tools with `$chat()` or `$stream()`.",
+          i = "Async tools are supported, but you must use `$chat_async()` or `$stream_async()`."
+        ))
+      }
 
-    result_promises <- lapply(result_promises, function(p) {
-      p$then(function(result) {
-        maybe_echo_tool(result, echo = echo)
-      })
-    })
-    promises::promise_all(.list = result_promises)
+      maybe_echo_tool(result, echo = echo)
+      yield(result)
+    }
   })
-)
+
+  # invoke_tools_async is intentionally *not* an _async_ generator, instead it
+  # is a generator that returns promises. This lets the caller decide if the
+  # tasks should be run in parallel or sequentially.
+  invoke_tools_async <- coro::generator(function(turn, tools, echo = "none") {
+    tool_requests <- extract_tool_requests(turn)
+
+    invoke_tool_async_wrapper <- coro::async(function(request) {
+      maybe_echo_tool(request, echo = echo)
+      result <- coro::await(invoke_tool_async(request))
+      maybe_echo_tool(result, echo = echo)
+      result
+    })
+
+    for (request in tool_requests) {
+      yield(invoke_tool_async_wrapper(request))
+    }
+  })
+})
+
+gen_async_promise_all <- function(generator) {
+  promises::promise_all(
+    .list = coro::collect(generator),
+  )
+}
 
 extract_tool_requests <- function(turn) {
   if (is.null(turn)) return(NULL)

--- a/R/content-tools.R
+++ b/R/content-tools.R
@@ -55,9 +55,7 @@ on_load({
 })
 
 gen_async_promise_all <- function(generator) {
-  promises::promise_all(
-    .list = coro::collect(generator),
-  )
+  promises::promise_all(.list = coro::collect(generator))
 }
 
 extract_tool_requests <- function(turn) {

--- a/tests/testthat/_snaps/content-tools.md
+++ b/tests/testthat/_snaps/content-tools.md
@@ -1,7 +1,7 @@
 # invoke_tools() echoes tool requests and results
 
     Code
-      . <- invoke_tools(turn, echo = "output")
+      . <- coro::collect(invoke_tools(turn, echo = "output"))
     Message
       ( ) [tool call] my_tool()
       o #> 1
@@ -20,7 +20,7 @@
 # invoke_tools_async() echoes tool requests and results
 
     Code
-      . <- sync(invoke_tools_async(turn, echo = "output"))
+      . <- sync(gen_async_promise_all(invoke_tools_async(turn, echo = "output")))
     Message
       ( ) [tool call] my_tool()
       ( ) [tool call] my_tool(x = 1)

--- a/tests/testthat/_snaps/content-tools.md
+++ b/tests/testthat/_snaps/content-tools.md
@@ -35,6 +35,22 @@
       o #> a
         #> b
         #> c
+    Code
+      . <- sync(coro::async_collect(invoke_tools_async(turn, echo = "output")))
+    Message
+      ( ) [tool call] my_tool()
+      o #> 1
+      ( ) [tool call] my_tool(x = 1)
+      # #> Error: Unused argument: x
+      ( ) [tool call] tool_list()
+      o #> {"a":1,"b":2}
+      ( ) [tool call] tool_chr()
+      o #> a
+        #> b
+        #> c
+      ( ) [tool call] tool_abort()
+      # #> Error: Unexpected input
+        #> i Please revise and try again.
 
 # tool error warnings
 

--- a/tests/testthat/test-content-tools.R
+++ b/tests/testthat/test-content-tools.R
@@ -163,15 +163,17 @@ test_that("invoke_tool_async returns a ContentToolResult", {
 test_that("invoke_tools() echoes tool requests and results", {
   turn <- fixture_turn_with_tool_requests()
 
-  expect_silent(invoke_tools(turn))
-  expect_snapshot(. <- invoke_tools(turn, echo = "output"))
+  expect_silent(coro::collect(invoke_tools(turn)))
+  expect_snapshot(. <- coro::collect(invoke_tools(turn, echo = "output")))
 })
 
 test_that("invoke_tools_async() echoes tool requests and results", {
   turn <- fixture_turn_with_tool_requests()
 
-  expect_silent(sync(invoke_tools_async(turn)))
-  expect_snapshot(. <- sync(invoke_tools_async(turn, echo = "output")))
+  expect_silent(sync(gen_async_promise_all(invoke_tools_async(turn))))
+  expect_snapshot(
+    . <- sync(gen_async_promise_all(invoke_tools_async(turn, echo = "output")))
+  )
 })
 
 test_that("invoke_tools() converts to R data structures", {

--- a/tests/testthat/test-content-tools.R
+++ b/tests/testthat/test-content-tools.R
@@ -170,10 +170,18 @@ test_that("invoke_tools() echoes tool requests and results", {
 test_that("invoke_tools_async() echoes tool requests and results", {
   turn <- fixture_turn_with_tool_requests()
 
-  expect_silent(sync(gen_async_promise_all(invoke_tools_async(turn))))
-  expect_snapshot(
+  expect_silent(sync({
+    # Concurrent tool calls
+    gen_async_promise_all(invoke_tools_async(turn))
+    # Sequential tool calls
+    coro::async_collect(invoke_tools_async(turn))
+  }))
+  expect_snapshot({
+    # Concurrent tool calls
     . <- sync(gen_async_promise_all(invoke_tools_async(turn, echo = "output")))
-  )
+    # Sequential tool calls
+    . <- sync(coro::async_collect(invoke_tools_async(turn, echo = "output")))
+  })
 })
 
 test_that("invoke_tools() converts to R data structures", {


### PR DESCRIPTION
This PR turns `invoke_tools()` and `invoke_tools_async()` into generators.

This is part of the work toward #400 and #401, as it will allow us to better control the execution flow of tool calls in `$chat_impl()` and `$chat_impl_async()`. The primary benefit is that by using generators we'll be able to yield tool requests and results as they happen rather than as a chunk before and after all tool calls are evaluated.