### PR TITLE
Use a Vertex-specific API scope in chat_google_vertex()

### DIFF
--- a/R/provider-gemini.R
+++ b/R/provider-gemini.R
@@ -567,10 +567,12 @@ default_google_credentials <- function(
   error_call = caller_env(),
   gemini = FALSE
 ) {
+if (gemini) {
   gemini_scope <- "https://www.googleapis.com/auth/generative-language.retriever"
-  if (!gemini) {
-    gemini_scope <- "https://www.googleapis.com/auth/cloud-vertex-ai.firstparty.predict"
-  }
+} else {
+  gemini_scope <- "https://www.googleapis.com/auth/cloud-vertex-ai.firstparty.predict"
+}
+
 
   check_string(api_key, allow_null = TRUE, call = error_call)
   api_key <- api_key %||% Sys.getenv("GOOGLE_API_KEY")


### PR DESCRIPTION
This is an attempt to resolve #523. Google's API in that case seems to be indicating that a different scope is required to access Vertex AI compared to Gemini:

    Error in `req_perform_connection()`:
    ! HTTP 403 Forbidden.
    * OAuth error: insufficient_scope
    * realm: https://accounts.google.com/
    * scope: https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/cloud-platform.read-only https://www.googleapis.com/auth/cloud-vertex-ai.firstparty.predict
    * Request had insufficient authentication scopes.

Of the options listed in that error message
`https://www.googleapis.com/auth/cloud-vertex-ai.firstparty.predict` is the least privileged scope, so that's the one I've opted for.