### PR TITLE
fix(chat_anthropic): Drop empty assistant turns in `as_json()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ellmer (development version)
 
+* `chat_anthropic()` drops empty assistant turns to avoid API errors (#710).
+
 * `contents_replay()` now also restores the tool definition in `ContentToolResult` objects (in `@request@tool`) (#693).
 
 # ellmer 0.3.0

--- a/R/provider-anthropic.R
+++ b/R/provider-anthropic.R
@@ -309,6 +309,11 @@ method(as_json, list(ProviderAnthropic, Turn)) <- function(provider, x) {
     # claude passes system prompt as separate arg
     NULL
   } else if (x@role %in% c("user", "assistant")) {
+    if (x@role == "assistant" && identical(x@contents, list())) {
+      # Drop empty assistant turns to avoid an API error
+      # (all messages must have non-empty content)
+      return(NULL)
+    }
     list(role = x@role, content = as_json(provider, x@contents))
   } else {
     cli::cli_abort("Unknown role {turn@role}", .internal = TRUE)

--- a/tests/testthat/test-provider-anthropic.R
+++ b/tests/testthat/test-provider-anthropic.R
@@ -88,7 +88,26 @@ test_that("max_tokens is deprecated", {
 
 test_that("can match prices for some common models", {
   provider <- chat_anthropic_test()$get_provider()
-  
+
   expect_true(has_cost(provider, "claude-sonnet-4-20250514"))
   expect_true(has_cost(provider, "claude-3-7-sonnet-latest"))
+})
+
+test_that("removes empty final chat messages", {
+  chat <- chat_anthropic_test()
+  chat$set_turns(
+    list(
+      Turn("user", "Don't say anything"),
+      Turn("assistant")
+    )
+  )
+
+  turns_json <- as_json(chat$get_provider(), chat$get_turns())
+
+  expect_length(turns_json, 1)
+  expect_equal(turns_json[[1]]$role, "user")
+  expect_equal(
+    turns_json[[1]]$content,
+    list(list(type = "text", text = "Don't say anything"))
+  )
 })


### PR DESCRIPTION
Fixes #710

``` r
pkgload::load_all()
#> ℹ Loading ellmer

chat <- chat_anthropic()
#> Using model = "claude-sonnet-4-20250514".

show_word <- tool(
  function(word) {
    cat("The word is:", word, "\n")
    "Success. Don't say anything else."
  },
  name = "show_word",
  description = "Show the word to the user.",
  arguments = list(
    word = type_string()
  )
)

chat$register_tool(show_word)
```

```r
chat$chat("Think of a random word and show it to me.")
#> I'll think of a random word and show it to you.
#> ◯ [tool call] show_word(word = "butterfly")
#> The word is: butterfly
#> ● #> Success. Don't say anything else.

chat$chat("What does the word mean?")
#> A butterfly is a flying insect with large, often colorful wings and a slender 
#> body. Butterflies belong to the order Lepidoptera and undergo complete 
#> metamorphosis, transforming from caterpillars through a chrysalis stage into 
#> their adult winged form. They are known for their beautiful wing patterns and 
#> colors, and they play important roles as pollinators in many ecosystems. The 
#> word "butterfly" can also be used metaphorically to describe something 
#> delicate, graceful, or transformative.
```