### PR TITLE
Add support for structured outputs with chat_snowflake()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
   `chat_anthropic()` (#539, @atheriel).
 * `chat_snowflake()` now parses streaming outputs correctly into turns (#542,
   @atheriel).
+* `chat_snowflake()` now supports structured ouputs (#544, @atheriel).
 
 # ellmer 0.2.0
 

--- a/man/chat_snowflake.Rd
+++ b/man/chat_snowflake.Rd
@@ -65,8 +65,7 @@ package.
 
 \subsection{Known limitations}{
 
-Note that Snowflake-hosted models do not support images, tool calling, or
-structured outputs.
+Note that Snowflake-hosted models do not support images or tool calling.
 
 See \code{\link[=chat_cortex_analyst]{chat_cortex_analyst()}} to chat with the Snowflake Cortex Analyst rather
 than a general-purpose model.

--- a/tests/testthat/test-provider-snowflake.R
+++ b/tests/testthat/test-provider-snowflake.R
@@ -36,9 +36,7 @@ test_that("all tool variations work", {
 })
 
 test_that("can extract data", {
-  # Snowflake models don't support structured data.
-  #
-  # test_data_extraction(chat_snowflake)
+  test_data_extraction(chat_snowflake)
 })
 
 test_that("can use images", {


### PR DESCRIPTION
More updates to Snowflake's API have enabled us to support structured outputs. I've also re-enabled the associated unit test.