### PR TITLE
feat(models_ollama): Include model capabilities

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,14 +4,14 @@
 * `chat_huggingface()` now works much better.
 * [BREAKING CHANGE] `type_array()` and `type_enum()` now have the description as the second argument and `items/`/`values` as the first. This makes them easier to use in the common case where the description isn't necessary (#610).
 * By default, ellmer now retries requests up to 3 times, controllable with `option(ellmer_max_tries)` and will retry if the connection fails (rather than just if the request itself returns a transient error).
-* The default timeout, controlled by `option(ellmer_timeout_s)`, now applies to the initial connection phase.
+* The default timeout, controlled by `option(ellmer_timeout_s)`, now applies to the initial connection phase. 
 * [BREAKING CHANGE] `tool()` has a simpler specification: you now specify the `name`, `description`, and `arguments`. I have done my best to deprecate old usage and give clear errors, but I have likely missed a few edge cases. I apologise for the pain this causes, but I'm convinced that it is going to making tool usage easier and clearer. If you have many calls to convert, `?tool` contains a prompt that will help you use an LLM to convert them. (#603).
 * `tool()` now returns a function so you can call it (and/or export it from your package) (#602).
 * `chat_google_gemini()` and `chat_google_vertex()` now default to Gemini 2.5 flash (#576).
 * `batch_chat_structured()` now longer gives a confusing message if prompts/path/provider don't match (#599).
 * `chat_github()` (and other OpenAI extensions), no longer warn about `seed` (#574).
 * New `ellmer_echo` option controls default value for `echo`.
-* `chat_portkey()` works once again, and now will read the virtual API key
+* `chat_portkey()` works once again, and now will read the virtual API key 
   from the `PORTKEY_VIRTUAL_KEY` env var (#588).
 * `models_github()` lists models for `chat_github()` (#561).
 * `chat_snowflake()` now works with tool calling (#557, @atheriel).
@@ -20,12 +20,12 @@
 
 # ellmer 0.2.1
 
-* When you save a `Chat` object to disk, API keys are automatically redacted.
-  This means that you can no longer easily resume a chat you've saved on disk
-  (we'll figure this out in a future release) but ensures that you never
+* When you save a `Chat` object to disk, API keys are automatically redacted. 
+  This means that you can no longer easily resume a chat you've saved on disk 
+  (we'll figure this out in a future release) but ensures that you never 
   accidentally save your secret key in an RDS file (#534).
 
-* `chat_anthropic()` now defaults to Claude Sonnet 4, and I've added pricing
+* `chat_anthropic()` now defaults to Claude Sonnet 4, and I've added pricing 
   information for the latest generation of Claude models.
 
 * `chat_databricks()` now picks up on Databricks workspace URLs set in the
@@ -33,14 +33,14 @@
   (#521, @atheriel). It now also supports tool calling (#548, @atheriel).
 
 * `chat_snowflake()` no longer streams answers that include a mysterious
-  `list(type = "text", text = "")` trailer (#533, @atheriel). It now parses
+  `list(type = "text", text = "")` trailer (#533, @atheriel). It now parses 
   streaming outputs correctly into turns (#542), supports structured ouputs
   (#544), and standard model parameters (#545, @atheriel).
 
 * `chat_snowflake()` and `chat_databricks()` now default to Claude Sonnet 3.7,
   the same default as `chat_anthropic()` (#539 and #546, @atheriel).
 
-* `type_from_schema()` lets you to use pre-existing JSON schemas in structured
+* `type_from_schema()` lets you to use pre-existing JSON schemas in structured 
   chats (#133, @hafen)
 
 # ellmer 0.2.0
@@ -49,36 +49,36 @@
 
 * We have made a number of refinements to the way ellmer converts JSON
   to R data structures. These are breaking changes, although we don't expect
-  them to affect much code in the wild. Most importantly, tools are now invoked
+  them to affect much code in the wild. Most importantly, tools are now invoked 
   with their inputs coerced to standard R data structures (#461); opt-out
   by setting `convert = FALSE` in `tool()`.
 
-  Additionally ellmer now converts `NULL` to `NA` for `type_boolean()`,
-  `type_integer()`, `type_number()`, and `type_string()` (#445), and does a
+  Additionally ellmer now converts `NULL` to `NA` for `type_boolean()`, 
+  `type_integer()`, `type_number()`, and `type_string()` (#445), and does a 
   better job with arrays when `required = FALSE` (#384).
 
 * `chat_` functions no longer have a `turn` argument. If you need to set the
-  turns, you can now use `Chat$set_turns()` (#427). Additionally,
-  `Chat$tokens()` has been renamed to `Chat$get_tokens()` and returns a data
-  frame of tokens, correctly aligned to the individual turn. The print method
-  now uses this to show how many input/output tokens were used by each turn
+  turns, you can now use `Chat$set_turns()` (#427). Additionally, 
+  `Chat$tokens()` has been renamed to `Chat$get_tokens()` and returns a data 
+  frame of tokens, correctly aligned to the individual turn. The print method 
+  now uses this to show how many input/output tokens were used by each turn 
   (#354).
 
 ## New features
 
 * Two new interfaces help you do multiple chats with a single function call:
 
-  * `batch_chat()` and `batch_chat_structured()` allow you to submit multiple
-    chats to OpenAI and Anthropic's batched interfaces. These only guarantee a
-    response within 24 hours, but are 50% of the price of regular requests
+  * `batch_chat()` and `batch_chat_structured()` allow you to submit multiple 
+    chats to OpenAI and Anthropic's batched interfaces. These only guarantee a 
+    response within 24 hours, but are 50% of the price of regular requests 
     (#143).
 
   * `parallel_chat()` and `parallel_chat_structured()` work with any provider
     and allow you to submit multiple chats in parallel (#143). This doesn't give
     you any cost savings, but it's can be much, much faster.
 
-  This new family of functions is experimental because I'm not 100% sure that
-  the shape of the user interface is correct, particularly as it pertains to
+  This new family of functions is experimental because I'm not 100% sure that 
+  the shape of the user interface is correct, particularly as it pertains to 
   handling errors.
 
 * `google_upload()` lets you upload files to Google Gemini or Vertex AI (#310).
@@ -94,14 +94,14 @@
 
 * `interpolate()` and friends are now vectorised so you can generate multiple
   prompts for (e.g.) a data frame of inputs. They also now return a specially
-  classed object with a custom print method (#445). New `interpolate_package()`
-  makes it easier to interpolate from prompts stored in the `inst/prompts`
+  classed object with a custom print method (#445). New `interpolate_package()` 
+  makes it easier to interpolate from prompts stored in the `inst/prompts` 
   directory inside a package (#164).
 
-* `chat_anthropic()`, `chat_azure()`, `chat_openai()`, and `chat_gemini()` now
-  take a `params` argument, that coupled with the `params()` helper, makes it
-  easy to specify common model parameters (like `seed` and `temperature`)
-  across providers. Support for other providers will grow as you request it
+* `chat_anthropic()`, `chat_azure()`, `chat_openai()`, and `chat_gemini()` now 
+  take a `params` argument, that coupled with the `params()` helper, makes it 
+  easy to specify common model parameters (like `seed` and `temperature`) 
+  across providers. Support for other providers will grow as you request it 
   (#280).
 
 * ellmer now tracks the cost of input and output tokens. The cost is displayed
@@ -121,7 +121,7 @@
   * `chat_portkey()` and `models_portkey()` for models hosted at
     <https://portkey.ai> (#363, @maciekbanas).
 
-* We also renamed (with deprecation) a few functions to make the naming
+* We also renamed (with deprecation) a few functions to make the naming 
   scheme more consistent (#382, @gadenbuie):
 
   * `chat_azure_openai()` replaces `chat_azure()`.
@@ -135,17 +135,17 @@
 
 ## Developer tooling
 
-* New `Chat$get_provider()` lets you access the underlying provider object
+* New `Chat$get_provider()` lets you access the underlying provider object 
   (#202).
 
-* `Chat$chat_async()` and `Chat$stream_async()` gain a `tool_mode` argument to
-  decide between `"sequential"` and `"concurrent"` tool calling. This is an
+* `Chat$chat_async()` and `Chat$stream_async()` gain a `tool_mode` argument to 
+  decide between `"sequential"` and `"concurrent"` tool calling. This is an 
   advanced feature that primarily affects asynchronous tools (#488, @gadenbuie).
 
-* `Chat$stream()` and `Chat$stream_async()` gain support for streaming the
-  additional content types generated during a tool call with a new `stream`
-  argument. When `stream = "content"` is set, the streaming response yields
-  `Content` objects, including the `ContentToolRequest` and `ContentToolResult`
+* `Chat$stream()` and `Chat$stream_async()` gain support for streaming the 
+  additional content types generated during a tool call with a new `stream` 
+  argument. When `stream = "content"` is set, the streaming response yields 
+  `Content` objects, including the `ContentToolRequest` and `ContentToolResult` 
   objects used to request and return tool calls (#400, @gadenbuie).
 
 * New `Chat$on_tool_request()` and `$on_tool_result()` methods allow you to
@@ -153,7 +153,7 @@
   can be used to implement custom logging or other actions when tools are
   called, without modifying the tool function (#493, @gadenbuie).
 
-* `Chat$chat(echo = "output")` replaces the now-deprecated `echo = "text"`
+* `Chat$chat(echo = "output")` replaces the now-deprecated `echo = "text"` 
   option. When using `echo = "output"`, additional output, such as tool
   requests and results, are shown as they occur. When `echo = "none"`, tool
   call failures are emitted as warnings (#366, @gadenbuie).
@@ -167,7 +167,7 @@
     `ContentToolResult` no longer has an `id` property, instead the tool call
     ID can be retrieved from `request@id`.
 
-  They also include the error condition in the `error` property when a tool call
+  They also include the error condition in the `error` property when a tool call 
   fails (#421, @gadenbuie).
 
 * `ContentToolRequest` gains a `tool` property that includes the `tool()`
@@ -187,31 +187,31 @@
 ## Minor improvements and bug fixes
 
 * All requests now set a custom User-Agent that identifies that the requests
-  come from ellmer (#341). The default timeout has been increased to
+  come from ellmer (#341). The default timeout has been increased to 
   5 minutes (#451, #321).
 
-* `chat_anthropic()` now supports the thinking content type (#396), and
-  `content_image_url()` (#347). It gains a `beta_header` argument to opt-in
-  to beta features (#339). It (along with `chat_bedrock()`) no longer chokes
+* `chat_anthropic()` now supports the thinking content type (#396), and 
+  `content_image_url()` (#347). It gains a `beta_header` argument to opt-in 
+  to beta features (#339). It (along with `chat_bedrock()`) no longer chokes 
   after receiving an output that consists only of whitespace (#376).
   Finally, `chat_anthropic(max_tokens =)` is now deprecated in favour of
   `chat_anthropic(params = )` (#280).
 
-* `chat_google_gemini()` and `chat_google_vertex()` gain more ways to
-  authenticate. They can use `GEMINI_API_KEY` if set (@t-kalinowski, #513),
-  authenticate with Google default application credentials (including service
-  accounts, etc) (#317, @atheriel) and use viewer-based credentials when
-  running on Posit Connect (#320, @atheriel). Authentication with default
-  application credentials requires the {gargle} package. They now also can now
+* `chat_google_gemini()` and `chat_google_vertex()` gain more ways to 
+  authenticate. They can use `GEMINI_API_KEY` if set (@t-kalinowski, #513), 
+  authenticate with Google default application credentials (including service 
+  accounts, etc) (#317, @atheriel) and use viewer-based credentials when 
+  running on Posit Connect (#320, @atheriel). Authentication with default 
+  application credentials requires the {gargle} package. They now also can now 
   handle responses that include citation metadata (#358).
 
-* `chat_ollama()` now works with `tool()` definitions with optional arguments
-  or empty properties (#342, #348, @gadenbuie), and now accepts `api_key` and
-  consults the `OLLAMA_API_KEY` environment variable. This is not needed for
-  local usage, but enables bearer-token authentication when Ollama is running
+* `chat_ollama()` now works with `tool()` definitions with optional arguments 
+  or empty properties (#342, #348, @gadenbuie), and now accepts `api_key` and 
+  consults the `OLLAMA_API_KEY` environment variable. This is not needed for 
+  local usage, but enables bearer-token authentication when Ollama is running 
   behind a reverse proxy (#501, @gadenbuie).
 
-* `chat_openai(seed =)` is now deprecated in favour of `chat_openai(params = )`
+* `chat_openai(seed =)` is now deprecated in favour of `chat_openai(params = )` 
   (#280).
 
 * `create_tool_def()` can now use any Chat instance (#118, @pedrobtz).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,15 +1,16 @@
 # ellmer (development version)
 
+* `models_ollama()` now includes a `capabilities` column with a comma-separated list of model capabilities (#623).
 * [BREAKING CHANGE] `type_array()` and `type_enum()` now have the description as the second argument and `items/`/`values` as the first. This makes them easier to use in the common case where the description isn't necessary (#610).
 * By default, ellmer now retries requests up to 3 times, controllable with `option(ellmer_max_tries)` and will retry if the connection fails (rather than just if the request itself returns a transient error).
-* The default timeout, controlled by `option(ellmer_timeout_s)`, now applies to the initial connection phase. 
+* The default timeout, controlled by `option(ellmer_timeout_s)`, now applies to the initial connection phase.
 * [BREAKING CHANGE] `tool()` has a simpler specification: you now specify the `name`, `description`, and `arguments`. I have done my best to deprecate old usage and give clear errors, but I have likely missed a few edge cases. I apologise for the pain this causes, but I'm convinced that it is going to making tool usage easier and clearer. If you have many calls to convert, `?tool` contains a prompt that will help you use an LLM to convert them. (#603).
 * `tool()` now returns a function so you can call it (and/or export it from your package) (#602).
 * `chat_google_gemini()` and `chat_google_vertex()` now default to Gemini 2.5 flash (#576).
 * `batch_chat_structured()` now longer gives a confusing message if prompts/path/provider don't match (#599).
 * `chat_github()` (and other OpenAI extensions), no longer warn about `seed` (#574).
 * New `ellmer_echo` option controls default value for `echo`.
-* `chat_portkey()` works once again, and now will read the virtual API key 
+* `chat_portkey()` works once again, and now will read the virtual API key
   from the `PORTKEY_VIRTUAL_KEY` env var (#588).
 * `models_github()` lists models for `chat_github()` (#561).
 * `chat_snowflake()` now works with tool calling (#557, @atheriel).
@@ -18,12 +19,12 @@
 
 # ellmer 0.2.1
 
-* When you save a `Chat` object to disk, API keys are automatically redacted. 
-  This means that you can no longer easily resume a chat you've saved on disk 
-  (we'll figure this out in a future release) but ensures that you never 
+* When you save a `Chat` object to disk, API keys are automatically redacted.
+  This means that you can no longer easily resume a chat you've saved on disk
+  (we'll figure this out in a future release) but ensures that you never
   accidentally save your secret key in an RDS file (#534).
 
-* `chat_anthropic()` now defaults to Claude Sonnet 4, and I've added pricing 
+* `chat_anthropic()` now defaults to Claude Sonnet 4, and I've added pricing
   information for the latest generation of Claude models.
 
 * `chat_databricks()` now picks up on Databricks workspace URLs set in the
@@ -31,14 +32,14 @@
   (#521, @atheriel). It now also supports tool calling (#548, @atheriel).
 
 * `chat_snowflake()` no longer streams answers that include a mysterious
-  `list(type = "text", text = "")` trailer (#533, @atheriel). It now parses 
+  `list(type = "text", text = "")` trailer (#533, @atheriel). It now parses
   streaming outputs correctly into turns (#542), supports structured ouputs
   (#544), and standard model parameters (#545, @atheriel).
 
 * `chat_snowflake()` and `chat_databricks()` now default to Claude Sonnet 3.7,
   the same default as `chat_anthropic()` (#539 and #546, @atheriel).
 
-* `type_from_schema()` lets you to use pre-existing JSON schemas in structured 
+* `type_from_schema()` lets you to use pre-existing JSON schemas in structured
   chats (#133, @hafen)
 
 # ellmer 0.2.0
@@ -47,36 +48,36 @@
 
 * We have made a number of refinements to the way ellmer converts JSON
   to R data structures. These are breaking changes, although we don't expect
-  them to affect much code in the wild. Most importantly, tools are now invoked 
+  them to affect much code in the wild. Most importantly, tools are now invoked
   with their inputs coerced to standard R data structures (#461); opt-out
   by setting `convert = FALSE` in `tool()`.
 
-  Additionally ellmer now converts `NULL` to `NA` for `type_boolean()`, 
-  `type_integer()`, `type_number()`, and `type_string()` (#445), and does a 
+  Additionally ellmer now converts `NULL` to `NA` for `type_boolean()`,
+  `type_integer()`, `type_number()`, and `type_string()` (#445), and does a
   better job with arrays when `required = FALSE` (#384).
 
 * `chat_` functions no longer have a `turn` argument. If you need to set the
-  turns, you can now use `Chat$set_turns()` (#427). Additionally, 
-  `Chat$tokens()` has been renamed to `Chat$get_tokens()` and returns a data 
-  frame of tokens, correctly aligned to the individual turn. The print method 
-  now uses this to show how many input/output tokens were used by each turn 
+  turns, you can now use `Chat$set_turns()` (#427). Additionally,
+  `Chat$tokens()` has been renamed to `Chat$get_tokens()` and returns a data
+  frame of tokens, correctly aligned to the individual turn. The print method
+  now uses this to show how many input/output tokens were used by each turn
   (#354).
 
 ## New features
 
 * Two new interfaces help you do multiple chats with a single function call:
 
-  * `batch_chat()` and `batch_chat_structured()` allow you to submit multiple 
-    chats to OpenAI and Anthropic's batched interfaces. These only guarantee a 
-    response within 24 hours, but are 50% of the price of regular requests 
+  * `batch_chat()` and `batch_chat_structured()` allow you to submit multiple
+    chats to OpenAI and Anthropic's batched interfaces. These only guarantee a
+    response within 24 hours, but are 50% of the price of regular requests
     (#143).
 
   * `parallel_chat()` and `parallel_chat_structured()` work with any provider
     and allow you to submit multiple chats in parallel (#143). This doesn't give
     you any cost savings, but it's can be much, much faster.
 
-  This new family of functions is experimental because I'm not 100% sure that 
-  the shape of the user interface is correct, particularly as it pertains to 
+  This new family of functions is experimental because I'm not 100% sure that
+  the shape of the user interface is correct, particularly as it pertains to
   handling errors.
 
 * `google_upload()` lets you upload files to Google Gemini or Vertex AI (#310).
@@ -92,14 +93,14 @@
 
 * `interpolate()` and friends are now vectorised so you can generate multiple
   prompts for (e.g.) a data frame of inputs. They also now return a specially
-  classed object with a custom print method (#445). New `interpolate_package()` 
-  makes it easier to interpolate from prompts stored in the `inst/prompts` 
+  classed object with a custom print method (#445). New `interpolate_package()`
+  makes it easier to interpolate from prompts stored in the `inst/prompts`
   directory inside a package (#164).
 
-* `chat_anthropic()`, `chat_azure()`, `chat_openai()`, and `chat_gemini()` now 
-  take a `params` argument, that coupled with the `params()` helper, makes it 
-  easy to specify common model parameters (like `seed` and `temperature`) 
-  across providers. Support for other providers will grow as you request it 
+* `chat_anthropic()`, `chat_azure()`, `chat_openai()`, and `chat_gemini()` now
+  take a `params` argument, that coupled with the `params()` helper, makes it
+  easy to specify common model parameters (like `seed` and `temperature`)
+  across providers. Support for other providers will grow as you request it
   (#280).
 
 * ellmer now tracks the cost of input and output tokens. The cost is displayed
@@ -119,7 +120,7 @@
   * `chat_portkey()` and `models_portkey()` for models hosted at
     <https://portkey.ai> (#363, @maciekbanas).
 
-* We also renamed (with deprecation) a few functions to make the naming 
+* We also renamed (with deprecation) a few functions to make the naming
   scheme more consistent (#382, @gadenbuie):
 
   * `chat_azure_openai()` replaces `chat_azure()`.
@@ -133,17 +134,17 @@
 
 ## Developer tooling
 
-* New `Chat$get_provider()` lets you access the underlying provider object 
+* New `Chat$get_provider()` lets you access the underlying provider object
   (#202).
 
-* `Chat$chat_async()` and `Chat$stream_async()` gain a `tool_mode` argument to 
-  decide between `"sequential"` and `"concurrent"` tool calling. This is an 
+* `Chat$chat_async()` and `Chat$stream_async()` gain a `tool_mode` argument to
+  decide between `"sequential"` and `"concurrent"` tool calling. This is an
   advanced feature that primarily affects asynchronous tools (#488, @gadenbuie).
 
-* `Chat$stream()` and `Chat$stream_async()` gain support for streaming the 
-  additional content types generated during a tool call with a new `stream` 
-  argument. When `stream = "content"` is set, the streaming response yields 
-  `Content` objects, including the `ContentToolRequest` and `ContentToolResult` 
+* `Chat$stream()` and `Chat$stream_async()` gain support for streaming the
+  additional content types generated during a tool call with a new `stream`
+  argument. When `stream = "content"` is set, the streaming response yields
+  `Content` objects, including the `ContentToolRequest` and `ContentToolResult`
   objects used to request and return tool calls (#400, @gadenbuie).
 
 * New `Chat$on_tool_request()` and `$on_tool_result()` methods allow you to
@@ -151,7 +152,7 @@
   can be used to implement custom logging or other actions when tools are
   called, without modifying the tool function (#493, @gadenbuie).
 
-* `Chat$chat(echo = "output")` replaces the now-deprecated `echo = "text"` 
+* `Chat$chat(echo = "output")` replaces the now-deprecated `echo = "text"`
   option. When using `echo = "output"`, additional output, such as tool
   requests and results, are shown as they occur. When `echo = "none"`, tool
   call failures are emitted as warnings (#366, @gadenbuie).
@@ -165,7 +166,7 @@
     `ContentToolResult` no longer has an `id` property, instead the tool call
     ID can be retrieved from `request@id`.
 
-  They also include the error condition in the `error` property when a tool call 
+  They also include the error condition in the `error` property when a tool call
   fails (#421, @gadenbuie).
 
 * `ContentToolRequest` gains a `tool` property that includes the `tool()`
@@ -185,31 +186,31 @@
 ## Minor improvements and bug fixes
 
 * All requests now set a custom User-Agent that identifies that the requests
-  come from ellmer (#341). The default timeout has been increased to 
+  come from ellmer (#341). The default timeout has been increased to
   5 minutes (#451, #321).
 
-* `chat_anthropic()` now supports the thinking content type (#396), and 
-  `content_image_url()` (#347). It gains a `beta_header` argument to opt-in 
-  to beta features (#339). It (along with `chat_bedrock()`) no longer chokes 
+* `chat_anthropic()` now supports the thinking content type (#396), and
+  `content_image_url()` (#347). It gains a `beta_header` argument to opt-in
+  to beta features (#339). It (along with `chat_bedrock()`) no longer chokes
   after receiving an output that consists only of whitespace (#376).
   Finally, `chat_anthropic(max_tokens =)` is now deprecated in favour of
   `chat_anthropic(params = )` (#280).
 
-* `chat_google_gemini()` and `chat_google_vertex()` gain more ways to 
-  authenticate. They can use `GEMINI_API_KEY` if set (@t-kalinowski, #513), 
-  authenticate with Google default application credentials (including service 
-  accounts, etc) (#317, @atheriel) and use viewer-based credentials when 
-  running on Posit Connect (#320, @atheriel). Authentication with default 
-  application credentials requires the {gargle} package. They now also can now 
+* `chat_google_gemini()` and `chat_google_vertex()` gain more ways to
+  authenticate. They can use `GEMINI_API_KEY` if set (@t-kalinowski, #513),
+  authenticate with Google default application credentials (including service
+  accounts, etc) (#317, @atheriel) and use viewer-based credentials when
+  running on Posit Connect (#320, @atheriel). Authentication with default
+  application credentials requires the {gargle} package. They now also can now
   handle responses that include citation metadata (#358).
 
-* `chat_ollama()` now works with `tool()` definitions with optional arguments 
-  or empty properties (#342, #348, @gadenbuie), and now accepts `api_key` and 
-  consults the `OLLAMA_API_KEY` environment variable. This is not needed for 
-  local usage, but enables bearer-token authentication when Ollama is running 
+* `chat_ollama()` now works with `tool()` definitions with optional arguments
+  or empty properties (#342, #348, @gadenbuie), and now accepts `api_key` and
+  consults the `OLLAMA_API_KEY` environment variable. This is not needed for
+  local usage, but enables bearer-token authentication when Ollama is running
   behind a reverse proxy (#501, @gadenbuie).
 
-* `chat_openai(seed =)` is now deprecated in favour of `chat_openai(params = )` 
+* `chat_openai(seed =)` is now deprecated in favour of `chat_openai(params = )`
   (#280).
 
 * `create_tool_def()` can now use any Chat instance (#118, @pedrobtz).

--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -133,14 +133,14 @@ models_ollama <- function(base_url = "http://localhost:11434") {
   df[order(-xtfrm(df$created_at)), ]
 }
 
-.ollama_model_details <- new_environment()
+the$ollama_cache <- new_environment()
 
 ollama_model_details <- function(model) {
   # https://github.com/ollama/ollama/blob/main/docs/api.md#show-model-information
   url <- "http://localhost:11434/api/show"
 
-  if (model %in% names(.ollama_model_details)) {
-    return(.ollama_model_details[[model]])
+  if (env_has(the$ollama_cache, model)) {
+    return(the$ollama_cache[[model]])
   }
 
   req <- request(url)
@@ -151,7 +151,7 @@ ollama_model_details <- function(model) {
   details <- resp_body_json(resp)
 
   # Cache model information (very unlikely to change during a session)
-  assign(model, details, envir = .ollama_model_details)
+  the$ollama_cache[[model]] <- details
   details
 }
 


### PR DESCRIPTION
I'm on a plane and didn't have WiFi, which reminded me that one bit of friction with local models via Ollama is that I can never remember which models have tool calling capabilities.

It turns out that you can query a model's details via [the `/api/show` endpoint](https://github.com/ollama/ollama/blob/main/docs/api.md#show-model-information). I thought this would be useful information to have, so I used this to add a `capabilities` column to `models_ollama()`. Having to query one-at-a-time slows down the call to `models_ollama()` at about 10ms per model (on my Macbook Air M3), but we can cache model details to avoid paying for the model details more than once.

```r
models_ollama() |> dplyr::as_tibble()
#> # A tibble: 10 × 4
#>    id                              created_at                size capabilities             
#>    <chr>                           <dttm>                   <dbl> <chr>                    
#>  1 qwen3:14b                       2025-07-05 00:00:00 9276198565 completion,tools,thinking
#>  2 phi4-mini                       2025-07-05 00:00:00 2491876774 completion,tools         
#>  3 granite3.3:8b                   2025-07-03 00:00:00 4942891653 completion,tools         
#>  4 gemma3:4b                       2025-07-03 00:00:00 3338801804 completion,vision        
#>  5 qwen3:4b                        2025-05-12 00:00:00 2620788019 completion,tools         
#>  6 qwen2.5-coder:14b-instruct-q2_K 2025-03-02 00:00:00 5770511454 completion,tools,insert  
#>  7 deepseek-r1:14b                 2025-01-30 00:00:00 8988112040 completion               
#>  8 nomic-embed-text                2024-10-14 00:00:00  274302450 embedding                
#>  9 llama3.1:8b                     2024-10-08 00:00:00 4661230766 completion,tools         
#> 10 llama3.2                        2024-10-01 00:00:00 2019393189 completion,tools 
```