### PR TITLE
Update naming claude brand in documentation, `document()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Config/testthat/parallel: true
 Config/testthat/start-first: chat, provider*
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Collate:
     'utils-S7.R'
     'types.R'

--- a/R/provider-anthropic.R
+++ b/R/provider-anthropic.R
@@ -7,11 +7,11 @@ NULL
 #' Chat with an Anthropic Claude model
 #'
 #' @description
-#' [Anthropic](https://www.anthropic.com) provides a number of chat based
-#' models under the [Claude](https://www.anthropic.com/claude) moniker.
-#' Note that a Claude Pro membership does not give you the ability to call
-#' models via the API; instead, you will need to sign up (and pay for) a
-#' [developer account](https://console.anthropic.com/).
+#' [Anthropic](https://www.anthropic.com) provides a number of chat based models
+#' under the [Claude](https://claude.com/product/overview) moniker. Note that a
+#' Claude Pro membership does not give you the ability to call models via the
+#' API; instead, you will need to sign up (and pay for) a
+#' [developer account](https://platform.claude.com/).
 #'
 #' @inheritParams chat_openai
 #' @inherit chat_openai return

--- a/man/batch_chat.Rd
+++ b/man/batch_chat.Rd
@@ -95,7 +95,7 @@ errors in the most helpful way. Fortunately they don't seem to be common,
 but if you have ideas, please let me know!
 }
 \examples{
-\dontshow{if (has_credentials("openai")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (has_credentials("openai")) withAutoprint(\{ # examplesIf}
 chat <- chat_openai(model = "gpt-4.1-nano")
 
 # Chat ----------------------------------------------------------------------

--- a/man/chat_anthropic.Rd
+++ b/man/chat_anthropic.Rd
@@ -66,11 +66,11 @@ Note this only affects the \code{chat()} method.}
 A \link{Chat} object.
 }
 \description{
-\href{https://www.anthropic.com}{Anthropic} provides a number of chat based
-models under the \href{https://www.anthropic.com/claude}{Claude} moniker.
-Note that a Claude Pro membership does not give you the ability to call
-models via the API; instead, you will need to sign up (and pay for) a
-\href{https://console.anthropic.com/}{developer account}.
+\href{https://www.anthropic.com}{Anthropic} provides a number of chat based models
+under the \href{https://claude.com/product/overview}{Claude} moniker. Note that a
+Claude Pro membership does not give you the ability to call models via the
+API; instead, you will need to sign up (and pay for) a
+\href{https://platform.claude.com/}{developer account}.
 }
 \examples{
 \dontshow{ellmer:::vcr_example_start("chat_anthropic")}

--- a/man/chat_azure_openai.Rd
+++ b/man/chat_azure_openai.Rd
@@ -90,7 +90,7 @@ package.
 }
 \examples{
 \dontrun{
-chat <- chat_azure_openai(deployment_id = "gpt-4o-mini")
+chat <- chat_azure_openai(model = "gpt-4o-mini")
 chat$chat("Tell me three jokes about statisticians")
 }
 }

--- a/man/chat_snowflake.Rd
+++ b/man/chat_snowflake.Rd
@@ -79,7 +79,7 @@ than a general-purpose model.
 }
 }
 \examples{
-\dontshow{if (has_credentials("snowflake")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (has_credentials("snowflake")) withAutoprint(\{ # examplesIf}
 chat <- chat_snowflake()
 chat$chat("Tell me a joke in the form of a SQL query.")
 \dontshow{\}) # examplesIf}

--- a/man/ellmer-package.Rd
+++ b/man/ellmer-package.Rd
@@ -32,7 +32,7 @@ Authors:
 
 Other contributors:
 \itemize{
-  \item Posit Software, PBC (03wc8by49) [copyright holder, funder]
+  \item Posit Software, PBC (\href{https://ror.org/03wc8by49}{ROR}) [copyright holder, funder]
 }
 
 }


### PR DESCRIPTION
According to Anthropic's announcement earlier this week: Today, we’re unifying all of our developer offerings under the Claude brand. You'll see updated naming across our platform and documentation, but your technical implementation stays the same—no action needed.