### PR TITLE
Add support for tool calling with chat_snowflake().

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * `chat_snowflake()` now supports structured ouputs and standard model
   parameters (#544 and #545, @atheriel).
 * `chat_databricks()` now works with tool calling (#548, @atheriel).
+* `chat_snowflake()` now works with tool calling (#557, @atheriel).
 
 # ellmer 0.2.0
 

--- a/man/chat_snowflake.Rd
+++ b/man/chat_snowflake.Rd
@@ -68,7 +68,7 @@ package.
 
 \subsection{Known limitations}{
 
-Note that Snowflake-hosted models do not support images or tool calling.
+Note that Snowflake-hosted models do not support images.
 
 See \code{\link[=chat_cortex_analyst]{chat_cortex_analyst()}} to chat with the Snowflake Cortex Analyst rather
 than a general-purpose model.

--- a/tests/testthat/_snaps/provider-snowflake.md
+++ b/tests/testthat/_snaps/provider-snowflake.md
@@ -5,3 +5,12 @@
     Message
       Using model = "claude-3-7-sonnet".
 
+# all tool variations work
+
+    Code
+      chat$chat("Great. Do it again.")
+    Condition
+      Error:
+      ! Can't use async tools with `$chat()` or `$stream()`.
+      i Async tools are supported, but you must use `$chat_async()` or `$stream_async()`.
+

--- a/tests/testthat/test-provider-snowflake.R
+++ b/tests/testthat/test-provider-snowflake.R
@@ -27,12 +27,10 @@ test_that("defaults are reported", {
 })
 
 test_that("all tool variations work", {
-  # Snowflake models don't support tool calling.
-  #
-  # test_tools_simple(chat_snowflake)
-  # test_tools_async(chat_snowflake)
-  # test_tools_parallel(chat_snowflake)
-  # test_tools_sequential(chat_snowflake, total_calls = 6)
+  test_tools_simple(chat_snowflake)
+  test_tools_async(chat_snowflake)
+  test_tools_parallel(chat_snowflake, total_calls = 6)
+  test_tools_sequential(chat_snowflake, total_calls = 6)
 })
 
 test_that("can extract data", {


### PR DESCRIPTION
This commit wires up all of the machinery to support tool calling against the Snowflake LLM API, which is pretty new and rife with documentation errors and omissions...

Unit tests have been re-enabled for this feature.