### PR TITLE
feat(chat_ollama): Accept `api_key`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 # ellmer (development version)
 
-* New `chat_portkey()` and `models_portkey()` for models hosted at 
+* `chat_ollama()` now accepts `api_key` or consults the `OLLAMA_API_KEY`
+  environment variable. This is not needed for local usage, but enables
+  bearer-token authentication when Ollama is running behind a reverse proxy
+  (#501, @gadenbuie).
+
+* New `chat_portkey()` and `models_portkey()` for models hosted at
   <https://portkey.ai> (#363, @maciekbanas).
 
 * `$stream()` and `$stream_async()` gain support for streaming the additional

--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -65,7 +65,9 @@ chat_ollama <- function(
     model = model,
     seed = seed,
     extra_args = api_args,
-    api_key = api_key %||% ollama_key()
+    # ollama doesn't require an API key for local usage, but one might be needed
+    # if ollama is served behind a proxy (see #501)
+    api_key = api_key %||% Sys.getenv("OLLAMA_API_KEY", "ollama")
   )
 
   Chat$new(provider = provider, system_prompt = system_prompt, echo = echo)
@@ -80,15 +82,6 @@ ProviderOllama <- new_class(
     seed = prop_number_whole(allow_null = TRUE)
   )
 )
-
-ollama_key <- function() {
-  # ollama doesn't require an API key for local usage, but one might be needed
-  # if ollama is served behind a proxy (see #501)
-  tryCatch(
-    key_get("OLLAMA_API_KEY"),
-    error = function(err) "ollama"
-  )
-}
 
 chat_ollama_test <- function(..., model = "llama3.2:1b") {
   # model: Note that tests require a model with tool capabilities

--- a/man/chat_ollama.Rd
+++ b/man/chat_ollama.Rd
@@ -11,7 +11,8 @@ chat_ollama(
   model,
   seed = NULL,
   api_args = list(),
-  echo = NULL
+  echo = NULL,
+  api_key = NULL
 )
 
 models_ollama(base_url = "http://localhost:11434")
@@ -40,6 +41,13 @@ the console).
 }
 
 Note this only affects the \code{chat()} method.}
+
+\item{api_key}{Ollama doesn't require an API key for local usage and in most
+cases you do not need to provide an \code{api_key}.
+
+However, if you're accessing an Ollama instance hosted behind a reverse
+proxy or secured endpoint that enforces bearer‐token authentication, you
+can set \code{api_key} (or the \code{OLLAMA_API_KEY} environment variable).}
 }
 \value{
 A \link{Chat} object.


### PR DESCRIPTION
Fixes #501

This isn't needed for `ollama` running locally, but allows for access to Ollama when served behind a reverse proxy. I used `OLLAMA_API_KEY` for consistency with other environment variables, but we still default to a placeholder key of `"ollama"`.