### PR TITLE
Drop `completed`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -148,9 +148,6 @@
 * `chat_claude()` now defaults to Sonnet 3.7 and displays the default
   model (#336).
 
-* `Turn` objects now include a POSIXct timestamp in the `completed` slot that
-  records when the turn was completed (#337, @simonpcouch).
-
 * `create_tool_def()` can now use any Chat instance (#118, @pedrobtz).
 
 * New experimental `parallel_chat()` and `parallel_chat_structured()` make it

--- a/R/chat.R
+++ b/R/chat.R
@@ -105,7 +105,7 @@ Chat <- R6::R6Class(
       }
       # Add prompt, if new
       if (is.character(value)) {
-        system_turn <- Turn("system", value, completed = NULL)
+        system_turn <- Turn("system", value)
         private$.turns <- c(list(system_turn), private$.turns)
       }
       invisible(self)

--- a/R/turns.R
+++ b/R/turns.R
@@ -26,7 +26,6 @@ NULL
 #' @param tokens A numeric vector of length 2 representing the number of
 #'   input and output tokens (respectively) used in this turn. Currently
 #'   only recorded for assistant turns.
-#' @param completed A POSIXct timestamp indicating when the turn completed.
 #' @export
 #' @return An S7 `Turn` object
 #' @examples
@@ -49,15 +48,13 @@ Turn <- new_class(
     text = new_property(
       class = class_character,
       getter = function(self) contents_text(self)
-    ),
-    completed = new_property(class = class_POSIXct | NULL)
+    )
   ),
   constructor = function(
     role,
     contents = list(),
     json = list(),
-    tokens = c(0, 0),
-    completed = Sys.time()
+    tokens = c(0, 0)
   ) {
     if (is.character(contents)) {
       contents <- list(ContentText(paste0(contents, collapse = "\n")))
@@ -67,8 +64,7 @@ Turn <- new_class(
       role = role,
       contents = contents,
       json = json,
-      tokens = tokens,
-      completed = completed
+      tokens = tokens
     )
   }
 )
@@ -160,7 +156,7 @@ normalize_turns <- function(
   }
 
   if (!is.null(system_prompt)) {
-    system_turn <- Turn("system", system_prompt, completed = NULL)
+    system_turn <- Turn("system", system_prompt)
 
     # No turns; start with just the system prompt
     if (length(turns) == 0) {

--- a/man/Turn.Rd
+++ b/man/Turn.Rd
@@ -4,13 +4,7 @@
 \alias{Turn}
 \title{A user or assistant turn}
 \usage{
-Turn(
-  role,
-  contents = list(),
-  json = list(),
-  tokens = c(0, 0),
-  completed = Sys.time()
-)
+Turn(role, contents = list(), json = list(), tokens = c(0, 0))
 }
 \arguments{
 \item{role}{Either "user", "assistant", or "system".}
@@ -26,8 +20,6 @@ doesn't otherwise expose.}
 \item{tokens}{A numeric vector of length 2 representing the number of
 input and output tokens (respectively) used in this turn. Currently
 only recorded for assistant turns.}
-
-\item{completed}{A POSIXct timestamp indicating when the turn completed.}
 }
 \value{
 An S7 \code{Turn} object

--- a/tests/testthat/test-chat-parallel.R
+++ b/tests/testthat/test-chat-parallel.R
@@ -12,25 +12,6 @@ test_that("can chat in parallel", {
   expect_equal(chats[[2]]$last_turn()@contents[[1]]@text, "4")
 })
 
-test_that("messages get timestamped correctly", {
-  chat <- chat_openai_test()
-
-  before_send <- Sys.time()
-  results <- parallel_chat(chat, list("What's 1 + 1?", "What's 2 + 2?"))
-  after_receive <- Sys.time()
-
-  turns1 <- results[[1]]$get_turns()
-  turns2 <- results[[2]]$get_turns()
-
-  expect_true(turns1[[1]]@completed >= before_send)
-  expect_true(turns1[[1]]@completed <= turns1[[2]]@completed)
-  expect_true(turns1[[2]]@completed <= after_receive)
-
-  expect_true(turns2[[1]]@completed >= before_send)
-  expect_true(turns2[[1]]@completed <= turns2[[2]]@completed)
-  expect_true(turns2[[2]]@completed <= after_receive)
-})
-
 test_that("can call tools in parallel", {
   prompts <- rep(list("Roll the dice, please! Reply with 'You rolled ____'"), 2)
 

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -40,11 +40,7 @@ test_that("can retrieve system prompt with last_turn()", {
   chat2 <- chat_openai_test(system_prompt = "You are from New Zealand")
   expect_equal(
     chat2$last_turn("system"),
-    Turn(
-      "system",
-      "You are from New Zealand",
-      completed = NULL
-    )
+    Turn("system", "You are from New Zealand")
   )
 })
 
@@ -218,36 +214,6 @@ test_that("can retrieve last_turn for user and assistant", {
   chat$chat("Hi")
   expect_equal(chat$last_turn("user")@role, "user")
   expect_equal(chat$last_turn("assistant")@role, "assistant")
-})
-
-test_that("chat messages get timestamped in sequence", {
-  chat <- chat_openai_test()
-
-  before_send <- Sys.time()
-  chat$chat("What's 1 + 1?")
-  after_receive <- Sys.time()
-  turns <- chat$get_turns()
-
-  expect_true(turns[[1]]@completed >= before_send)
-  expect_true(turns[[1]]@completed <= turns[[2]]@completed)
-
-  expect_true(turns[[2]]@completed >= turns[[1]]@completed)
-  expect_true(turns[[2]]@completed <= after_receive)
-})
-
-test_that("async chat messages get timestamped in sequence", {
-  chat <- chat_openai_test()
-
-  before_send <- Sys.time()
-  promise <- chat$chat_async("What's 1 + 1?")
-  result <- sync(promise)
-  after_receive <- Sys.time()
-
-  turns <- chat$get_turns()
-
-  expect_true(turns[[1]]@completed >= before_send)
-  expect_true(turns[[1]]@completed <= turns[[2]]@completed)
-  expect_true(turns[[2]]@completed <= after_receive)
 })
 
 test_that("chat can get and register a list of tools", {

--- a/tests/testthat/test-turns.R
+++ b/tests/testthat/test-turns.R
@@ -1,29 +1,18 @@
 test_that("system prompt is applied correctly", {
   sys_prompt <- "foo"
-  sys_msg <- Turn("system", sys_prompt, completed = NULL)
+  sys_msg <- Turn("system", sys_prompt)
   user_msg <- Turn("user", "bar")
-
-  standardise_completed <- function(turn) {
-    turn@completed <- NULL
-    turn
-  }
-
-  expect_equal_turns <- function(object, expected, ...) {
-    object <- lapply(object, standardise_completed)
-    expected <- lapply(expected, standardise_completed)
-    expect_equal(object, expected, ...)
-  }
 
   expect_equal(normalize_turns(), list())
   expect_equal(normalize_turns(list(user_msg)), list(user_msg))
   expect_equal(normalize_turns(list(sys_msg)), list(sys_msg))
 
-  expect_equal_turns(normalize_turns(list(), sys_prompt), list(sys_msg))
-  expect_equal_turns(
+  expect_equal(normalize_turns(list(), sys_prompt), list(sys_msg))
+  expect_equal(
     normalize_turns(list(user_msg), sys_prompt),
     list(sys_msg, user_msg)
   )
-  expect_equal_turns(
+  expect_equal(
     normalize_turns(list(sys_msg, user_msg), sys_prompt),
     list(sys_msg, user_msg)
   )
@@ -69,20 +58,6 @@ test_that("can extract text easily", {
     )
   )
   expect_equal(turn@text, "ABCDEF")
-})
-
-test_that("turns have completion timestamps", {
-  before <- Sys.time()
-  turn <- Turn("user", "hello")
-  after <- Sys.time()
-
-  expect_s3_class(turn@completed, "POSIXct")
-  expect_true(turn@completed >= before)
-  expect_true(turn@completed <= after)
-
-  other_time <- as.POSIXct("2023-01-01")
-  turn@completed <- other_time
-  expect_equal(turn@completed, other_time)
 })
 
 test_that("turns have a reasonable print method", {


### PR DESCRIPTION
Because we can't correctly collect for parallel chats, and I think we might actually want to capture the duration here anyway (which we can do with some help from httr2)

@gadenbuie since @simonpcouch is out this week, do you mind quickly casting your eyes over this? There's a bit more context at https://github.com/tidyverse/ellmer/issues/479#issuecomment-2881186374