### PR TITLE
Hopefully resolve test/vignette failures on CRAN

### DIFF
--- a/tests/testthat/helper-provider.R
+++ b/tests/testthat/helper-provider.R
@@ -84,6 +84,9 @@ test_data_extraction <- function(chat_fun) {
 # Images -----------------------------------------------------------------
 
 test_images_inline <- function(chat_fun, test_shape = TRUE) {
+  # has a subtle dependency on imagemagick
+  skip_on_cran()
+
   chat <- chat_fun()
   response <- chat$chat(
     "What's in this image? (Be sure to mention the outside shape)",

--- a/vignettes/structured-data.Rmd
+++ b/vignettes/structured-data.Rmd
@@ -382,6 +382,8 @@ Even without any descriptions, ChatGPT does pretty well:
 ```{r}
 #| label: examples-image
 #| cassette: true
+#| # Skip on CRAN because it has a subtle dependency on imagemagick
+#| eval: !expr ellmer:::has_credentials("openai")
 
 type_asset <- type_object(
   assert_name = type_string(),


### PR DESCRIPTION
`content_image_inline()` has a subtle dependency on the exact version of imagemagick installed. This shouldn't affect user code, just vcr cassette matching, so we just skip on CRAN.