### PR TITLE
Fix typos in source comments and regenerate documentation

### DIFF
--- a/R/chat.R
+++ b/R/chat.R
@@ -114,7 +114,7 @@ Chat <- R6::R6Class(
       invisible(self)
     },
 
-    #' @description A data frame with a `tokens` column that proides the
+    #' @description A data frame with a `tokens` column that provides the
     #'   number of input tokens used by user turns and the number of
     #'   output tokens used by assistant turns.
     #' @param include_system_prompt Whether to include the system prompt in

--- a/R/provider-azure.R
+++ b/R/provider-azure.R
@@ -24,7 +24,7 @@ NULL
 #'
 #' @param endpoint Azure OpenAI endpoint url with protocol and hostname, i.e.
 #'  `https://{your-resource-name}.openai.azure.com`. Defaults to using the
-#'   value of the `AZURE_OPENAI_ENDPOINT` envinronment variable.
+#'   value of the `AZURE_OPENAI_ENDPOINT` environment variable.
 #' @param deployment_id Deployment id for the model you want to use.
 #' @param api_version The API version to use.
 #' @param api_key `r api_key_param("AZURE_OPENAI_API_KEY")`

--- a/R/tools-def-auto.R
+++ b/R/tools-def-auto.R
@@ -24,7 +24,7 @@
 #'   metadata for. Can also be an expression of the form `pkg::fun`.
 #' @param chat A `Chat` object used to generate the output. If `NULL`
 #'   (the default) uses [chat_openai()].
-#' @param model `lifecycle::badge("deprecated")` Formally used for definining
+#' @param model `lifecycle::badge("deprecated")` Formally used for defining
 #'   the model used by the chat. Now supply `chat` instead.
 #' @param echo Emit the registration code to the console. Defaults to `TRUE` in
 #'   interactive sessions.

--- a/R/types.R
+++ b/R/types.R
@@ -180,7 +180,7 @@ type_array <- function(items, description = NULL, required = TRUE) {
   TypeArray(items = items, description = description, required = required)
 }
 
-#' @param ... Name-type pairs defineing the components that the object must
+#' @param ... Name-type pairs defining the components that the object must
 #'   possess.
 #' @param .additional_properties Can the object have arbitrary additional
 #'   properties that are not explicitly listed? Only supported by Claude.

--- a/man/Chat.Rd
+++ b/man/Chat.Rd
@@ -179,7 +179,7 @@ Update the system prompt
 \if{html}{\out{<a id="method-Chat-get_tokens"></a>}}
 \if{latex}{\out{\hypertarget{method-Chat-get_tokens}{}}}
 \subsection{Method \code{get_tokens()}}{
-A data frame with a \code{tokens} column that proides the
+A data frame with a \code{tokens} column that provides the
 number of input tokens used by user turns and the number of
 output tokens used by assistant turns.
 \subsection{Usage}{

--- a/man/chat_azure_openai.Rd
+++ b/man/chat_azure_openai.Rd
@@ -21,7 +21,7 @@ chat_azure_openai(
 \arguments{
 \item{endpoint}{Azure OpenAI endpoint url with protocol and hostname, i.e.
 \verb{https://\{your-resource-name\}.openai.azure.com}. Defaults to using the
-value of the \code{AZURE_OPENAI_ENDPOINT} envinronment variable.}
+value of the \code{AZURE_OPENAI_ENDPOINT} environment variable.}
 
 \item{deployment_id}{Deployment id for the model you want to use.}
 

--- a/man/create_tool_def.Rd
+++ b/man/create_tool_def.Rd
@@ -19,7 +19,7 @@ metadata for. Can also be an expression of the form \code{pkg::fun}.}
 \item{chat}{A \code{Chat} object used to generate the output. If \code{NULL}
 (the default) uses \code{\link[=chat_openai]{chat_openai()}}.}
 
-\item{model}{\code{lifecycle::badge("deprecated")} Formally used for definining
+\item{model}{\code{lifecycle::badge("deprecated")} Formally used for defining
 the model used by the chat. Now supply \code{chat} instead.}
 
 \item{echo}{Emit the registration code to the console. Defaults to \code{TRUE} in

--- a/man/type_boolean.Rd
+++ b/man/type_boolean.Rd
@@ -54,7 +54,7 @@ value, the default value will be used.}
 \item{items}{The type of the array items. Can be created by any of the
 \code{type_} function.}
 
-\item{...}{Name-type pairs defineing the components that the object must
+\item{...}{Name-type pairs defining the components that the object must
 possess.}
 
 \item{.additional_properties}{Can the object have arbitrary additional


### PR DESCRIPTION
Corrects typos in roxygen2 comments across several source files.