### PR TITLE
Fix #732 by de-duplicating duplicated JSON responses from AWS Bedrock in structured data extraction

### DIFF
--- a/R/chat-structured.R
+++ b/R/chat-structured.R
@@ -1,12 +1,37 @@
-extract_data <- function(turn, type, convert = TRUE, needs_wrapper = FALSE) {
+extract_data <- function(turn, type, convert = TRUE, needs_wrapper = FALSE, prompt_index = NULL) {
   is_json <- map_lgl(turn@contents, S7_inherits, ContentJson)
   n <- sum(is_json)
-  if (n != 1) {
-    cli::cli_abort("Data extraction failed: {n} data results recieved.")
+  
+  if (n == 0) {
+    cli::cli_abort("Data extraction failed: 0 data results received.")
+  } else if (n == 1) {
+    # Normal case - exactly 1 JSON object
+    json <- turn@contents[[which(is_json)]]
+    out <- json@value
+  } else if (n == 2) {
+    # Check if the two JSON objects are identical (duplicate case)
+    json_indices <- which(is_json)
+    json1 <- turn@contents[[json_indices[1]]]
+    json2 <- turn@contents[[json_indices[2]]]
+    
+    val1 <- json1@value
+    val2 <- json2@value
+    
+    if (identical(val1, val2)) {
+      # Duplicate case - use the first one
+      index_msg <- if (!is.null(prompt_index)) paste0(" (prompt ", prompt_index, ")") else ""
+      warning("Found duplicate JSON responses, using the first one", index_msg, ".", call. = FALSE, immediate. = TRUE)
+      out <- val1
+    } else {
+      # Different JSON objects - use the last one (likely the final response)
+      index_msg <- if (!is.null(prompt_index)) paste0(" (prompt ", prompt_index, ")") else ""
+      warning("Found multiple different JSON responses, using the last one", index_msg, ".", call. = FALSE, immediate. = TRUE)
+      out <- val2
+    }
+  } else {
+    # More than 2 JSON objects - this is unexpected
+    cli::cli_abort("Data extraction failed: {n} data results received. Expected 1 or 2.")
   }
-
-  json <- turn@contents[[which(is_json)]]
-  out <- json@value
 
   if (needs_wrapper) {
     out <- out$wrapper

--- a/R/parallel-chat.R
+++ b/R/parallel-chat.R
@@ -170,12 +170,13 @@ multi_convert <- function(
 ) {
   needs_wrapper <- type_needs_wrapper(type, provider)
 
-  rows <- map(turns, \(turn) {
+  rows <- imap(turns, \(turn, idx) {
     extract_data(
       turn = turn,
       type = wrap_type_if_needed(type, needs_wrapper),
       convert = FALSE,
-      needs_wrapper = needs_wrapper
+      needs_wrapper = needs_wrapper,
+      prompt_index = idx
     )
   })
 

--- a/tests/testthat/test-chat-structured.R
+++ b/tests/testthat/test-chat-structured.R
@@ -24,6 +24,82 @@ test_that("can extract data when wrapper is used", {
   expect_equal(extract_data(turn, type, needs_wrapper = TRUE), list(x = 1))
 })
 
+test_that("handles duplicate identical JSON responses", {
+  # This test covers the Bedrock duplicate JSON issue
+  json_data <- list(name = "John", age = 25)
+  turn <- Turn("assistant", list(
+    ContentJson(json_data),
+    ContentJson(json_data)  # Identical duplicate
+  ))
+  type <- type_object(name = type_string(), age = type_integer())
+  
+  # Should warn about duplicates and use the first one
+  expect_warning(
+    result <- extract_data(turn, type),
+    "Found duplicate JSON responses, using the first one"
+  )
+  expect_equal(result, list(name = "John", age = 25))
+})
+
+test_that("handles duplicate identical JSON responses with prompt index", {
+  # Test that prompt index is included in warning message
+  json_data <- list(score = 42)
+  turn <- Turn("assistant", list(
+    ContentJson(json_data),
+    ContentJson(json_data)
+  ))
+  type <- type_object(score = type_integer())
+  
+  expect_warning(
+    extract_data(turn, type, prompt_index = 3),
+    "Found duplicate JSON responses, using the first one \\(prompt 3\\)"
+  )
+})
+
+test_that("handles different JSON responses", {
+  # This test covers the case where two different JSON objects are returned
+  turn <- Turn("assistant", list(
+    ContentJson(list(name = "John", age = 25)),
+    ContentJson(list(name = "Jane", age = 30))  # Different data
+  ))
+  type <- type_object(name = type_string(), age = type_integer())
+  
+  # Should warn about multiple responses and use the last one
+  expect_warning(
+    result <- extract_data(turn, type),
+    "Found multiple different JSON responses, using the last one"
+  )
+  expect_equal(result, list(name = "Jane", age = 30))
+})
+
+test_that("handles different JSON responses with prompt index", {
+  turn <- Turn("assistant", list(
+    ContentJson(list(value = 1)),
+    ContentJson(list(value = 2))
+  ))
+  type <- type_object(value = type_integer())
+  
+  expect_warning(
+    extract_data(turn, type, prompt_index = 5),
+    "Found multiple different JSON responses, using the last one \\(prompt 5\\)"
+  )
+})
+
+test_that("errors on more than 2 JSON responses", {
+  # Should error if there are more than 2 JSON objects
+  turn <- Turn("assistant", list(
+    ContentJson(list(x = 1)),
+    ContentJson(list(x = 2)),
+    ContentJson(list(x = 3))
+  ))
+  type <- type_object(x = type_integer())
+  
+  expect_error(
+    extract_data(turn, type),
+    "Data extraction failed: 3 data results received. Expected 1 or 2."
+  )
+})
+
 # Type coercion ---------------------------------------------------------------
 
 test_that("optional base types (scalars) stay as NULL", {


### PR DESCRIPTION
## Problem

AWS Bedrock occasionally returns duplicate identical JSON objects during structured data extraction, causing
`extract_data()` to fail with the error:
```
  Data extraction failed: 2 data results received.
```
This causes `parallel_chat_structured()` to fail completely when processing batches of prompts.

## Evidence

See also the reprex based on my own data, in https://github.com/tidyverse/ellmer/issues/732#issuecomment-3222467503.

Captured failure case from real-world usage (Spanish political manifesto analysis):
  
```r
# The Turn object contains two identical ContentJson objects:
turn@contents:
  [[1]] <ellmer::ContentJson>
  @value: List of 9
$ Country_LLM         : chr "Spain"
$ Party_LLM           : chr "Partido Popular"
$ is_populist         : logi FALSE
$ is_populist_evidence: chr "The party does not consistently frame politics in populist terms..."
$ antielitism         :List of 2
..$ evidence: chr "The party criticizes the current government's policy of 'cesiones humillantes'..."
..$ score   : int 4
$ generalwill         :List of 2
..$ evidence: chr "The party emphasizes the importance of unity and the general will of the people..."
..$ score   : int 5
$ indivisible         :List of 2
..$ evidence: chr "The party portrays Spain as a single nation with a common identity..."
..$ score   : int 6
$ manichean           :List of 2
..$ evidence: chr "The party criticizes the current government's policies and actions..."
..$ score   : int 3
$ peoplecentrism      :List of 2
..$ evidence: chr "The party emphasizes the importance of listening to the people..."
..$ score   : int 5

[[2]] <ellmer::ContentJson>
  @value: List of 9

# IDENTICAL structure and values as [[1]]
# Verification: identical(json1, json2) == TRUE
```
Scale: Captured 11 failure cases vs 3 success cases during batch processing, indicating this is a significant
intermittent issue with Bedrock's tool calling mechanism.

  Solution

  Updated extract_data() in R/chat-structured.R to gracefully handle multiple JSON responses:

  if (n == 2) {
    # Check if the two JSON objects are identical (duplicate case)
    if (identical(val1, val2)) {
      warning("Found duplicate JSON responses, using the first one", call. = FALSE)
      out <- val1
    } else {
      # Different JSON objects - use the last one (likely the final response)  
      warning("Found multiple different JSON responses, using the last one", call. = FALSE)
      out <- val2
    }
  }

## Tests

  Added comprehensive tests in test-chat-structured.R:
  - Handle duplicate identical JSON responses with warning
  - Handle different JSON responses (use last one)
  - Include prompt index in warning messages for parallel operations
  - Error appropriately on >2 JSON responses

##  Impact

Before:
```r
# This would fail completely
parallel_chat_structured(chat, prompts, type = my_type)
#> Error: Data extraction failed: 2 data results received.
```

After:
```r
# This now succeeds with warning
result <- parallel_chat_structured(chat, prompts, type = my_type)
#> Warning: Found duplicate JSON responses, using the first one (prompt 43).
#> ... successful extraction continues

This ensures robust structured data extraction for production use, even when providers exhibit intermittent duplication behaviour.

## Additional notes

This works best when combined with #725. #705 does not fix this issue, but if the other two PRs are accepted, I will redo #705 and integrate them into a single, more `robust parallel_chat_structured()`.

