### PR TITLE
Fix tool calling for chat_databricks()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
   @atheriel).
 * `chat_snowflake()` now supports structured ouputs and standard model
   parameters (#544 and #545, @atheriel).
+* `chat_databricks()` now works with tool calling (#548, @atheriel).
 
 # ellmer 0.2.0
 

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -254,7 +254,10 @@ method(value_turn, ProviderOpenAI) <- function(
     calls <- lapply(message$tool_calls, function(call) {
       name <- call$`function`$name
       # TODO: record parsing error
-      args <- jsonlite::parse_json(call$`function`$arguments)
+      args <- tryCatch(
+        jsonlite::parse_json(call$`function`$arguments),
+        error = function(cnd) list()
+      )
       ContentToolRequest(name = name, arguments = args, id = call$id)
     })
     content <- c(content, calls)

--- a/man/chat_databricks.Rd
+++ b/man/chat_databricks.Rd
@@ -73,8 +73,7 @@ package.
 \subsection{Known limitations}{
 
 Databricks models do not support images, but they do support structured
-outputs. Tool calling support is also very limited at present and is
-currently not supported by ellmer.
+outputs and tool calls for most models.
 }
 }
 \examples{

--- a/tests/testthat/_snaps/provider-databricks.md
+++ b/tests/testthat/_snaps/provider-databricks.md
@@ -5,6 +5,15 @@
     Message
       Using model = "databricks-claude-3-7-sonnet".
 
+# all tool variations work
+
+    Code
+      chat$chat("Great. Do it again.")
+    Condition
+      Error:
+      ! Can't use async tools with `$chat()` or `$stream()`.
+      i Async tools are supported, but you must use `$chat_async()` or `$stream_async()`.
+
 # M2M authentication requests look correct
 
     Code

--- a/tests/testthat/helper-provider.R
+++ b/tests/testthat/helper-provider.R
@@ -66,7 +66,7 @@ test_tools_async <- function(chat_fun) {
   )
 }
 
-test_tools_parallel <- function(chat_fun) {
+test_tools_parallel <- function(chat_fun, total_calls = 4) {
   chat <- chat_fun(system_prompt = "Be very terse, not even punctuation.")
   favourite_color <- function(person) {
     if (person == "Joe") "sage green" else "red"
@@ -85,7 +85,7 @@ test_tools_parallel <- function(chat_fun) {
   )
   expect_match(result, "Joe: sage green")
   expect_match(result, "Hadley: red")
-  expect_length(chat$get_turns(), 4)
+  expect_length(chat$get_turns(), total_calls)
 }
 
 test_tools_sequential <- function(chat_fun, total_calls) {


### PR DESCRIPTION
This commit fixes up the tool definitions we send to Databricks so that they actually work.

Also: despite their documentation, multi-step tool calling *does* seem to work now. So this is a significant upgrade in terms of possibilities with this provider.

Unit tests for tool calling have been re-enabled and there are some new ones to ensure we get the format right.

Closes #548.