### PR TITLE
Fix a `chat_snowflake()`/`chat_databricks()` mixup in the 0.2.1 NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,12 +12,12 @@
 
 * `chat_databricks()` now picks up on Databricks workspace URLs set in the
   configuration file, which should improve compatibility with the Databricks CLI
-  (#521, @atheriel).
+  (#521, @atheriel). It now also supports tool calling (#548, @atheriel).
 
 * `chat_snowflake()` no longer streams answers that include a mysterious
   `list(type = "text", text = "")` trailer (#533, @atheriel). It now parses 
   streaming outputs correctly into turns (#542), supports structured ouputs
-  (#544), tool calling (#548), and standard model parameters (#545, @atheriel).
+  (#544), and standard model parameters (#545, @atheriel).
 
 * `chat_snowflake()` and `chat_databricks()` now default to Claude Sonnet 3.7,
   the same default as `chat_anthropic()` (#539 and #546, @atheriel).


### PR DESCRIPTION
Tool calling support landed for `chat_databricks()`, not `chat_snowflake()`.