### PR TITLE
Capture cached input token counts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # ellmer (development version)
 
-* `chat_openai()`, `chat_google_gemini()`, and `chat_anthropic()` now capture the number of cached input tokens. This is primarily useful for OpenAI and Gemini since both offer implicit caching (activated automatically) yielding improved cost estimates (#466).
+* `chat_openai()`, `chat_google_gemini()`, and `chat_anthropic()` now capture the number of cached input tokens. This is primarily useful for OpenAI and Gemini since both offer automatic caching yielding improved cost estimates (#466).
 * `chat_aws_bedrock()`, `chat_google_gemini()`, `chat_ollama()`, and `chat_vllm()` now use a more robust method for generate model URLs from the `base_url` (#593, @benyake).
 * `Chat$chat_structured()` no longer requires a prompt (since it may be obvious from the context) (#570).
 * `models_ollama()` now includes a `capabilities` column with a comma-separated list of model capabilities (#623).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ellmer (development version)
 
+* `chat_openai()`, `chat_google_gemini()`, and `chat_anthropic()` now capture the number of cached input tokens. This is primarily useful for OpenAI and Gemini since both offer implicit caching (activated automatically) yielding improved cost estimates (#466).
 * `models_ollama()` now includes a `capabilities` column with a comma-separated list of model capabilities (#623).
 * `chat_huggingface()` now works much better.
 * [BREAKING CHANGE] `type_array()` and `type_enum()` now have the description as the second argument and `items/`/`values` as the first. This makes them easier to use in the common case where the description isn't necessary (#610).

--- a/R/chat-parallel.R
+++ b/R/chat-parallel.R
@@ -176,11 +176,12 @@ multi_convert <- function(
   }
 
   if (is.data.frame(out) && (include_tokens || include_cost)) {
-    tokens <- t(vapply(turns, \(turn) turn@tokens, integer(2)))
+    tokens <- t(vapply(turns, \(turn) turn@tokens, integer(3)))
 
     if (include_tokens) {
       out$input_tokens <- tokens[, 1]
       out$output_tokens <- tokens[, 2]
+      out$cached_input_tokens <- tokens[, 3]
     }
 
     if (include_cost) {
@@ -188,7 +189,8 @@ multi_convert <- function(
         provider@name,
         standardise_model(provider, provider@model),
         input = tokens[, 1],
-        output = tokens[, 2]
+        output = tokens[, 2],
+        cached_input = tokens[, 3]
       )
     }
   }

--- a/R/chat.R
+++ b/R/chat.R
@@ -129,8 +129,9 @@ Chat <- R6::R6Class(
         function(turn) turn@tokens,
         double(3)
       ))
-      # Combine both types of input tokens (cached and uncached)
+      # Combine counts for input tokens (cached and uncached)
       tokens_acc[, 1] <- tokens_acc[, 1] + tokens_acc[, 3]
+      # Then drop cached tokens counts
       tokens_acc <- tokens_acc[, 1:2]
 
       tokens <- tokens_acc
@@ -139,7 +140,6 @@ Chat <- R6::R6Class(
         tokens[-1, 1] <- tokens[seq(2, n), 1] -
           (tokens[seq(1, n - 1), 1] + tokens[seq(1, n - 1), 2])
       }
-      # TODO: add in cached inputs tokens
 
       # collapse into a single vector
       tokens_v <- c(t(tokens))

--- a/R/chat.R
+++ b/R/chat.R
@@ -127,8 +127,11 @@ Chat <- R6::R6Class(
       tokens_acc <- t(vapply(
         assistant_turns,
         function(turn) turn@tokens,
-        double(2)
+        double(3)
       ))
+      # Combine both types of input tokens (cached and uncached)
+      tokens_acc[, 1] <- tokens_acc[, 1] + tokens_acc[, 3]
+      tokens_acc <- tokens_acc[, 1:2]
 
       tokens <- tokens_acc
       if (n > 1) {
@@ -136,6 +139,8 @@ Chat <- R6::R6Class(
         tokens[-1, 1] <- tokens[seq(2, n), 1] -
           (tokens[seq(1, n - 1), 1] + tokens[seq(1, n - 1), 2])
       }
+      # TODO: add in cached inputs tokens
+
       # collapse into a single vector
       tokens_v <- c(t(tokens))
       tokens_acc_v <- c(t(tokens_acc))
@@ -170,14 +175,18 @@ Chat <- R6::R6Class(
       tokens <- t(vapply(
         assistant_turns,
         function(turn) turn@tokens,
-        double(2)
+        double(3)
       ))
 
       if (include == "last") {
         tokens <- tokens[nrow(tokens), , drop = FALSE]
       }
 
-      private$compute_cost(input = sum(tokens[, 1]), output = sum(tokens[, 2]))
+      private$compute_cost(
+        input = sum(tokens[, 1]),
+        output = sum(tokens[, 2]),
+        cached_input = sum(tokens[, 3])
+      )
     },
 
     #' @description The last turn returned by the assistant.
@@ -792,12 +801,13 @@ Chat <- R6::R6Class(
       length(private$.turns) > 0 && private$.turns[[1]]@role == "system"
     },
 
-    compute_cost = function(input, output) {
+    compute_cost = function(input, output, cached_input) {
       get_token_cost(
         private$provider@name,
         standardise_model(private$provider, private$provider@model),
         input = input,
-        output = output
+        output = output,
+        cached_input = cached_input
       )
     }
   )

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -291,7 +291,8 @@ method(value_turn, ProviderAnthropic) <- function(
   tokens <- tokens_log(
     provider,
     input = result$usage$input_tokens,
-    output = result$usage$output_tokens
+    output = result$usage$output_tokens,
+    cached_input = result$usage$cache_read_input_tokens
   )
 
   assistant_turn(contents, json = result, tokens = tokens)

--- a/R/provider-gemini.R
+++ b/R/provider-gemini.R
@@ -284,8 +284,9 @@ method(value_turn, ProviderGoogleGemini) <- function(
   usage <- result$usageMetadata
   tokens <- tokens_log(
     provider,
-    input = usage$promptTokenCount,
-    output = usage$candidatesTokenCount
+    input = usage$promptTokenCount - (usage$cachedContentTokenCount %||% 0),
+    output = usage$candidatesTokenCount,
+    cached_input = usage$cachedContentTokenCount
   )
 
   assistant_turn(contents, json = result, tokens = tokens)

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -264,10 +264,13 @@ method(value_turn, ProviderOpenAI) <- function(
     })
     content <- c(content, calls)
   }
+
+  cached_tokens <- result$usage$prompt_tokens_details$cached_tokens %||% 0
   tokens <- tokens_log(
     provider,
-    input = result$usage$prompt_tokens,
-    output = result$usage$completion_tokens
+    input = result$usage$prompt_tokens - cached_tokens,
+    output = result$usage$completion_tokens,
+    cached_input = cached_tokens
   )
   assistant_turn(
     content,

--- a/R/turns.R
+++ b/R/turns.R
@@ -38,10 +38,10 @@ Turn <- new_class(
     json = class_list,
     tokens = new_property(
       class_numeric,
-      default = c(NA_real_, NA_real_),
+      default = c(NA_real_, NA_real_, NA_real_),
       validator = function(value) {
-        if (length(value) != 2) {
-          "must be length two"
+        if (length(value) != 3) {
+          "must be length three"
         }
       }
     ),
@@ -54,7 +54,7 @@ Turn <- new_class(
     role,
     contents = list(),
     json = list(),
-    tokens = c(0, 0)
+    tokens = c(0, 0, 0)
   ) {
     if (is.character(contents)) {
       contents <- list(ContentText(paste0(contents, collapse = "\n")))

--- a/man/Turn.Rd
+++ b/man/Turn.Rd
@@ -4,7 +4,7 @@
 \alias{Turn}
 \title{A user or assistant turn}
 \usage{
-Turn(role, contents = list(), json = list(), tokens = c(0, 0))
+Turn(role, contents = list(), json = list(), tokens = c(0, 0, 0))
 }
 \arguments{
 \item{role}{Either "user", "assistant", or "system".}

--- a/tests/testthat/_snaps/tokens.md
+++ b/tests/testthat/_snaps/tokens.md
@@ -10,14 +10,14 @@
     Code
       token_usage()
     Output
-            provider model input output price
-      1 testprovider  test    10     60    NA
+            provider model input output cached_input price
+      1 testprovider  test    10     60          100    NA
 
 # token_usage() shows price if available
 
     Code
       token_usage()
     Output
-            provider model    input output price
-      1 testprovider  test 12300000 678000 $1.24
+            provider model    input output cached_input price
+      1 testprovider  test 12300000 678000            0 $1.24
 

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -179,7 +179,7 @@ test_that("has a basic print method", {
   chat <- chat_openai_test()
   chat$set_turns(list(
     Turn("user", "What's 1 + 1?\nWhat's 1 + 2?"),
-    Turn("assistant", "2\n\n3", tokens = c(15, 5))
+    Turn("assistant", "2\n\n3", tokens = c(10, 5, 5))
   ))
   expect_snapshot(chat)
 })
@@ -188,9 +188,9 @@ test_that("print method shows cumulative tokens & cost", {
   chat <- chat_openai_test(model = "gpt-4o", system_prompt = NULL)
   chat$set_turns(list(
     Turn("user", "Input 1"),
-    Turn("assistant", "Output 1", tokens = c(15000, 500)),
+    Turn("assistant", "Output 1", tokens = c(15000, 500, 0)),
     Turn("user", "Input 2"),
-    Turn("assistant", "Output 1", tokens = c(30000, 1000))
+    Turn("assistant", "Output 1", tokens = c(30000, 1000, 0))
   ))
   expect_snapshot(chat)
 

--- a/tests/testthat/test-provider-azure.R
+++ b/tests/testthat/test-provider-azure.R
@@ -4,7 +4,7 @@ test_that("can make simple request", {
   chat <- chat_azure_openai_test("Be as terse as possible; no punctuation")
   resp <- chat$chat("What is 1 + 1?", echo = FALSE)
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-bedrock.R
+++ b/tests/testthat/test-provider-bedrock.R
@@ -2,7 +2,7 @@ test_that("can make simple batch request", {
   chat <- chat_aws_bedrock("Be as terse as possible; no punctuation")
   resp <- chat$chat("What is 1 + 1?", echo = FALSE)
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-claude.R
+++ b/tests/testthat/test-provider-claude.R
@@ -4,7 +4,7 @@ test_that("can make simple batch request", {
   chat <- chat_anthropic_test("Be as terse as possible; no punctuation")
   resp <- chat$chat("What is 1 + 1?")
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-cloudflare.R
+++ b/tests/testthat/test-provider-cloudflare.R
@@ -4,7 +4,7 @@ test_that("can make simple request", {
   chat <- chat_cloudflare_test("Be as terse as possible; no punctuation")
   resp <- chat$chat("What is 1 + 1?", echo = FALSE)
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -4,7 +4,7 @@ test_that("can make simple batch request", {
   )
   resp <- chat$chat("What is 1 + 1?", echo = FALSE)
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-deepseek.R
+++ b/tests/testthat/test-provider-deepseek.R
@@ -4,7 +4,7 @@ test_that("can make simple request", {
   chat <- chat_deepseek("Be as terse as possible; no punctuation")
   resp <- chat$chat("What is 1 + 1?", echo = FALSE)
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-gemini.R
+++ b/tests/testthat/test-provider-gemini.R
@@ -4,7 +4,7 @@ test_that("can make simple request", {
   chat <- chat_google_gemini_test("Be as terse as possible; no punctuation")
   resp <- chat$chat("What is 1 + 1?")
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-huggingface.R
+++ b/tests/testthat/test-provider-huggingface.R
@@ -2,7 +2,7 @@ test_that("can make simple request", {
   chat <- chat_huggingface_test()
   resp <- chat$chat("What is 1 + 1?", echo = FALSE)
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-mistral.R
+++ b/tests/testthat/test-provider-mistral.R
@@ -4,7 +4,7 @@ test_that("can make simple request", {
   chat <- chat_mistral_test("Be as terse as possible; no punctuation")
   resp <- chat$chat("What is 1 + 1?", echo = FALSE)
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-ollama.R
+++ b/tests/testthat/test-provider-ollama.R
@@ -4,7 +4,7 @@ test_that("can make simple request", {
   chat <- chat_ollama_test("Be as terse as possible; no punctuation")
   resp <- chat$chat("What is 1 + 1?", echo = FALSE)
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-openai.R
+++ b/tests/testthat/test-provider-openai.R
@@ -4,7 +4,7 @@ test_that("can make simple request", {
   chat <- chat_openai_test()
   resp <- chat$chat("What is 1 + 1?", echo = FALSE)
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-openrouter.R
+++ b/tests/testthat/test-provider-openrouter.R
@@ -4,7 +4,7 @@ test_that("can make simple request", {
   chat <- chat_openrouter_test("Be as terse as possible; no punctuation")
   resp <- chat$chat("What is 1 + 1?", echo = FALSE)
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-portkey.R
+++ b/tests/testthat/test-provider-portkey.R
@@ -7,7 +7,7 @@ test_that("can make simple request", {
   )
   resp <- chat$chat("What is 1 + 1?", echo = FALSE)
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-provider-snowflake.R
+++ b/tests/testthat/test-provider-snowflake.R
@@ -4,14 +4,14 @@ test_that("can make simple request", {
   chat <- chat_snowflake("Be as terse as possible; no punctuation")
   resp <- chat$chat("What is 1 + 1?", echo = FALSE)
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {
   chat <- chat_snowflake("Be as terse as possible; no punctuation")
   resp <- coro::collect(chat$stream("What is 1 + 1?"))
   expect_match(paste0(unlist(resp), collapse = ""), "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 # Common provider interface -----------------------------------------------

--- a/tests/testthat/test-provider-vllm.R
+++ b/tests/testthat/test-provider-vllm.R
@@ -4,7 +4,7 @@ test_that("can make simple request", {
   chat <- chat_vllm_test("Be as terse as possible; no punctuation")
   resp <- chat$chat("What is 1 + 1?", echo = FALSE)
   expect_match(resp, "2")
-  expect_equal(chat$last_turn()@tokens > 0, c(TRUE, TRUE))
+  expect_equal(chat$last_turn()@tokens[1:2] > 0, c(TRUE, TRUE))
 })
 
 test_that("can make simple streaming request", {

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -8,21 +8,25 @@ test_that("can retrieve and log tokens", {
   local_tokens()
   provider <- test_provider("testprovider", "test")
 
-  expect_equal(tokens_log(provider, 10, 50), c(10, 50))
-  expect_equal(the$tokens, tokens_row("testprovider", "test", 10, 50))
+  expect_equal(tokens_log(provider, 0, 0, 100), c(0, 0, 100))
+  expect_equal(the$tokens, tokens_row("testprovider", "test", 0, 0, 100))
 
-  expect_equal(tokens_log(provider, 0, 10), c(0, 10))
-  expect_equal(the$tokens, tokens_row("testprovider", "test", 10, 60))
+  expect_equal(tokens_log(provider, 10, 50), c(10, 50, 0))
+  expect_equal(the$tokens, tokens_row("testprovider", "test", 10, 50, 100))
 
-  expect_equal(tokens_log(provider), c(0, 0))
-  expect_equal(the$tokens, tokens_row("testprovider", "test", 10, 60))
+  expect_equal(tokens_log(provider, 0, 10), c(0, 10, 0))
+  expect_equal(the$tokens, tokens_row("testprovider", "test", 10, 60, 100))
+
+  expect_equal(tokens_log(provider), c(0, 0, 0))
+  expect_equal(the$tokens, tokens_row("testprovider", "test", 10, 60, 100))
 
   expect_snapshot(token_usage())
 })
 
 test_that("can compute price of tokens", {
-  expect_equal(get_token_cost("OpenAI", "gpt-4o", 1e6, 0), dollars(2.5))
-  expect_equal(get_token_cost("OpenAI", "gpt-4o", 0, 1e6), dollars(10))
+  expect_equal(get_token_cost("OpenAI", "gpt-4o", 1e6, 0, 0), dollars(2.5))
+  expect_equal(get_token_cost("OpenAI", "gpt-4o", 0, 1e6, 0), dollars(10))
+  expect_equal(get_token_cost("OpenAI", "gpt-4o", 0, 0, 1e6), dollars(1.25))
 })
 
 test_that("token_usage() shows price if available", {
@@ -32,7 +36,8 @@ test_that("token_usage() shows price if available", {
       provider = "testprovider",
       model = "test",
       input = 0.10,
-      output = 0.01
+      output = 0.01,
+      cached_input = 0
     )
   )
   provider <- test_provider("testprovider", "test")


### PR DESCRIPTION
This isn't going to be quite right for claude since they charge for both reads and writes, and the write cost varies by length of caching. But I can't see an easy way to capture all these details currently, and hopefully in the future providers will provide some way to know exactly how much a chat cost.

Fixes #466