### PR TITLE
Add models_mistral function.

### DIFF
--- a/R/provider-mistral.R
+++ b/R/provider-mistral.R
@@ -122,6 +122,10 @@ mistral_key <- function() {
   key_get("MISTRAL_API_KEY")
 }
 
+mistral_key_exists <- function() {
+  key_exists("MISTRAL_API_KEY")
+}
+
 # Models -----------------------------------------------------------------------
 
 #' @export

--- a/R/provider-mistral.R
+++ b/R/provider-mistral.R
@@ -147,9 +147,9 @@ models_mistral <- function(
 
   json <- resp_body_json(resp)
 
-  id <- purrr::map_chr(json$data, `[[`, "id")
-  display_name <- purrr::map_chr(json$data, `[[`, "name")
-  created_at <- as.POSIXct(purrr::map_int(json$data, `[[`, "created"))
+  id <- map_chr(json$data, `[[`, "id")
+  display_name <- map_chr(json$data, `[[`, "name")
+  created_at <- as.POSIXct(map_int(json$data, `[[`, "created"))
 
   df <- data.frame(
     id = id,

--- a/R/provider-mistral.R
+++ b/R/provider-mistral.R
@@ -118,7 +118,40 @@ method(chat_params, ProviderMistral) <- function(provider, params) {
   )
 }
 
-
 mistral_key <- function() {
   key_get("MISTRAL_API_KEY")
+}
+
+# Models -----------------------------------------------------------------------
+
+#' @export
+#' @rdname chat_mistral
+models_mistral <- function(
+  base_url = "https://api.mistral.ai/v1/",
+  api_key = mistral_key()
+) {
+  provider <- ProviderMistral(
+    name = "Mistrak",
+    model = "",
+    base_url = base_url,
+    api_key = api_key
+  )
+
+  req <- base_request(provider)
+  req <- req_url_path_append(req, "/models")
+  resp <- req_perform(req)
+
+  json <- resp_body_json(resp)
+
+  id <- purrr::map_chr(json$data, `[[`, "id")
+  display_name <- purrr::map_chr(json$data, `[[`, "name")
+  created_at <- as.POSIXct(purrr::map_int(json$data, `[[`, "created"))
+
+  df <- data.frame(
+    id = id,
+    name = display_name,
+    created_at = created_at
+  )
+  df <- cbind(df, ellmer:::match_prices("Mistral", df$id))
+  return(df)
 }

--- a/tests/testthat/test-provider-mistral.R
+++ b/tests/testthat/test-provider-mistral.R
@@ -18,6 +18,12 @@ test_that("can handle errors", {
   expect_snapshot(chat$chat("Hi"), error = TRUE)
 })
 
+test_that("can list models", {
+  vcr::local_cassette("mistral-list-models")
+
+  test_models(models_mistral)
+})
+
 # Common provider interface -----------------------------------------------
 
 test_that("defaults are reported", {


### PR DESCRIPTION
This PR adresses issue #750 after receiving green light for a PR.
It adds model_mistral() fashioned after the other models_provider() functions, and corresponding testthat tests