### PR TITLE
feat: Adds `content = "all"` option to `$stream()` and `$stream_async()`

### DIFF
--- a/R/content-tools.R
+++ b/R/content-tools.R
@@ -143,7 +143,6 @@ invoke_tool <- function(request) {
       new_tool_result(request, result)
     },
     error = function(e) {
-      # TODO: We need to report this somehow; it's way too hidden from the user
       new_tool_result(request, error = e)
     }
   )
@@ -167,7 +166,6 @@ on_load(
         new_tool_result(request, result)
       },
       error = function(e) {
-        # TODO: We need to report this somehow; it's way too hidden from the user
         new_tool_result(request, error = e)
       }
     )

--- a/man/Chat.Rd
+++ b/man/Chat.Rd
@@ -346,13 +346,17 @@ Returns A \href{https://coro.r-lib.org/articles/generator.html#iterating}{coro g
 that yields strings. While iterating, the generator will block while
 waiting for more content from the chatbot.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Chat$stream(...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Chat$stream(..., content = c("text", "all"))}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{...}}{The input to send to the chatbot. Can be strings or images.}
+
+\item{\code{content}}{Whether the stream should yield only \code{"text"} or \code{"all"}
+content types created during the round. When \code{content = "all"},
+\code{stream()} yields \link{Content} objects.}
 }
 \if{html}{\out{</div>}}
 }
@@ -365,7 +369,11 @@ Submit input to the chatbot, returning asynchronously
 streaming results. Returns a \href{https://coro.r-lib.org/reference/async_generator.html}{coro async generator} that
 yields string promises.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Chat$stream_async(..., tool_mode = c("concurrent", "sequential"))}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Chat$stream_async(
+  ...,
+  tool_mode = c("concurrent", "sequential"),
+  content = c("text", "all")
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -378,6 +386,10 @@ yields string promises.
 best for interactive applications, especially when a tool may involve
 an interactive user interface. Concurrent mode is the default and is
 best suited for automated scripts or non-interactive applications.}
+
+\item{\code{content}}{Whether the stream should yield only \code{"text"} or \code{"all"}
+content types created during the round. When \code{content = "all"},
+\code{stream()} yields \link{Content} objects.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -459,6 +459,121 @@ test_that("$chat_async() can run tools sequentially", {
   expect_true(res[[2]]$start < res[[2]]$end)
 })
 
+test_that("$stream(content='all') yields tool request/result contents", {
+  chat <- chat_openai_test()
+  tool_current_date <- tool(function() "2024-01-01", "Return the current date")
+  chat$register_tool(tool_current_date)
+
+  res <- coro::collect(
+    chat$stream(
+      "What's the current date in Y-M-D format?",
+      content = "all"
+    )
+  )
+
+  # 1. Tool request
+  # 2. Tool result (paired with request)
+  # 3. ...rest of assistant message
+  expect_s7_class(res[[1]], ContentToolRequest)
+  expect_equal(res[[1]]@tool, tool_current_date)
+  expect_s7_class(res[[2]], ContentToolResult)
+  expect_equal(res[[2]]@value, "2024-01-01")
+  expect_equal(res[[2]]@request, res[[1]])
+
+  for (delta in res[-(1:2)]) {
+    expect_s7_class(delta, ContentText)
+  }
+})
+
+test_that("$stream_async(content='all', tool_mode='concurrent') yields tool request/result contents concurrently", {
+  chat <- chat_openai_test()
+  tool_current_date <- tool(
+    coro::async(function() {
+      coro::await(coro::async_sleep(0.1))
+      "2024-01-01"
+    }),
+    "Return the current date",
+    .name = "current_date"
+  )
+  chat$register_tool(tool_current_date)
+
+  res <- sync(
+    coro::async_collect(
+      chat$stream_async(
+        "Confirm the current data by calling `current_date` twice.",
+        "Write YES if the dates match or NO if not.",
+        content = "all",
+        tool_mode = "concurrent"
+      )
+    )
+  )
+
+  # 1. Tool request 1
+  expect_s7_class(res[[1]], ContentToolRequest)
+  expect_equal(res[[1]]@tool, tool_current_date)
+  # 2. Tool request 2
+  expect_s7_class(res[[2]], ContentToolRequest)
+  expect_equal(res[[2]]@tool, tool_current_date)
+  # 3. Tool result 1
+  expect_s7_class(res[[3]], ContentToolResult)
+  expect_equal(res[[3]]@value, "2024-01-01")
+  expect_equal(res[[3]]@request, res[[1]])
+  # 4. Tool result 2
+  expect_s7_class(res[[4]], ContentToolResult)
+  expect_equal(res[[4]]@value, "2024-01-01")
+  expect_equal(res[[4]]@request, res[[2]])
+
+  # 5. ...rest of assistant message
+  for (delta in res[-(1:4)]) {
+    expect_s7_class(delta, ContentText)
+  }
+})
+
+test_that("$stream_async(content='all', tool_mode='sequential') yields tool request/result contents sequentially", {
+  chat <- chat_openai_test()
+  tool_current_date <- tool(
+    coro::async(function() {
+      coro::await(coro::async_sleep(0.1))
+      "2024-01-01"
+    }),
+    "Return the current date",
+    .name = "current_date"
+  )
+  chat$register_tool(tool_current_date)
+
+  res <- sync(
+    coro::async_collect(
+      chat$stream_async(
+        "Confirm the current data by calling `current_date` twice.",
+        "Write YES if the dates match or NO if not.",
+        content = "all",
+        tool_mode = "sequential"
+      )
+    )
+  )
+
+  # 1. Tool request 1
+  expect_s7_class(res[[1]], ContentToolRequest)
+  expect_equal(res[[1]]@tool, tool_current_date)
+  # 2. Tool result 1
+  expect_s7_class(res[[2]], ContentToolResult)
+  expect_equal(res[[2]]@value, "2024-01-01")
+  expect_equal(res[[2]]@request, res[[1]])
+  # 3. Tool request 2
+  expect_s7_class(res[[3]], ContentToolRequest)
+  expect_equal(res[[3]]@tool, tool_current_date)
+  # 4. Tool result 2
+  expect_s7_class(res[[4]], ContentToolResult)
+  expect_equal(res[[4]]@value, "2024-01-01")
+  expect_equal(res[[4]]@request, res[[3]])
+
+  # 5. ...rest of assistant message
+  for (delta in res[-(1:4)]) {
+    expect_s7_class(delta, ContentText)
+  }
+})
+
+
 test_that("old extract methods are deprecated", {
   ChatNull <- R6::R6Class(
     "ChatNull",


### PR DESCRIPTION
Fixes #400
Closes #436 (supersedes)

Adds `content = c("text", "all")` option to `Chat$stream()` and `Chat$stream_async()`. When `content = "all"`, all content is yielded into the stream and the yielded content is always an ellmer `Content` object.

This feature currently supports yielding tool requests and results (as they happen), and in the future could support yielding streaming delta content types as well. (#436 has more context, but the approach in this PR is slightly different and builds on #493).