### PR TITLE
Avoid passing a schemaless host to the Databricks CLI

### DIFF
--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -255,11 +255,11 @@ default_databricks_credentials <- function(workspace = databricks_workspace()) {
   # When on desktop, try using the Databricks CLI for auth.
   cli_path <- Sys.getenv("DATABRICKS_CLI_PATH", "databricks")
   if (!is_hosted_session() && nchar(Sys.which(cli_path)) != 0) {
-    token <- databricks_cli_token(cli_path, host)
+    token <- databricks_cli_token(cli_path, workspace)
     if (!is.null(token)) {
       return(function() {
         # Ensure we get an up-to-date token.
-        token <- databricks_cli_token(cli_path, host)
+        token <- databricks_cli_token(cli_path, workspace)
         list(Authorization = paste("Bearer", token))
       })
     }

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -65,7 +65,12 @@ test_that("Databricks CLI tokens are detected correctly", {
     DATABRICKS_CLIENT_ID = NA,
     DATABRICKS_CLIENT_SECRET = NA
   )
-  local_mocked_bindings(databricks_cli_token = function(path, host) "cli_token")
+  local_mocked_bindings(
+    databricks_cli_token = function(path, host) {
+      stopifnot(startsWith(host, "https://"))
+      "cli_token"
+    }
+  )
 
   credentials <- default_databricks_credentials()
   expect_equal(credentials(), list(Authorization = "Bearer cli_token"))


### PR DESCRIPTION
Previously we were passing the host without the schema. I think this probably worked at some point in the past, but it does not work with modern versions of the Databricks CLI:

    $ databricks auth token --host example.cloud.databricks.com
    Error: host must start with 'https://': example.cloud.databricks.com

This commit ensures we pass the complete workspace URL. Unit tests have been updated to verify this as well.