### PR TITLE
chore: trim trailing whitespace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
     },
     "cSpell.words": [
         "ellmer"
-    ]
+    ],
+    "files.trimTrailingWhitespace": true,
+    "files.trimFinalNewlines": true,
+    "files.insertFinalNewline": true
 }


### PR DESCRIPTION
Adds Positron/VS Code workspace settings that match the `.Rproj` settings:

```
AutoAppendNewline: Yes
StripTrailingWhitespace: Yes
LineEndingConversion: Posix
```