### PR TITLE
Enable non-streaming responses from chat_snowflake()

### DIFF
--- a/R/provider-snowflake.R
+++ b/R/provider-snowflake.R
@@ -114,9 +114,6 @@ method(chat_body, ProviderSnowflakeCortex) <- function(
   if (!is.null(type) != 0) {
     cli::cli_abort("Structured data extraction is not supported.", call = call)
   }
-  if (!stream) {
-    cli::cli_abort("Non-streaming responses are not supported.", call = call)
-  }
 
   messages <- as_json(provider, turns)
   list(

--- a/tests/testthat/test-provider-snowflake.R
+++ b/tests/testthat/test-provider-snowflake.R
@@ -1,12 +1,10 @@
 # Getting started --------------------------------------------------------
 
 test_that("can make simple request", {
-  # Snowflake models don't support non-streaming responses.
-  #
-  # chat <- chat_snowflake("Be as terse as possible; no punctuation")
-  # resp <- chat$chat("What is 1 + 1?", echo = FALSE)
-  # expect_match(resp, "2")
-  # expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  chat <- chat_snowflake("Be as terse as possible; no punctuation")
+  resp <- chat$chat("What is 1 + 1?", echo = FALSE)
+  expect_match(resp, "2")
+  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {


### PR DESCRIPTION
In my testing looks like Snowflake now supports non-streaming responses compatible with OpenAI, so I've removed the error and re-enabled the corresponding test.