### PR TITLE
Fix partial matching issue when streaming from chat_snowflake()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 * `chat_databricks()` now picks up on Databricks workspace URLs set in the
   configuration file, which should improve compatibility with the Databricks CLI
   (#521, @atheriel).
+* `chat_snowflake()` no longer streams answers that include a mysterious
+  `list(type = "text", text = "")` trailer (#533, @atheriel).
 
 # ellmer 0.2.0
 

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -214,7 +214,7 @@ method(stream_text, ProviderOpenAI) <- function(provider, event) {
   if (length(event$choices) == 0) {
     NULL
   } else {
-    event$choices[[1]]$delta$content
+    event$choices[[1]]$delta[["content"]]
   }
 }
 method(stream_merge_chunks, ProviderOpenAI) <- function(


### PR DESCRIPTION
Partial matching strikes again!

Snowflake's "OpenAI-compatible" API always seems to return a final delta with no content. The JSON looks something like the following:

    {
      "type": "text",
      "content_list": [
        {
          "type": "text",
          "text": ""
        }
      ],
      "text": ""
    }

Unfortunately this `content_list` is partially matched by `content`, making us accidentally emit it when `content` is missing.

Closes #533.