### PR TITLE
Redact API keys when saving to disk

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ellmer (development version)
 
+* When you save a `Chat` object to disk, API keys are automatically redacted. This means that you can no longer easily resume a chat you've saved on disk (we'll figure this out in a future release) but ensures that you never accidentally save your secret key in an RDS file (#534).
 * `chat_anthropic()` now defaults to Claude Sonnet 4. 
 * Add pricing information for latest generation of Claude models.
 * You can now use pre-existing JSON schemas in structured chats using `type_from_schema()` (#133, @hafen)

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -80,7 +80,7 @@ ProviderAnthropic <- new_class(
   "ProviderAnthropic",
   parent = Provider,
   properties = list(
-    api_key = prop_string(),
+    prop_redacted("api_key"),
     beta_headers = class_character
   )
 )

--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -86,7 +86,7 @@ ProviderOllama <- new_class(
   "ProviderOllama",
   parent = ProviderOpenAI,
   properties = list(
-    api_key = prop_string(),
+    prop_redacted("api_key"),
     model = prop_string(),
     seed = prop_number_whole(allow_null = TRUE)
   )

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -74,7 +74,6 @@ chat_openai <- function(
   )
   Chat$new(provider = provider, system_prompt = system_prompt, echo = echo)
 }
-
 chat_openai_test <- function(
   system_prompt = "Be terse.",
   ...,
@@ -97,7 +96,7 @@ ProviderOpenAI <- new_class(
   "ProviderOpenAI",
   parent = Provider,
   properties = list(
-    api_key = prop_string(),
+    prop_redacted("api_key"),
     # no longer used by OpenAI itself; but subclasses still need it
     seed = prop_number_whole(allow_null = TRUE)
   )

--- a/R/utils-S7.R
+++ b/R/utils-S7.R
@@ -119,3 +119,26 @@ prop_number_whole <- function(
     }
   )
 }
+
+prop_redacted <- function(name, default = NULL, allow_null = FALSE) {
+  force(allow_null)
+  key <- new_environment()
+
+  new_property(
+    name = name,
+    default = if (is.null(default) && !allow_null) {
+      quote(stop("Required"))
+    } else {
+      default
+    },
+    getter = function(self) {
+      wref_value(prop(self, name))
+    },
+    setter = function(self, value) {
+      check_string(value, allow_null = allow_null)
+
+      prop(self, name) <- new_weakref(key, value)
+      self
+    }
+  )
+}

--- a/tests/testthat/test-utils-S7.R
+++ b/tests/testthat/test-utils-S7.R
@@ -14,3 +14,19 @@ test_that("prop_whole_number validates inputs", {
     check_prop(max = -1)(0)
   })
 })
+
+test_that("redacted values aren't saved to disk", {
+  Test <- new_class("Test", properties = list(prop_redacted("redacted")))
+
+  # Can get and set redacted values
+  test <- Test(redacted = "secret")
+  expect_equal(test@redacted, "secret")
+  test@redacted <- "new secret"
+  expect_equal(test@redacted, "new secret")
+
+  # But can't save it to disk
+  path <- withr::local_tempfile()
+  saveRDS(test, path)
+  test <- readRDS(path)
+  expect_equal(test@redacted, NULL)
+})


### PR DESCRIPTION
Using the magic of weak refs. Fixes #534