### PR TITLE
Fix `chat_snowflake`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Suggests:
     curl (>= 6.0.1),
     gargle,
     gitcreds,
+    jose,
     knitr,
     magick,
     openssl,

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@
 
 * `contents_replay()` now also restores the tool definition in `ContentToolResult` objects (in `@request@tool`) (#693).
 
+* `chat_snowflake()` now supports Privatelink accounts (#694, @robert-norberg).
+
+* `chat_snowflake()` now works against Snowflake's latest API changes (#692, @robert-norberg).
+
 # ellmer 0.3.0
 
 ## New features

--- a/R/provider-snowflake.R
+++ b/R/provider-snowflake.R
@@ -284,7 +284,6 @@ method(as_json, list(ProviderSnowflakeCortex, Turn)) <- function(provider, x) {
   }
   list(
     role = x@role,
-    content = content,
     content_list = as_json(provider, x@contents)
   )
 }
@@ -435,6 +434,10 @@ snowflake_keypair_token <- function(
     fp <- openssl::base64_encode(
       openssl::sha256(openssl::write_der(key$pubkey))
     )
+    if (grepl(".+\\.privatelink$", account)) {
+      # account identifier is everything up to the first period
+      account <- gsub("^([^.]*).+", "\\1", account)
+    }
     sub <- toupper(paste0(account, ".", user))
     iss <- paste0(sub, ".SHA256:", fp)
     # Note: Snowflake employs a malformed issuer claim, so we have to inject it

--- a/tests/testthat/test-provider-snowflake.R
+++ b/tests/testthat/test-provider-snowflake.R
@@ -149,6 +149,20 @@ test_that("Snowflake key-pair credentials are detected correctly", {
   )
 })
 
+test_that("snowflake account identifier is extracted from privatelink account and used in JWT claim", {
+  skip_if_not_installed("jose")
+
+  testkey <- openssl::read_key(test_snowflake_key)
+  token <- snowflake_keypair_token(
+    account = "mycompany.us-east-1.privatelink",
+    user = "testuser",
+    key = testkey
+  )
+  pubkey <- as.list(testkey)$pubkey
+  decoded <- jose::jwt_decode_sig(token, pubkey = pubkey)
+  expect_equal(decoded$sub, "MYCOMPANY.TESTUSER")
+})
+
 test_that("tokens can be requested from a Connect server", {
   skip_if_not_installed("connectcreds")
 


### PR DESCRIPTION
Resolves #692.

I also updated `default_snowflake_credentials` so that the account identifier is pulled out of `account` when `account` is a PrivateLink account (e.g. `mycompany.us-east-1.privatelink`). This allowed me to run the tests for `provider-snowflake`.

Once I was able to run the tests, four tests in `test-provider-snowflake.R` were failing. My deletion of line 287 resolved this and all of the tests are passing again.

I didn't look too closely at `provider-snowflake-cortex.R`, but I ran those tests as well. Only the last one failed, and that fails with or without my deletion of line 287 in `provider-snowflake.R`.