### PR TITLE
chore: Remove trailing whitespace from NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,11 +9,11 @@
 
 * Bumped default time out up to 5 minutes (#451, #321).
 
-* BREAKING CHANGE: Tools are now invoked with their inputs coerced to standard 
+* BREAKING CHANGE: Tools are now invoked with their inputs coerced to standard
   R data structures (#461).
 
-* `$extract_data(convert = TRUE)` now converts `NULL` to `NA` for 
-  `type_boolean()`, `type_integer()`, `type_number()`, and `type_string()` 
+* `$extract_data(convert = TRUE)` now converts `NULL` to `NA` for
+  `type_boolean()`, `type_integer()`, `type_number()`, and `type_string()`
   (#445).
 
 * `interpolate()` and friends are now vectorised so you can generate multiple
@@ -27,10 +27,10 @@
 
 * New `chat_mistral()` for models hosted at <https://mistral.ai> (#319).
 
-* `chat_gemini()` can now handle responses that include citation metadata 
+* `chat_gemini()` can now handle responses that include citation metadata
   (#358).
 
-* `chat_` functions no longer take a turns object, instead use `set_turns()` 
+* `chat_` functions no longer take a turns object, instead use `set_turns()`
   (#427).
 
 * `echo = "output"` replaces the now-deprecated `echo = "text"` option in
@@ -51,10 +51,10 @@
   definition when a request is matched to a tool by ellmer (#423, @gadenbuie).
 
 * ellmer now tracks the cost of input and output tokens. The cost is displayed
-  when you print a `Chat` object, in `tokens_usage()`, and with 
+  when you print a `Chat` object, in `tokens_usage()`, and with
   `Chat$get_cost()`. You can also request costs in `$parallel_extract_data()`.
-  
-  We do our best to accurately compute the cost, but you should treat it as an 
+
+  We do our best to accurately compute the cost, but you should treat it as an
   estimate rather than the exact price. Unfortunately LLM APIs currently make it
   very hard to figure out exactly how much your queries cost (#203).
 
@@ -63,7 +63,7 @@
 
 * Several chat functions were renamed to better align with the companies
   providing the API (#382, @gadenbuie):
-  
+
   * `chat_azure_openai()` replaces `chat_azure()`
   * `chat_aws_bedrock()` replaces `chat_bedrock()`
   * `chat_anthropic()` replaces `chat_claude()`
@@ -82,29 +82,29 @@
 * New `interpolate_package()` to make it easier to interpolate from prompts
   stored in the `inst/prompts` inside a package (#164).
 
-* `chat_azure()`, `chat_claude()`, `chat_openai()`, and `chat_gemini()` now have 
-  a `params`  argument that allows you to specify common model paramaters (like 
-  `seed` and `temperature`). Support for other models will grow as you request 
+* `chat_azure()`, `chat_claude()`, `chat_openai()`, and `chat_gemini()` now have
+  a `params`  argument that allows you to specify common model paramaters (like
+  `seed` and `temperature`). Support for other models will grow as you request
   it (#280).
 
-* `chat_claude(max_tokens =)` is now deprecated in favour of 
+* `chat_claude(max_tokens =)` is now deprecated in favour of
   `chat_claude(params = )` (#280).
 
-* `chat_openai(seed =)` is now deprecated in favour of 
+* `chat_openai(seed =)` is now deprecated in favour of
   `chat_openai(params = )` (#280).
 
 * `Chat$get_provider()` lets you access the underlying provider object, if needed (#202).
 
 * `$extract_data()` now works better for arrays when `required = FALSE` (#384).
 
-* `chat_claude()` and `chat_bedrock()` no longer choke after receiving an 
+* `chat_claude()` and `chat_bedrock()` no longer choke after receiving an
   output that consists only of whitespace (#376).
 
 * `live_browser()` now initializes `shinychat::chat_ui()` with the messages from
   the chat turns, rather than replaying the turns server-side (#381).
 
-* `Chat$tokens()` is now called `Chat$get_tokens()` and returns a data frame of 
-  tokens, correctly aligned to the individual turn. The print method now uses 
+* `Chat$tokens()` is now called `Chat$get_tokens()` and returns a data frame of
+  tokens, correctly aligned to the individual turn. The print method now uses
   this to show how many input/output tokens each turn used (#354).
 
 * All requests now set a custom User-Agent that identifies that the requests


### PR DESCRIPTION
I keep bumping my shins on trailing whitespace in the NEWS file, so I thought I'd just take care of it in a PR and plug setting `"files.trimTrailingWhitespace": true` in Positron.