### PR TITLE
feat(chat_github): Use newer REST API base url

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ellmer (development version)
 
+* `chat_github()` now uses the `https://models.github.ai/inference` endpoint and `chat()` supports GitHub models in the format `chat("github/openai/gpt-4.1")` (#726).
+
 * `chat_openai()` now uses `OPENAI_BASE_URL`, if set, for the `base_url`. Similarly, `chat_ollama()` also uses `OLLAMA_BASE_URL` if set (#713).
 
 * In the `value_turn()` method for OpenAI providers, `usage` is checked if `NULL` before logging tokens to avoid errors when streaming with some OpenAI-compatible services (#706, @stevegbrooks).

--- a/R/provider-any.R
+++ b/R/provider-any.R
@@ -23,13 +23,18 @@ chat <- function(
   if (length(pieces) == 1) {
     provider <- pieces[[1]]
     model <- NULL
-  } else if (length(pieces) == 2) {
+  } else if (length(pieces) >= 2) {
     provider <- pieces[[1]]
-    model <- pieces[[2]]
-  } else {
-    cli::cli_abort(
-      "{.arg name} must be in form {.str provider} or {.str provider/model}."
-    )
+    if (provider == "github") {
+      # GitHub model names use the `provider/model` format
+      model <- paste(pieces[-1], collapse = "/")
+    } else if (length(pieces) > 2) {
+      cli::cli_abort(
+        "{.arg name} must be in form {.str provider} or {.str provider/model}."
+      )
+    } else {
+      model <- pieces[[2]]
+    }
   }
 
   provider_name <- paste0("chat_", pieces[[1]])

--- a/R/provider-any.R
+++ b/R/provider-any.R
@@ -20,27 +20,12 @@ chat <- function(
   check_string(name, allow_empty = FALSE)
   pieces <- strsplit(name, "/", fixed = TRUE)[[1]]
 
-  provider <- model <- NULL
-
   if (length(pieces) == 1) {
     provider <- pieces[[1]]
-  } else if (length(pieces) >= 2) {
+    model <- NULL
+  } else {
     provider <- pieces[[1]]
-    if (length(pieces) == 2) {
-      model <- pieces[[2]]
-    } else if (provider == "github") {
-      # GitHub model names use the `provider/model` format
-      model <- paste(pieces[-1], collapse = "/")
-    } else {
-      # invalid format
-      provider <- NULL
-    }
-  }
-
-  if (is.null(provider)) {
-    cli::cli_abort(
-      "{.arg name} must be in form {.str provider} or {.str provider/model}."
-    )
+    model <- paste(pieces[-1], collapse = "/")
   }
 
   provider_fn_name <- paste0("chat_", provider)

--- a/R/provider-any.R
+++ b/R/provider-any.R
@@ -20,12 +20,10 @@ chat <- function(
   check_string(name, allow_empty = FALSE)
   pieces <- strsplit(name, "/", fixed = TRUE)[[1]]
 
-  provider <- NULL
-  model <- NULL
+  provider <- model <- NULL
 
   if (length(pieces) == 1) {
     provider <- pieces[[1]]
-    model <- NULL
   } else if (length(pieces) >= 2) {
     provider <- pieces[[1]]
     if (length(pieces) == 2) {
@@ -35,7 +33,7 @@ chat <- function(
       model <- paste(pieces[-1], collapse = "/")
     } else {
       # invalid format
-      provider <- model <- NULL
+      provider <- NULL
     }
   }
 

--- a/man/chat_github.Rd
+++ b/man/chat_github.Rd
@@ -7,7 +7,7 @@
 \usage{
 chat_github(
   system_prompt = NULL,
-  base_url = "https://models.inference.ai.azure.com/",
+  base_url = "https://models.github.ai/inference/",
   api_key = github_key(),
   model = NULL,
   seed = NULL,
@@ -16,21 +16,18 @@ chat_github(
   api_headers = character()
 )
 
-models_github(
-  base_url = "https://models.inference.ai.azure.com/",
-  api_key = github_key()
-)
+models_github(base_url = "https://models.github.ai/", api_key = github_key())
 }
 \arguments{
 \item{system_prompt}{A system prompt to set the behavior of the assistant.}
 
 \item{base_url}{The base URL to the endpoint; the default uses OpenAI.}
 
-\item{api_key}{The API key to use for authentication. You generally should
-not supply this directly, but instead manage your GitHub credentials
-as described in \url{https://usethis.r-lib.org/articles/git-credentials.html}.
-For headless environments, this will also look in the \code{GITHUB_PAT}
-env var.}
+\item{api_key}{API key to use for authentication.
+
+You generally should not supply this directly, but instead set the \code{GITHUB_PAT} environment variable.
+The best place to set this is in \code{.Renviron},
+which you can easily edit by calling \code{usethis::edit_r_environ()}.}
 
 \item{model}{The model to use for the chat (defaults to "gpt-4o").
 We regularly update the default, so we strongly recommend explicitly specifying a model for anything other than casual use.}
@@ -59,13 +56,16 @@ to every chat API call.}
 A \link{Chat} object.
 }
 \description{
-GitHub (via Azure) hosts a number of open source and OpenAI models.
-To access the GitHub model marketplace, you will need to apply for and
-be accepted into the beta access program. See
-\url{https://github.com/marketplace/models} for details.
+GitHub Models hosts a number of open source and OpenAI models. To access the
+GitHub model marketplace, you will need to apply for and be accepted into the
+beta access program. See \url{https://github.com/marketplace/models} for details.
 
 This function is a lightweight wrapper around \code{\link[=chat_openai]{chat_openai()}} with
-the defaults tweaked for the GitHub model marketplace.
+the defaults tweaked for the GitHub Models marketplace.
+
+GitHub also suports the Azure AI Inference SDK, which you can use by setting
+\code{base_url} to \code{"https://models.inference.ai.azure.com/"}. This endpoint was
+used in \pkg{ellmer} v0.3.0 and earlier.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/_snaps/provider-any.md
+++ b/tests/testthat/_snaps/provider-any.md
@@ -6,10 +6,10 @@
       Error in `chat()`:
       ! `name` must be a single string, not absent.
     Code
-      chat("a/b/c")
+      chat("")
     Condition
       Error in `chat()`:
-      ! `name` must be in form "provider" or "provider/model".
+      ! `name` must be a single string, not the empty string "".
     Code
       chat("susan")
     Condition

--- a/tests/testthat/test-provider-any.R
+++ b/tests/testthat/test-provider-any.R
@@ -1,7 +1,7 @@
 test_that("useful errors", {
   expect_snapshot(error = TRUE, {
     chat()
-    chat("a/b/c")
+    chat("")
     chat("susan")
     chat("susan/jones")
   })
@@ -16,4 +16,9 @@ test_that("can set model or use default", {
   chat2 <- chat("openai/gpt-4.1-mini")
   expect_equal(chat2$get_provider()@name, "OpenAI")
   expect_equal(chat2$get_provider()@model, "gpt-4.1-mini")
+
+  # We split at the first slash, the remainder is passed to `model`
+  chat3 <- chat("openai/provider/model")
+  expect_equal(chat3$get_provider()@name, "OpenAI")
+  expect_equal(chat3$get_provider()@model, "provider/model")
 })


### PR DESCRIPTION
Updates `chat_github()` to use https://models.github.ai/inference instead of https://models.inference.ai.azure.com, while leaving a note in the docs about the previous `base_url`.

I also updated `models_github()`, which includes some newer fields. I kept support for listing models from the previous endpoint, too.

One interesting twist: GitHub models use the `provider/model` format. So I carved out an exception in `chat()` that lets users write `chat("github/openai/gpt-4.1")` (that requires #699 to work).