### PR TITLE
feat: Record and replay external classes that extend `Turn` or `Content`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,12 +44,12 @@
 
 # ellmer 0.2.1
 
-* When you save a `Chat` object to disk, API keys are automatically redacted.
-  This means that you can no longer easily resume a chat you've saved on disk
-  (we'll figure this out in a future release) but ensures that you never
+* When you save a `Chat` object to disk, API keys are automatically redacted. 
+  This means that you can no longer easily resume a chat you've saved on disk 
+  (we'll figure this out in a future release) but ensures that you never 
   accidentally save your secret key in an RDS file (#534).
 
-* `chat_anthropic()` now defaults to Claude Sonnet 4, and I've added pricing
+* `chat_anthropic()` now defaults to Claude Sonnet 4, and I've added pricing 
   information for the latest generation of Claude models.
 
 * `chat_databricks()` now picks up on Databricks workspace URLs set in the
@@ -57,14 +57,14 @@
   (#521, @atheriel). It now also supports tool calling (#548, @atheriel).
 
 * `chat_snowflake()` no longer streams answers that include a mysterious
-  `list(type = "text", text = "")` trailer (#533, @atheriel). It now parses
+  `list(type = "text", text = "")` trailer (#533, @atheriel). It now parses 
   streaming outputs correctly into turns (#542), supports structured ouputs
   (#544), and standard model parameters (#545, @atheriel).
 
 * `chat_snowflake()` and `chat_databricks()` now default to Claude Sonnet 3.7,
   the same default as `chat_anthropic()` (#539 and #546, @atheriel).
 
-* `type_from_schema()` lets you to use pre-existing JSON schemas in structured
+* `type_from_schema()` lets you to use pre-existing JSON schemas in structured 
   chats (#133, @hafen)
 
 # ellmer 0.2.0
@@ -73,36 +73,36 @@
 
 * We have made a number of refinements to the way ellmer converts JSON
   to R data structures. These are breaking changes, although we don't expect
-  them to affect much code in the wild. Most importantly, tools are now invoked
+  them to affect much code in the wild. Most importantly, tools are now invoked 
   with their inputs coerced to standard R data structures (#461); opt-out
   by setting `convert = FALSE` in `tool()`.
 
-  Additionally ellmer now converts `NULL` to `NA` for `type_boolean()`,
-  `type_integer()`, `type_number()`, and `type_string()` (#445), and does a
+  Additionally ellmer now converts `NULL` to `NA` for `type_boolean()`, 
+  `type_integer()`, `type_number()`, and `type_string()` (#445), and does a 
   better job with arrays when `required = FALSE` (#384).
 
 * `chat_` functions no longer have a `turn` argument. If you need to set the
-  turns, you can now use `Chat$set_turns()` (#427). Additionally,
-  `Chat$tokens()` has been renamed to `Chat$get_tokens()` and returns a data
-  frame of tokens, correctly aligned to the individual turn. The print method
-  now uses this to show how many input/output tokens were used by each turn
+  turns, you can now use `Chat$set_turns()` (#427). Additionally, 
+  `Chat$tokens()` has been renamed to `Chat$get_tokens()` and returns a data 
+  frame of tokens, correctly aligned to the individual turn. The print method 
+  now uses this to show how many input/output tokens were used by each turn 
   (#354).
 
 ## New features
 
 * Two new interfaces help you do multiple chats with a single function call:
 
-  * `batch_chat()` and `batch_chat_structured()` allow you to submit multiple
-    chats to OpenAI and Anthropic's batched interfaces. These only guarantee a
-    response within 24 hours, but are 50% of the price of regular requests
+  * `batch_chat()` and `batch_chat_structured()` allow you to submit multiple 
+    chats to OpenAI and Anthropic's batched interfaces. These only guarantee a 
+    response within 24 hours, but are 50% of the price of regular requests 
     (#143).
 
   * `parallel_chat()` and `parallel_chat_structured()` work with any provider
     and allow you to submit multiple chats in parallel (#143). This doesn't give
     you any cost savings, but it's can be much, much faster.
 
-  This new family of functions is experimental because I'm not 100% sure that
-  the shape of the user interface is correct, particularly as it pertains to
+  This new family of functions is experimental because I'm not 100% sure that 
+  the shape of the user interface is correct, particularly as it pertains to 
   handling errors.
 
 * `google_upload()` lets you upload files to Google Gemini or Vertex AI (#310).
@@ -118,14 +118,14 @@
 
 * `interpolate()` and friends are now vectorised so you can generate multiple
   prompts for (e.g.) a data frame of inputs. They also now return a specially
-  classed object with a custom print method (#445). New `interpolate_package()`
-  makes it easier to interpolate from prompts stored in the `inst/prompts`
+  classed object with a custom print method (#445). New `interpolate_package()` 
+  makes it easier to interpolate from prompts stored in the `inst/prompts` 
   directory inside a package (#164).
 
-* `chat_anthropic()`, `chat_azure()`, `chat_openai()`, and `chat_gemini()` now
-  take a `params` argument, that coupled with the `params()` helper, makes it
-  easy to specify common model parameters (like `seed` and `temperature`)
-  across providers. Support for other providers will grow as you request it
+* `chat_anthropic()`, `chat_azure()`, `chat_openai()`, and `chat_gemini()` now 
+  take a `params` argument, that coupled with the `params()` helper, makes it 
+  easy to specify common model parameters (like `seed` and `temperature`) 
+  across providers. Support for other providers will grow as you request it 
   (#280).
 
 * ellmer now tracks the cost of input and output tokens. The cost is displayed
@@ -145,7 +145,7 @@
   * `chat_portkey()` and `models_portkey()` for models hosted at
     <https://portkey.ai> (#363, @maciekbanas).
 
-* We also renamed (with deprecation) a few functions to make the naming
+* We also renamed (with deprecation) a few functions to make the naming 
   scheme more consistent (#382, @gadenbuie):
 
   * `chat_azure_openai()` replaces `chat_azure()`.
@@ -159,17 +159,17 @@
 
 ## Developer tooling
 
-* New `Chat$get_provider()` lets you access the underlying provider object
+* New `Chat$get_provider()` lets you access the underlying provider object 
   (#202).
 
-* `Chat$chat_async()` and `Chat$stream_async()` gain a `tool_mode` argument to
-  decide between `"sequential"` and `"concurrent"` tool calling. This is an
+* `Chat$chat_async()` and `Chat$stream_async()` gain a `tool_mode` argument to 
+  decide between `"sequential"` and `"concurrent"` tool calling. This is an 
   advanced feature that primarily affects asynchronous tools (#488, @gadenbuie).
 
-* `Chat$stream()` and `Chat$stream_async()` gain support for streaming the
-  additional content types generated during a tool call with a new `stream`
-  argument. When `stream = "content"` is set, the streaming response yields
-  `Content` objects, including the `ContentToolRequest` and `ContentToolResult`
+* `Chat$stream()` and `Chat$stream_async()` gain support for streaming the 
+  additional content types generated during a tool call with a new `stream` 
+  argument. When `stream = "content"` is set, the streaming response yields 
+  `Content` objects, including the `ContentToolRequest` and `ContentToolResult` 
   objects used to request and return tool calls (#400, @gadenbuie).
 
 * New `Chat$on_tool_request()` and `$on_tool_result()` methods allow you to
@@ -177,7 +177,7 @@
   can be used to implement custom logging or other actions when tools are
   called, without modifying the tool function (#493, @gadenbuie).
 
-* `Chat$chat(echo = "output")` replaces the now-deprecated `echo = "text"`
+* `Chat$chat(echo = "output")` replaces the now-deprecated `echo = "text"` 
   option. When using `echo = "output"`, additional output, such as tool
   requests and results, are shown as they occur. When `echo = "none"`, tool
   call failures are emitted as warnings (#366, @gadenbuie).
@@ -191,7 +191,7 @@
     `ContentToolResult` no longer has an `id` property, instead the tool call
     ID can be retrieved from `request@id`.
 
-  They also include the error condition in the `error` property when a tool call
+  They also include the error condition in the `error` property when a tool call 
   fails (#421, @gadenbuie).
 
 * `ContentToolRequest` gains a `tool` property that includes the `tool()`
@@ -211,31 +211,31 @@
 ## Minor improvements and bug fixes
 
 * All requests now set a custom User-Agent that identifies that the requests
-  come from ellmer (#341). The default timeout has been increased to
+  come from ellmer (#341). The default timeout has been increased to 
   5 minutes (#451, #321).
 
-* `chat_anthropic()` now supports the thinking content type (#396), and
-  `content_image_url()` (#347). It gains a `beta_header` argument to opt-in
-  to beta features (#339). It (along with `chat_bedrock()`) no longer chokes
+* `chat_anthropic()` now supports the thinking content type (#396), and 
+  `content_image_url()` (#347). It gains a `beta_header` argument to opt-in 
+  to beta features (#339). It (along with `chat_bedrock()`) no longer chokes 
   after receiving an output that consists only of whitespace (#376).
   Finally, `chat_anthropic(max_tokens =)` is now deprecated in favour of
   `chat_anthropic(params = )` (#280).
 
-* `chat_google_gemini()` and `chat_google_vertex()` gain more ways to
-  authenticate. They can use `GEMINI_API_KEY` if set (@t-kalinowski, #513),
-  authenticate with Google default application credentials (including service
-  accounts, etc) (#317, @atheriel) and use viewer-based credentials when
-  running on Posit Connect (#320, @atheriel). Authentication with default
-  application credentials requires the {gargle} package. They now also can now
+* `chat_google_gemini()` and `chat_google_vertex()` gain more ways to 
+  authenticate. They can use `GEMINI_API_KEY` if set (@t-kalinowski, #513), 
+  authenticate with Google default application credentials (including service 
+  accounts, etc) (#317, @atheriel) and use viewer-based credentials when 
+  running on Posit Connect (#320, @atheriel). Authentication with default 
+  application credentials requires the {gargle} package. They now also can now 
   handle responses that include citation metadata (#358).
 
-* `chat_ollama()` now works with `tool()` definitions with optional arguments
-  or empty properties (#342, #348, @gadenbuie), and now accepts `api_key` and
-  consults the `OLLAMA_API_KEY` environment variable. This is not needed for
-  local usage, but enables bearer-token authentication when Ollama is running
+* `chat_ollama()` now works with `tool()` definitions with optional arguments 
+  or empty properties (#342, #348, @gadenbuie), and now accepts `api_key` and 
+  consults the `OLLAMA_API_KEY` environment variable. This is not needed for 
+  local usage, but enables bearer-token authentication when Ollama is running 
   behind a reverse proxy (#501, @gadenbuie).
 
-* `chat_openai(seed =)` is now deprecated in favour of `chat_openai(params = )`
+* `chat_openai(seed =)` is now deprecated in favour of `chat_openai(params = )` 
   (#280).
 
 * `create_tool_def()` can now use any Chat instance (#118, @pedrobtz).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ellmer (development version)
 
+* `contents_record()` and `contents_replay()` now record and replay custom classes that extend ellmer's `Turn` or `Content` classes (#689).
+
 # ellmer 0.3.0
 
 ## New features
@@ -42,12 +44,12 @@
 
 # ellmer 0.2.1
 
-* When you save a `Chat` object to disk, API keys are automatically redacted. 
-  This means that you can no longer easily resume a chat you've saved on disk 
-  (we'll figure this out in a future release) but ensures that you never 
+* When you save a `Chat` object to disk, API keys are automatically redacted.
+  This means that you can no longer easily resume a chat you've saved on disk
+  (we'll figure this out in a future release) but ensures that you never
   accidentally save your secret key in an RDS file (#534).
 
-* `chat_anthropic()` now defaults to Claude Sonnet 4, and I've added pricing 
+* `chat_anthropic()` now defaults to Claude Sonnet 4, and I've added pricing
   information for the latest generation of Claude models.
 
 * `chat_databricks()` now picks up on Databricks workspace URLs set in the
@@ -55,14 +57,14 @@
   (#521, @atheriel). It now also supports tool calling (#548, @atheriel).
 
 * `chat_snowflake()` no longer streams answers that include a mysterious
-  `list(type = "text", text = "")` trailer (#533, @atheriel). It now parses 
+  `list(type = "text", text = "")` trailer (#533, @atheriel). It now parses
   streaming outputs correctly into turns (#542), supports structured ouputs
   (#544), and standard model parameters (#545, @atheriel).
 
 * `chat_snowflake()` and `chat_databricks()` now default to Claude Sonnet 3.7,
   the same default as `chat_anthropic()` (#539 and #546, @atheriel).
 
-* `type_from_schema()` lets you to use pre-existing JSON schemas in structured 
+* `type_from_schema()` lets you to use pre-existing JSON schemas in structured
   chats (#133, @hafen)
 
 # ellmer 0.2.0
@@ -71,36 +73,36 @@
 
 * We have made a number of refinements to the way ellmer converts JSON
   to R data structures. These are breaking changes, although we don't expect
-  them to affect much code in the wild. Most importantly, tools are now invoked 
+  them to affect much code in the wild. Most importantly, tools are now invoked
   with their inputs coerced to standard R data structures (#461); opt-out
   by setting `convert = FALSE` in `tool()`.
 
-  Additionally ellmer now converts `NULL` to `NA` for `type_boolean()`, 
-  `type_integer()`, `type_number()`, and `type_string()` (#445), and does a 
+  Additionally ellmer now converts `NULL` to `NA` for `type_boolean()`,
+  `type_integer()`, `type_number()`, and `type_string()` (#445), and does a
   better job with arrays when `required = FALSE` (#384).
 
 * `chat_` functions no longer have a `turn` argument. If you need to set the
-  turns, you can now use `Chat$set_turns()` (#427). Additionally, 
-  `Chat$tokens()` has been renamed to `Chat$get_tokens()` and returns a data 
-  frame of tokens, correctly aligned to the individual turn. The print method 
-  now uses this to show how many input/output tokens were used by each turn 
+  turns, you can now use `Chat$set_turns()` (#427). Additionally,
+  `Chat$tokens()` has been renamed to `Chat$get_tokens()` and returns a data
+  frame of tokens, correctly aligned to the individual turn. The print method
+  now uses this to show how many input/output tokens were used by each turn
   (#354).
 
 ## New features
 
 * Two new interfaces help you do multiple chats with a single function call:
 
-  * `batch_chat()` and `batch_chat_structured()` allow you to submit multiple 
-    chats to OpenAI and Anthropic's batched interfaces. These only guarantee a 
-    response within 24 hours, but are 50% of the price of regular requests 
+  * `batch_chat()` and `batch_chat_structured()` allow you to submit multiple
+    chats to OpenAI and Anthropic's batched interfaces. These only guarantee a
+    response within 24 hours, but are 50% of the price of regular requests
     (#143).
 
   * `parallel_chat()` and `parallel_chat_structured()` work with any provider
     and allow you to submit multiple chats in parallel (#143). This doesn't give
     you any cost savings, but it's can be much, much faster.
 
-  This new family of functions is experimental because I'm not 100% sure that 
-  the shape of the user interface is correct, particularly as it pertains to 
+  This new family of functions is experimental because I'm not 100% sure that
+  the shape of the user interface is correct, particularly as it pertains to
   handling errors.
 
 * `google_upload()` lets you upload files to Google Gemini or Vertex AI (#310).
@@ -116,14 +118,14 @@
 
 * `interpolate()` and friends are now vectorised so you can generate multiple
   prompts for (e.g.) a data frame of inputs. They also now return a specially
-  classed object with a custom print method (#445). New `interpolate_package()` 
-  makes it easier to interpolate from prompts stored in the `inst/prompts` 
+  classed object with a custom print method (#445). New `interpolate_package()`
+  makes it easier to interpolate from prompts stored in the `inst/prompts`
   directory inside a package (#164).
 
-* `chat_anthropic()`, `chat_azure()`, `chat_openai()`, and `chat_gemini()` now 
-  take a `params` argument, that coupled with the `params()` helper, makes it 
-  easy to specify common model parameters (like `seed` and `temperature`) 
-  across providers. Support for other providers will grow as you request it 
+* `chat_anthropic()`, `chat_azure()`, `chat_openai()`, and `chat_gemini()` now
+  take a `params` argument, that coupled with the `params()` helper, makes it
+  easy to specify common model parameters (like `seed` and `temperature`)
+  across providers. Support for other providers will grow as you request it
   (#280).
 
 * ellmer now tracks the cost of input and output tokens. The cost is displayed
@@ -143,7 +145,7 @@
   * `chat_portkey()` and `models_portkey()` for models hosted at
     <https://portkey.ai> (#363, @maciekbanas).
 
-* We also renamed (with deprecation) a few functions to make the naming 
+* We also renamed (with deprecation) a few functions to make the naming
   scheme more consistent (#382, @gadenbuie):
 
   * `chat_azure_openai()` replaces `chat_azure()`.
@@ -157,17 +159,17 @@
 
 ## Developer tooling
 
-* New `Chat$get_provider()` lets you access the underlying provider object 
+* New `Chat$get_provider()` lets you access the underlying provider object
   (#202).
 
-* `Chat$chat_async()` and `Chat$stream_async()` gain a `tool_mode` argument to 
-  decide between `"sequential"` and `"concurrent"` tool calling. This is an 
+* `Chat$chat_async()` and `Chat$stream_async()` gain a `tool_mode` argument to
+  decide between `"sequential"` and `"concurrent"` tool calling. This is an
   advanced feature that primarily affects asynchronous tools (#488, @gadenbuie).
 
-* `Chat$stream()` and `Chat$stream_async()` gain support for streaming the 
-  additional content types generated during a tool call with a new `stream` 
-  argument. When `stream = "content"` is set, the streaming response yields 
-  `Content` objects, including the `ContentToolRequest` and `ContentToolResult` 
+* `Chat$stream()` and `Chat$stream_async()` gain support for streaming the
+  additional content types generated during a tool call with a new `stream`
+  argument. When `stream = "content"` is set, the streaming response yields
+  `Content` objects, including the `ContentToolRequest` and `ContentToolResult`
   objects used to request and return tool calls (#400, @gadenbuie).
 
 * New `Chat$on_tool_request()` and `$on_tool_result()` methods allow you to
@@ -175,7 +177,7 @@
   can be used to implement custom logging or other actions when tools are
   called, without modifying the tool function (#493, @gadenbuie).
 
-* `Chat$chat(echo = "output")` replaces the now-deprecated `echo = "text"` 
+* `Chat$chat(echo = "output")` replaces the now-deprecated `echo = "text"`
   option. When using `echo = "output"`, additional output, such as tool
   requests and results, are shown as they occur. When `echo = "none"`, tool
   call failures are emitted as warnings (#366, @gadenbuie).
@@ -189,7 +191,7 @@
     `ContentToolResult` no longer has an `id` property, instead the tool call
     ID can be retrieved from `request@id`.
 
-  They also include the error condition in the `error` property when a tool call 
+  They also include the error condition in the `error` property when a tool call
   fails (#421, @gadenbuie).
 
 * `ContentToolRequest` gains a `tool` property that includes the `tool()`
@@ -209,31 +211,31 @@
 ## Minor improvements and bug fixes
 
 * All requests now set a custom User-Agent that identifies that the requests
-  come from ellmer (#341). The default timeout has been increased to 
+  come from ellmer (#341). The default timeout has been increased to
   5 minutes (#451, #321).
 
-* `chat_anthropic()` now supports the thinking content type (#396), and 
-  `content_image_url()` (#347). It gains a `beta_header` argument to opt-in 
-  to beta features (#339). It (along with `chat_bedrock()`) no longer chokes 
+* `chat_anthropic()` now supports the thinking content type (#396), and
+  `content_image_url()` (#347). It gains a `beta_header` argument to opt-in
+  to beta features (#339). It (along with `chat_bedrock()`) no longer chokes
   after receiving an output that consists only of whitespace (#376).
   Finally, `chat_anthropic(max_tokens =)` is now deprecated in favour of
   `chat_anthropic(params = )` (#280).
 
-* `chat_google_gemini()` and `chat_google_vertex()` gain more ways to 
-  authenticate. They can use `GEMINI_API_KEY` if set (@t-kalinowski, #513), 
-  authenticate with Google default application credentials (including service 
-  accounts, etc) (#317, @atheriel) and use viewer-based credentials when 
-  running on Posit Connect (#320, @atheriel). Authentication with default 
-  application credentials requires the {gargle} package. They now also can now 
+* `chat_google_gemini()` and `chat_google_vertex()` gain more ways to
+  authenticate. They can use `GEMINI_API_KEY` if set (@t-kalinowski, #513),
+  authenticate with Google default application credentials (including service
+  accounts, etc) (#317, @atheriel) and use viewer-based credentials when
+  running on Posit Connect (#320, @atheriel). Authentication with default
+  application credentials requires the {gargle} package. They now also can now
   handle responses that include citation metadata (#358).
 
-* `chat_ollama()` now works with `tool()` definitions with optional arguments 
-  or empty properties (#342, #348, @gadenbuie), and now accepts `api_key` and 
-  consults the `OLLAMA_API_KEY` environment variable. This is not needed for 
-  local usage, but enables bearer-token authentication when Ollama is running 
+* `chat_ollama()` now works with `tool()` definitions with optional arguments
+  or empty properties (#342, #348, @gadenbuie), and now accepts `api_key` and
+  consults the `OLLAMA_API_KEY` environment variable. This is not needed for
+  local usage, but enables bearer-token authentication when Ollama is running
   behind a reverse proxy (#501, @gadenbuie).
 
-* `chat_openai(seed =)` is now deprecated in favour of `chat_openai(params = )` 
+* `chat_openai(seed =)` is now deprecated in favour of `chat_openai(params = )`
   (#280).
 
 * `create_tool_def()` can now use any Chat instance (#118, @pedrobtz).

--- a/R/content-replay.R
+++ b/R/content-replay.R
@@ -86,29 +86,17 @@ contents_replay <- function(x, tools = list(), .envir = parent.frame()) {
 # Helpers ----------------------------------------------------------------------
 
 check_is_ellmer_object <- function(x) {
-  if (S7_inherits(x, ellmer::Content)) {
+  if (S7_inherits(x, ellmer::Content) || S7_inherits(x, ellmer::Turn)) {
     return(invisible(x))
   }
 
-  class_name <- class(x)[[1]]
-
-  if (grepl("^ellmer::", class_name)) {
-    return(invisible(x))
-  }
-
-  if (S7_inherits(x)) {
-    while (!is.null(x@parent)) {
-      x <- x@parent
-      if (S7_inherits(x, ellmer::Content) || S7_inherits(x, ellmer::Turn)) {
-        return(invisible(x))
-      }
-    }
-  }
-
-  cli::cli_abort(c(
-    "Only S7 classes from or that extend classes from {.pkg ellmer} are currently supported.",
-    "i" = "Received: {.val {class_name}}."
-  ))
+  cli::cli_abort(
+    c(
+      "Cannot record or replay {.obj_type_friendly {x}}.",
+      "i" = "Only {.code ellmer::Content} or {.code ellmer::Turn} classes or subclasses are currently supported."
+    ),
+    call = caller_env()
+  )
 }
 
 recorded_object <- function(class, props) {

--- a/R/content-replay.R
+++ b/R/content-replay.R
@@ -58,7 +58,7 @@ contents_record <- function(x) {
 contents_replay <- function(x, tools = list(), .envir = parent.frame()) {
   check_recorded(x)
 
-  x_class <- recorded_class_info(x, .envir = .envir)
+  class <- recorded_class_info(x, .envir = .envir)
 
   obj_props <- map(x$props, function(prop_value) {
     if (is_list_of_recorded_objects(prop_value)) {
@@ -72,12 +72,12 @@ contents_replay <- function(x, tools = list(), .envir = parent.frame()) {
     }
   })
 
-  env <- if (!is.null(x_class$pkg)) ns_env(x_class$pkg) else .envir
+  env <- if (!is.null(class$pkg)) ns_env(class$pkg) else .envir
 
   # This is a bit of overkill, but gives nicer tracebacks
-  out <- exec(x_class$name, !!!obj_props, .env = env)
+  out <- exec(class$name, !!!obj_props, .env = env)
 
-  if (x_class$name == "Turn") {
+  if (class$name == "Turn") {
     out <- match_tools(out, tools)
   }
   out
@@ -143,7 +143,7 @@ recorded_class_info <- function(x, .envir = parent.frame()) {
   class_split <- strsplit(x$class, "::")[[1]]
   if (length(class_split) > 2) {
     cli::cli_abort(
-      "Expected the class to be in the form `package::ClassName`, got: {.val {x$class}}.",
+      "Expected the class to be in the form `package::ClassName`, not {.val {x$class}}.",
       call = caller_env()
     )
   }

--- a/R/content-replay.R
+++ b/R/content-replay.R
@@ -19,11 +19,7 @@ NULL
 contents_record <- function(x) {
   class_name <- class(x)[[1]]
 
-  if (!grepl("^ellmer::", class_name)) {
-    cli::cli_abort(
-      "Only S7 classes from the `ellmer` package are currently supported. Received: {.val {class_name}}."
-    )
-  }
+  check_is_ellmer_object(x)
 
   # Assume that we can replay attributes (the underlying data in an S7 object)
   # to the constructor, i.e. do.call(S7_class(obj), attributes(obj))
@@ -54,42 +50,61 @@ contents_record <- function(x) {
 
 #' @rdname contents_record
 #' @export
-contents_replay <- function(x, tools = list()) {
+contents_replay <- function(x, tools = list(), .envir = parent.frame()) {
   check_recorded(x)
 
-  class_name <- gsub("^ellmer::", "", x$class)
-  cls <- ns_env("ellmer")[[class_name]]
-  if (is.null(cls)) {
-    cli::cli_abort("Unable to find the S7 class: {.val {x$class}}.")
-  }
-  if (!S7_inherits(cls)) {
-    cli::cli_abort(
-      "The object returned for {.val {x$class}} is not an S7 class."
-    )
-  }
+  x_class <- recorded_class_info(x, .envir = .envir)
 
   obj_props <- map(x$props, function(prop_value) {
     if (is_list_of_recorded_objects(prop_value)) {
       # If the prop is a list of recorded objects, replay each one
-      map(prop_value, contents_replay, tools = tools)
+      map(prop_value, contents_replay, tools = tools, .envir = .envir)
     } else if (is_recorded_object(prop_value)) {
       # If the prop is a recorded object, replay it
-      contents_replay(prop_value, tools = tools)
+      contents_replay(prop_value, tools = tools, .envir = .envir)
     } else {
       prop_value
     }
   })
 
-  # This is a bit of overkill, but gives nicer tracebacks
-  out <- exec(class_name, !!!obj_props, .env = ns_env("ellmer"))
+  env <- if (!is.null(x_class$pkg)) ns_env(x_class$pkg) else .envir
 
-  if (class_name == "Turn") {
+  # This is a bit of overkill, but gives nicer tracebacks
+  out <- exec(x_class$name, !!!obj_props, .env = env)
+
+  if (x_class$name == "Turn") {
     out <- match_tools(out, tools)
   }
   out
 }
 
 # Helpers ----------------------------------------------------------------------
+
+check_is_ellmer_object <- function(x) {
+  if (S7_inherits(x, ellmer::Content)) {
+    return(invisible(x))
+  }
+
+  class_name <- class(x)[[1]]
+
+  if (grepl("^ellmer::", class_name)) {
+    return(invisible(x))
+  }
+
+  if (S7_inherits(x)) {
+    while (!is.null(x@parent)) {
+      x <- x@parent
+      if (S7_inherits(x, ellmer::Content) || S7_inherits(x, ellmer::Turn)) {
+        return(invisible(x))
+      }
+    }
+  }
+
+  cli::cli_abort(c(
+    "Only S7 classes from or that extend classes from {.pkg ellmer} are currently supported.",
+    "i" = "Received: {.val {class_name}}."
+  ))
+}
 
 recorded_object <- function(class, props) {
   list(
@@ -129,11 +144,51 @@ check_recorded <- function(recorded, call = caller_env()) {
       call = call
     )
   }
+}
 
-  if (!grepl("ellmer::", recorded$class, fixed = TRUE)) {
+recorded_class_info <- function(x, .envir = parent.frame()) {
+  class_split <- strsplit(x$class, "::")[[1]]
+  if (length(class_split) > 2) {
     cli::cli_abort(
-      "Only S7 classes from the `ellmer` package are currently supported. Received: {.val {recorded$class}}.",
-      call = call
+      "Expected the class to be in the form `package::ClassName`, got: {.val {x$class}}.",
+      call = caller_env()
     )
   }
+
+  if (length(class_split) < 2) {
+    pkg <- NULL
+    name <- class_split[[1]]
+  } else {
+    pkg <- class_split[[1]]
+    name <- class_split[[2]]
+  }
+
+  check_recorded_class(pkg, name, .envir)
+
+  list(pkg = pkg, name = name)
+}
+
+check_recorded_class <- function(pkg, name, .envir = parent.frame()) {
+  if (is.null(pkg)) {
+    cls_fmt <- name
+    cls <- get0(name, envir = .envir, inherits = TRUE)
+  } else {
+    cls_fmt <- sprintf("%s::%s", pkg, name)
+    cls <- ns_env(pkg)[[name]]
+  }
+
+  if (is.null(cls)) {
+    cli::cli_abort(
+      "Unable to find the S7 class: {.code {cls_fmt}}.",
+      call = caller_env(n = 2)
+    )
+  }
+  if (!S7_inherits(cls)) {
+    cli::cli_abort(
+      "Expected the object named {.code {cls_fmt}} to be an S7 class, not {.obj_type_friendly {cls}}.",
+      call = caller_env(n = 2)
+    )
+  }
+
+  invisible(cls)
 }

--- a/R/content-replay.R
+++ b/R/content-replay.R
@@ -49,6 +49,9 @@ contents_record <- function(x) {
 }
 
 #' @rdname contents_record
+#' @param .envir The environment in which to look for class definitions. Used
+#'   when the recorded objects include classes that extend [ellmer::Turn] or
+#'   [ellmer::Content] but are not from the \pkg{ellmer} package itself.
 #' @export
 contents_replay <- function(x, tools = list(), .envir = parent.frame()) {
   check_recorded(x)

--- a/R/content-replay.R
+++ b/R/content-replay.R
@@ -27,8 +27,10 @@ contents_record <- function(x) {
   attr <- attributes(x)
   serializable_props <- intersect(prop_names(x), names(attr))
 
-  # Don't serialize the actual tool definition, as it really belongs to the
-  # Chat object() and on replay we will re-apply by matching to existing tools
+  # Don't serialize the actual tool definition, as it really belongs to the Chat
+  # object() and on replay we will re-apply by matching to existing tools. Note
+  # that it's not possible for users to extend this class because ellmer always
+  # creates the tool request object, so we can check the class directly.
   if (class_name == "ellmer::ContentToolRequest") {
     serializable_props <- setdiff(serializable_props, "tool")
   }

--- a/man/contents_record.Rd
+++ b/man/contents_record.Rd
@@ -7,13 +7,17 @@
 \usage{
 contents_record(x)
 
-contents_replay(x, tools = list())
+contents_replay(x, tools = list(), .envir = parent.frame())
 }
 \arguments{
 \item{x}{A \link{Turn} or \link{Content} object to serialize; or a serialized object
 to replay.}
 
 \item{tools}{A named list of tools}
+
+\item{.envir}{The environment in which to look for class definitions. Used
+when the recorded objects include classes that extend \link{Turn} or
+\link{Content} but are not from the \pkg{ellmer} package itself.}
 }
 \description{
 These generic functions can be use to convert \link{Turn}/\link{Content} objects

--- a/tests/testthat/_snaps/content-replay.md
+++ b/tests/testthat/_snaps/content-replay.md
@@ -21,8 +21,9 @@
     Code
       contents_record(LocalClass())
     Condition
-      Error:
-      ! Can't find property <foo::LocalClass>@parent
+      Error in `contents_record()`:
+      ! Cannot record or replay a <foo::LocalClass> object.
+      i Only `ellmer::Content` or `ellmer::Turn` classes or subclasses are currently supported.
     Code
       contents_replay(recorded)
     Condition

--- a/tests/testthat/_snaps/content-replay.md
+++ b/tests/testthat/_snaps/content-replay.md
@@ -21,13 +21,21 @@
     Code
       contents_record(LocalClass())
     Condition
-      Error in `contents_record()`:
-      ! Only S7 classes from the `ellmer` package are currently supported. Received: "foo::LocalClass".
+      Error:
+      ! Can't find property <foo::LocalClass>@parent
     Code
       contents_replay(recorded)
     Condition
+      Error in `loadNamespace()`:
+      ! there is no package called 'foo'
+
+# local classes that extend ellmer classes can be replayed
+
+    Code
+      test_record_replay(test_content("hello world"))
+    Condition
       Error in `contents_replay()`:
-      ! Only S7 classes from the `ellmer` package are currently supported. Received: "foo::LocalClass".
+      ! Expected the object named `LocalContentText` to be an S7 class, not a function.
 
 # replayed objects must be existing S7 classes
 
@@ -35,10 +43,10 @@
       contents_replay(doesnt_exist)
     Condition
       Error in `contents_replay()`:
-      ! Unable to find the S7 class: "ellmer::Turn2".
+      ! Unable to find the S7 class: `ellmer::Turn2`.
     Code
       contents_replay(not_s7)
     Condition
       Error in `contents_replay()`:
-      ! The object returned for "ellmer::chat_openai" is not an S7 class.
+      ! Expected the object named `ellmer::chat_openai` to be an S7 class, not a function.
 

--- a/tests/testthat/helper-content-replay.R
+++ b/tests/testthat/helper-content-replay.R
@@ -1,5 +1,5 @@
-test_record_replay <- function(x, tools = list()) {
+test_record_replay <- function(x, tools = list(), .envir = parent.frame()) {
   recorded <- contents_record(x)
-  replayed <- contents_replay(recorded, tools = tools)
+  replayed <- contents_replay(recorded, tools = tools, .envir = .envir)
   expect_equal(replayed, x)
 }

--- a/tests/testthat/test-content-replay.R
+++ b/tests/testthat/test-content-replay.R
@@ -94,6 +94,60 @@ test_that("non-ellmer classes are not recorded/replayed by default", {
   })
 })
 
+test_that("packaged classes that extend ellmer classes can be replayed", {
+  env <- rlang::current_env()
+
+  local_mocked_bindings(
+    ns_env = function(x) {
+      if (x == "foo") {
+        return(env)
+      }
+      rlang::ns_env(x)
+    }
+  )
+
+  LocalContentText <- S7::new_class(
+    "LocalContentText",
+    package = "foo",
+    parent = ellmer::ContentText
+  )
+
+  test_record_replay(LocalContentText("hello world"))
+  test_record_replay(
+    Turn("user", list(LocalContentText(text = "hello world")))
+  )
+})
+
+test_that("local classes that extend ellmer classes can be replayed", {
+  LocalContentText <- S7::new_class(
+    "LocalContentText",
+    package = NULL,
+    parent = ellmer::ContentText
+  )
+
+  test_record_replay(LocalContentText("hello world"))
+  test_record_replay(
+    Turn("user", list(LocalContentText(text = "hello world")))
+  )
+})
+
+test_that("local classes that extend ellmer classes can be replayed", {
+  test_content <- S7::new_class(
+    "LocalContentText",
+    package = NULL,
+    parent = ellmer::ContentText
+  )
+
+  LocalContentText <- function(...) {
+    test_content(...)
+  }
+
+  expect_snapshot(
+    error = TRUE,
+    test_record_replay(test_content("hello world"))
+  )
+})
+
 test_that("replayed objects must be existing S7 classes", {
   doesnt_exist <- list(version = 1, class = "ellmer::Turn2", props = list())
   not_s7 <- list(version = 1, class = "ellmer::chat_openai", props = list())


### PR DESCRIPTION
Allows `contents_record()` and `contents_replay()` to record and replay content with external types that extend `Turn` or `Content`.

See discussion in https://github.com/tidyverse/ellmer/pull/503#discussion_r2245256933

The added tests show the two expected uses:

1. A locally-defined class that extends an ellmer class (this requires `content_replay()` to take `.envir` to find the local object).
2. A class from a package, similar to `btw:::BtwToolResult`.

