### PR TITLE
fix(match_tools): Match tools in tool results as well

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ellmer (development version)
 
+* `contents_replay()` now also restores the tool definition in `ContentToolResult` objects (in `@request@tool`) (#693).
+
 # ellmer 0.3.0
 
 ## New features

--- a/R/chat-tools.R
+++ b/R/chat-tools.R
@@ -11,16 +11,13 @@ match_tools <- function(turn, tools) {
 
   turn@contents <- map(turn@contents, function(content) {
     if (is_tool_request(content)) {
-      if (is.null(content@tool)) {
-        content@tool <- tools[[content@name]]
-      }
+      content@tool <- content@tool %||% tools[[content@name]]
       return(content)
     }
 
     if (is_tool_result(content)) {
-      if (is.null(content@request@tool)) {
-        content@request@tool <- tools[[content@request@name]]
-      }
+      content@request@tool <-
+        content@request@tool %||% tools[[content@request@name]]
       return(content)
     }
 

--- a/R/chat-tools.R
+++ b/R/chat-tools.R
@@ -14,7 +14,7 @@ match_tools <- function(turn, tools) {
       if (is.null(content@tool)) {
         content@tool <- tools[[content@name]]
       }
-      return(tool)
+      return(content)
     }
 
     if (is_tool_result(content)) {

--- a/R/chat-tools.R
+++ b/R/chat-tools.R
@@ -10,10 +10,20 @@ match_tools <- function(turn, tools) {
   }
 
   turn@contents <- map(turn@contents, function(content) {
-    if (!is_tool_request(content)) {
+    if (is_tool_request(content)) {
+      if (is.null(content@tool)) {
+        content@tool <- tools[[content@name]]
+      }
+      return(tool)
+    }
+
+    if (is_tool_result(content)) {
+      if (is.null(content@request@tool)) {
+        content@request@tool <- tools[[content@request@name]]
+      }
       return(content)
     }
-    content@tool <- tools[[content@name]]
+
     content
   })
 

--- a/tests/testthat/test-content-replay.R
+++ b/tests/testthat/test-content-replay.R
@@ -73,6 +73,23 @@ test_that("can re-match tools if present", {
   expect_equal(replayed@contents[[1]]@tool, NULL)
 })
 
+test_that("can re-match tools if present in tool results", {
+  mytool <- tool(function() {}, "mytool")
+
+  request <- ContentToolRequest("123", "mytool", tool = mytool)
+  result <- ContentToolResult("value", request = request)
+
+  turn <- Turn("user", list(result))
+  recorded <- contents_record(turn)
+
+  replayed <- contents_replay(recorded, tools = list(mytool = mytool))
+  expect_equal(replayed@contents[[1]]@request@tool, mytool)
+
+  # If no match, it still works, but tool is left as NULL
+  replayed <- contents_replay(recorded, tools = list())
+  expect_null(replayed@contents[[1]]@request@tool)
+})
+
 test_that("checks recorded value types", {
   bad_names <- list()
   bad_version <- list(version = 2, class = "ellmer::Content", props = list())

--- a/tests/testthat/test-content-replay.R
+++ b/tests/testthat/test-content-replay.R
@@ -73,21 +73,30 @@ test_that("can re-match tools if present", {
   expect_equal(replayed@contents[[1]]@tool, NULL)
 })
 
-test_that("can re-match tools if present in tool results", {
+test_that("can re-match tools if present", {
   mytool <- tool(function() {}, "mytool")
 
   request <- ContentToolRequest("123", "mytool", tool = mytool)
   result <- ContentToolResult("value", request = request)
 
-  turn <- Turn("user", list(result))
-  recorded <- contents_record(turn)
+  turn_request <- Turn("user", list(request))
+  turn_result <- Turn("user", list(result))
 
-  replayed <- contents_replay(recorded, tools = list(mytool = mytool))
-  expect_equal(replayed@contents[[1]]@request@tool, mytool)
+  test_record_replay(turn_request, tools = list(mytool = mytool))
+  test_record_replay(turn_result, tools = list(mytool = mytool))
 
-  # If no match, it still works, but tool is left as NULL
-  replayed <- contents_replay(recorded, tools = list())
-  expect_null(replayed@contents[[1]]@request@tool)
+  # If no tool match, it still works, but tool is left as NULL
+  replayed_turn_request <- contents_replay(
+    contents_record(turn_request),
+    tools = list()
+  )
+  expect_null(replayed_turn_request@contents[[1]]@tool)
+
+  replayed_turn_result <- contents_replay(
+    contents_record(turn_result),
+    tools = list()
+  )
+  expect_null(replayed_turn_result@contents[[1]]@request@tool)
 })
 
 test_that("checks recorded value types", {


### PR DESCRIPTION
Now that `contents_replay()` relies on `match_tools()` to resolve tool definitions, we also need to resolve tools in the `@request@tool` property of results.

Without this, the tool request is properly restored through `contents_replay()`, but the result will be missing the tool defintion. This affects shinychat because it only looks at the tool result when restoring a chat from bookmarked state (because the tool call is resolved we don't need to show the request).

I have a fix in shinychat, but it'd be best for `match_tools()`, at least when called through `contents_replay()` to return the full tool result.