### PR TITLE
Fix delta parsing for chat_snowflake()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
   `list(type = "text", text = "")` trailer (#533, @atheriel).
 * `chat_snowflake()` now defaults to Claude Sonnet 3.7, the same default as
   `chat_anthropic()` (#539, @atheriel).
+* `chat_snowflake()` now parses streaming outputs correctly into turns (#542,
+  @atheriel).
 
 # ellmer 0.2.0
 

--- a/tests/testthat/test-provider-snowflake.R
+++ b/tests/testthat/test-provider-snowflake.R
@@ -170,3 +170,60 @@ test_that("tokens can be requested from a Connect server", {
     )
   )
 })
+
+test_that("we can merge Snowflake's chunk format", {
+  chunk1 <- list(
+    id = "id",
+    model = "claude-3-5-sonnet",
+    choices = list(list(
+      delta = list(
+        type = "text",
+        content = "I",
+        content_list = list(list(type = "text", text = "I")),
+        text = "I"
+      )
+    )),
+    usage = structure(list(), names = character(0))
+  )
+  chunk2 <- list(
+    id = "id",
+    model = "claude-3-5-sonnet",
+    choices = list(list(
+      delta = list(
+        type = "text",
+        content = " aim to be direct and honest: I don't actually",
+        content_list = list(list(
+          type = "text",
+          text = " aim to be direct and honest: I don't actually"
+        )),
+        text = " aim to be direct and honest: I don't actually"
+      )
+    )),
+    usage = structure(list(), names = character(0))
+  )
+  expect_equal(
+    merge_snowflake_dicts(chunk1, chunk2),
+    list(
+      id = "id",
+      model = "claude-3-5-sonnet",
+      choices = list(list(
+        delta = list(
+          type = "text",
+          content = "I aim to be direct and honest: I don't actually",
+          content_list = list(
+            list(
+              type = "text",
+              text = "I"
+            ),
+            list(
+              type = "text",
+              text = " aim to be direct and honest: I don't actually"
+            )
+          ),
+          text = "I aim to be direct and honest: I don't actually"
+        )
+      )),
+      usage = structure(list(), names = character(0))
+    )
+  )
+})


### PR DESCRIPTION
Snowflake is doing something slightly different here again, so I added a specialization of the generic for that provider.

Unit tests are included, and I also added one for parsing OpenAI's format for future reference.

Closes #542.