### PR TITLE
Switch to chat_google_gemin() in example

### DIFF
--- a/R/provider-gemini-upload.R
+++ b/R/provider-gemini-upload.R
@@ -24,7 +24,7 @@
 #' \dontrun{
 #' file <- google_upload("path/to/file.pdf")
 #'
-#' chat <- chat_openai()
+#' chat <- chat_google_gemini()
 #' chat$chat(file, "Give me a three paragraph summary of this PDF")
 #' }
 google_upload <- function(

--- a/man/ellmer-package.Rd
+++ b/man/ellmer-package.Rd
@@ -26,6 +26,7 @@ Authors:
 \itemize{
   \item Joe Cheng
   \item Aaron Jacobs
+  \item Garrick Aden-Buie \email{garrick@posit.co} (\href{https://orcid.org/0000-0002-7111-0077}{ORCID})
 }
 
 Other contributors:

--- a/man/google_upload.Rd
+++ b/man/google_upload.Rd
@@ -47,7 +47,7 @@ be useful for you.
 \dontrun{
 file <- google_upload("path/to/file.pdf")
 
-chat <- chat_openai()
+chat <- chat_google_gemini()
 chat$chat(file, "Give me a three paragraph summary of this PDF")
 }
 }


### PR DESCRIPTION
The upload to Google Gemini example is followed by connecting to the OpenAI provider, which seems incorrect. Switching to connect to Google Gemini via the associated chat constructor.