### PR TITLE
Remove unneeded Portkey properties

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # ellmer (development version)
 
+* `chat_portkey()` works once again, and now will read the virtual API key 
+  from the `PORTKEY_VIRTUAL_KEY` env var (#588).
 * `models_github()` lists models for `chat_github()` (#561).
-
 * `chat_snowflake()` now works with tool calling (#557, @atheriel).
 
 # ellmer 0.2.1

--- a/R/provider-portkey.R
+++ b/R/provider-portkey.R
@@ -14,6 +14,7 @@
 #' @param model `r param_model("gpt-4o", "openai")`
 #' @param virtual_key A virtual identifier storing LLM provider's API key. See
 #'   [documentation](https://portkey.ai/docs/product/ai-gateway/virtual-keys).
+#'   Can be read from the `PORTKEY_VIRTUAL_KEY` environment variable.
 #' @export
 #' @inheritParams chat_openai
 #' @inherit chat_openai return
@@ -25,8 +26,8 @@
 chat_portkey <- function(
   system_prompt = NULL,
   base_url = "https://api.portkey.ai/v1",
-  api_key = portkeyai_key(),
-  virtual_key = NULL,
+  api_key = portkey_key(),
+  virtual_key = portkey_virtual_key(),
   model = NULL,
   params = NULL,
   api_args = list(),
@@ -64,20 +65,22 @@ ProviderPortkeyAI <- new_class(
   "ProviderPortkeyAI",
   parent = ProviderOpenAI,
   properties = list(
-    api_key = prop_string(allow_null = TRUE),
-    virtual_key = prop_string(allow_null = TRUE),
-    credentials = class_function | NULL,
-    model = prop_string()
+    virtual_key = prop_string(allow_null = TRUE)
   )
 )
 
-portkeyai_key_exists <- function() {
+portkey_key_exists <- function() {
   key_exists("PORTKEY_API_KEY")
 }
 
-portkeyai_key <- function() {
+portkey_key <- function() {
   key_get("PORTKEY_API_KEY")
 }
+
+portkey_virtual_key <- function() {
+  key_get("PORTKEY_VIRTUAL_KEY")
+}
+
 
 method(base_request, ProviderPortkeyAI) <- function(provider) {
   req <- request(provider@base_url)
@@ -98,7 +101,7 @@ method(base_request, ProviderPortkeyAI) <- function(provider) {
 #' @rdname chat_portkey
 models_portkey <- function(
   base_url = "https://api.portkey.ai/v1",
-  api_key = portkeyai_key(),
+  api_key = portkey_key(),
   virtual_key = NULL
 ) {
   provider <- ProviderPortkeyAI(

--- a/man/chat_portkey.Rd
+++ b/man/chat_portkey.Rd
@@ -8,8 +8,8 @@
 chat_portkey(
   system_prompt = NULL,
   base_url = "https://api.portkey.ai/v1",
-  api_key = portkeyai_key(),
-  virtual_key = NULL,
+  api_key = portkey_key(),
+  virtual_key = portkey_virtual_key(),
   model = NULL,
   params = NULL,
   api_args = list(),
@@ -18,7 +18,7 @@ chat_portkey(
 
 models_portkey(
   base_url = "https://api.portkey.ai/v1",
-  api_key = portkeyai_key(),
+  api_key = portkey_key(),
   virtual_key = NULL
 )
 }
@@ -34,7 +34,8 @@ The best place to set this is in \code{.Renviron},
 which you can easily edit by calling \code{usethis::edit_r_environ()}.}
 
 \item{virtual_key}{A virtual identifier storing LLM provider's API key. See
-\href{https://portkey.ai/docs/product/ai-gateway/virtual-keys}{documentation}.}
+\href{https://portkey.ai/docs/product/ai-gateway/virtual-keys}{documentation}.
+Can be read from the \code{PORTKEY_VIRTUAL_KEY} environment variable.}
 
 \item{model}{The model to use for the chat (defaults to "gpt-4o").
 We regularly update the default, so we strongly recommend explicitly specifying a model for anything other than casual use.

--- a/tests/testthat/_snaps/provider-portkey.md
+++ b/tests/testthat/_snaps/provider-portkey.md
@@ -2,3 +2,6 @@
 
     Code
       . <- chat_portkey()
+    Message
+      Using model = "gpt-4o".
+


### PR DESCRIPTION
And make it easier to test by looking at `PORTKEY_VIRTUAL_KEY` envvar.

Fixes #588