### PR TITLE
chore: Return full tool request call when `format(req, show="call")`

### DIFF
--- a/R/chat-tools.R
+++ b/R/chat-tools.R
@@ -307,14 +307,10 @@ maybe_echo_tool <- function(x, echo = "output") {
   }
 
   if (is_tool_request(x)) {
-    call_str <- format(x, show = "call")
-    if (length(call_str) > 1) {
-      call_str <- paste0(call_str[1], "...)")
-    }
     cli::cli_text(
       cli::col_blue(cli::symbol$circle),
       " [{cli::col_blue('tool call')}] ",
-      cli_escape(call_str)
+      cli_escape(format(x, show = "call_short"))
     )
     return(invisible(x))
   }

--- a/R/content.R
+++ b/R/content.R
@@ -203,7 +203,7 @@ ContentToolRequest <- new_class(
 method(format, ContentToolRequest) <- function(
   x,
   ...,
-  show = c("all", "call")
+  show = c("all", "call", "call_short")
 ) {
   show <- arg_match(show)
 
@@ -220,6 +220,10 @@ method(format, ContentToolRequest) <- function(
 
   if (length(call_str) > 1) {
     call_str <- paste0(call_str[1], "...)")
+  }
+
+  if (show == "call_short") {
+    return(call_str)
   }
 
   cli::format_inline("[{.strong tool request} ({x@id})]: {call_str}")


### PR DESCRIPTION
Small change to `method(format, ContentToolRequest)` to return the full call when `show = "call"`. Otherwise, when `show = "all"`, the call is truncated to the first line.

I'm using `format(req, show = "call")` in shinychat to get the tool call as code that the user can copy, paste and run directly if needed. It'd be helpful to avoid needing to replicate the `format()` logic, but for this to be effective, we want the full call.
