### PR TITLE
chore: Require curl >= 6.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     S7 (>= 0.2.0)
 Suggests:
     connectcreds,
-    curl (>= 6.0.1),
+    curl (>= 6.2.0),
     gargle,
     gitcreds,
     knitr,


### PR DESCRIPTION
Fixes #580 

`parallel_chat_structured()` requires curl >= v6.2.0 for `new_pool(max_streams=)`.