### PR TITLE
fix(tool_request_args): `tool` can be `NULL`

### DIFF
--- a/R/chat-tools.R
+++ b/R/chat-tools.R
@@ -187,7 +187,7 @@ tool_request_args <- function(request) {
   tool <- request@tool
   args <- request@arguments
 
-  if (!tool@convert) {
+  if (is.null(tool) || !isTRUE(tool@convert)) {
     return(args)
   }
 


### PR DESCRIPTION
A `ContentToolRequest` may not have a tool property, so we need to be more careful about formatting the tool request object.