### PR TITLE
fix(chat_ollama): Fix error message with installed model names

### DIFF
--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -55,6 +55,16 @@ chat_ollama <- function(
       "Must specify {.arg model}.",
       i = "Locally installed models: {.str {models}}."
     ))
+  } else if (!inherits(model, "AsIs")) {
+    if (!model %in% models_ollama(base_url)$id) {
+      cli::cli_abort(
+        c(
+          "Model {.val {model}} is not installed locally.",
+          i = "Run {.code ollama pull {model}} in your terminal or {.run ollamar::pull(\"{model}\")} in R to install the model.",
+          i = "See locally installed models with {.run ellmer::models_ollama()}."
+        )
+      )
+    }
   }
 
   echo <- check_echo(echo)

--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -50,7 +50,7 @@ chat_ollama <- function(
   }
 
   if (missing(model)) {
-    models <- models_ollama(base_url)$name
+    models <- models_ollama(base_url)$id
     cli::cli_abort(c(
       "Must specify {.arg model}.",
       i = "Locally installed models: {.str {models}}."

--- a/tests/testthat/_snaps/provider-ollama.md
+++ b/tests/testthat/_snaps/provider-ollama.md
@@ -1,3 +1,12 @@
+# includes list of models in error message if `model` is missing
+
+    Code
+      chat_ollama()
+    Condition
+      Error in `chat_ollama()`:
+      ! Must specify `model`.
+      i Locally installed models: "llama3.2:1b".
+
 # as_json specialised for Ollama
 
     Code

--- a/tests/testthat/_snaps/provider-ollama.md
+++ b/tests/testthat/_snaps/provider-ollama.md
@@ -7,6 +7,16 @@
       ! Must specify `model`.
       i Locally installed models: "llama3.2:1b".
 
+# checks that requested model is installed
+
+    Code
+      chat_ollama(model = "not-a-real-model")
+    Condition
+      Error in `chat_ollama()`:
+      ! Model "not-a-real-model" is not installed locally.
+      i Run `ollama pull not-a-real-model` in your terminal or `ollamar::pull("not-a-real-model")` in R to install the model.
+      i See locally installed models with `ellmer::models_ollama()`.
+
 # as_json specialised for Ollama
 
     Code

--- a/tests/testthat/test-provider-ollama.R
+++ b/tests/testthat/test-provider-ollama.R
@@ -18,6 +18,23 @@ test_that("can list models", {
   test_models(models_ollama)
 })
 
+test_that("includes list of models in error message if `model` is missing", {
+  skip_if_no_ollama()
+  # Get test model, skip if not available
+  chat <- chat_ollama_test()
+  test_model <- chat$get_model()
+
+  installed_models <- models_ollama()
+
+  local_mocked_bindings(
+    models_ollama = function(...) {
+      installed_models[installed_models$id == test_model, ]
+    }
+  )
+
+  expect_snapshot(chat_ollama(), error = TRUE)
+})
+
 # Common provider interface -----------------------------------------------
 
 test_that("can chat with tool request", {

--- a/tests/testthat/test-provider-ollama.R
+++ b/tests/testthat/test-provider-ollama.R
@@ -35,6 +35,19 @@ test_that("includes list of models in error message if `model` is missing", {
   expect_snapshot(chat_ollama(), error = TRUE)
 })
 
+test_that("checks that requested model is installed", {
+  local_mocked_bindings(
+    models_ollama = function(...) list(id = "llama3")
+  )
+  expect_snapshot(
+    chat_ollama(model = "not-a-real-model"),
+    error = TRUE
+  )
+  expect_silent(
+    chat_ollama(model = I("not-a-real-model"))
+  )
+})
+
 # Common provider interface -----------------------------------------------
 
 test_that("can chat with tool request", {


### PR DESCRIPTION
This PR fixes a small issue caused by `models_ollama()` having an `id` column instead of a `name` column.

While here, I thought it might be helpful to also validate the model name when provided

```r
chat_ollama(model = "not-a-real-model")
#> Error in `chat_ollama()`:
#> ! Model "not-a-real-model" is not installed locally.
#> ℹ Run `ollama pull not-a-real-model` in your terminal or ollamar::pull("not-a-real-model") in R to install the model.
#> ℹ See locally installed models with ellmer::models_ollama().
```

Previously, you'd get an error message when you try to use the API

```r
chat_ollama(model = "foo")$chat("bah")
#> Error in `req_perform_connection()` at ellmer/R/httr2.R:37:5:
#> ! HTTP 404 Not Found.
#> • model "foo" not found, try pulling it first
```

In case you want to create a Chat object without talking to the ollama API, the valid model checks is skipped for `model = I("model-name")`.

If you prefer the current behavior, we can revert eddece0660af2501516fad5e353ada0b782b35a6