### PR TITLE
fix(interpolate_package): Check `path` and improve error messages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ellmer (development version)
 
+* `interpolate_package()` now provides an informative error if the requested prompt file is not found in the package's `prompts/` directory (#763).
+
 * `models_ollama()` was fixed to correctly query model capabilities from remote Ollama servers (#746).
 
 * `chat_claude()` is no longer deprecated and is an alias for `chat_anthropic()`, reflecting Anthropic's recent rebranding of developer tools under the Claude name (#758).

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -51,6 +51,7 @@ interpolate <- function(prompt, ..., .envir = parent.frame()) {
 #' @rdname interpolate
 #' @export
 interpolate_file <- function(path, ..., .envir = parent.frame()) {
+  check_string(path)
   string <- read_file(path)
   interpolate(string, ..., .envir = .envir)
 }
@@ -64,12 +65,22 @@ interpolate_package <- function(
   ...,
   .envir = parent.frame()
 ) {
+  check_string(path)
+
   path <- system.file("prompts", path, package = package)
+
+  if (!nzchar(path)) {
+    cli::cli_abort(c(
+      "{.pkg {package}} does not have {.val {path}} in its {.field prompts/} directory.",
+      "i" = 'Run {.run dir(system.file("prompts", package = "{package}"))} to see available prompts.'
+    ))
+  }
+
   interpolate_file(path, ..., .envir = .envir)
 }
 
 read_file <- function(path) {
-  file_contents <- readChar(path, file.size(path))
+  readChar(path, file.size(path))
 }
 
 # Prompt class -----------------------------------------------------------------

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -67,16 +67,16 @@ interpolate_package <- function(
 ) {
   check_string(path)
 
-  path <- system.file("prompts", path, package = package)
+  path_pkg <- system.file("prompts", path, package = package)
 
-  if (!nzchar(path)) {
+  if (!nzchar(path_pkg)) {
     cli::cli_abort(c(
       "{.pkg {package}} does not have {.val {path}} in its {.field prompts/} directory.",
       "i" = 'Run {.run dir(system.file("prompts", package = "{package}"))} to see available prompts.'
     ))
   }
 
-  interpolate_file(path, ..., .envir = .envir)
+  interpolate_file(path_pkg, ..., .envir = .envir)
 }
 
 read_file <- function(path) {

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -7,7 +7,7 @@
 #'
 #' * `interpolate()` works with a string.
 #' * `interpolate_file()` works with a file.
-#' * `interpolate_package()` works with a file in the `insts/prompt`
+#' * `interpolate_package()` works with a file in the `inst/prompts`
 #'   directory of a package.
 #'
 #' Compared to glue, dynamic values should be wrapped in `{{ }}`, making it
@@ -46,7 +46,8 @@ interpolate <- function(prompt, ..., .envir = parent.frame()) {
   ellmer_prompt(out)
 }
 
-#' @param path A path to a prompt file (often a `.md`).
+#' @param path A path to a prompt file (often a `.md`). In
+#'   `interpolate_package()`, this path is relative to `inst/prompts`.
 #' @rdname interpolate
 #' @export
 interpolate_file <- function(path, ..., .envir = parent.frame()) {

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -80,6 +80,12 @@ interpolate_package <- function(
 }
 
 read_file <- function(path) {
+  if (!file.exists(path)) {
+    cli::cli_abort(
+      "{.arg path} {.path {path}} does not exist.",
+      call = caller_env()
+    )
+  }
   readChar(path, file.size(path))
 }
 

--- a/man/interpolate.Rd
+++ b/man/interpolate.Rd
@@ -23,7 +23,8 @@ code.}
 wrapping in another function. See \code{vignette("wrappers", package = "glue")}
 for more details.}
 
-\item{path}{A path to a prompt file (often a \code{.md}).}
+\item{path}{A path to a prompt file (often a \code{.md}). In
+\code{interpolate_package()}, this path is relative to \code{inst/prompts}.}
 
 \item{package}{Package name.}
 }
@@ -37,7 +38,7 @@ dynamic data into a static prompt:
 \itemize{
 \item \code{interpolate()} works with a string.
 \item \code{interpolate_file()} works with a file.
-\item \code{interpolate_package()} works with a file in the \code{insts/prompt}
+\item \code{interpolate_package()} works with a file in the \code{inst/prompts}
 directory of a package.
 }
 

--- a/tests/testthat/_snaps/interpolate.md
+++ b/tests/testthat/_snaps/interpolate.md
@@ -41,3 +41,17 @@
       [2] | a
           | ...
 
+# errors if the path does not exist
+
+    Code
+      interpolate_file("does-not-exist.md", x = 1)
+    Condition
+      Error in `interpolate_file()`:
+      ! `path` 'does-not-exist.md' does not exist.
+    Code
+      interpolate_package("ellmer", "does-not-exist.md", x = 1)
+    Condition
+      Error in `interpolate_package()`:
+      ! ellmer does not have "does-not-exist.md" in its prompts/ directory.
+      i Run `dir(system.file("prompts", package = "ellmer"))` to see available prompts.
+

--- a/tests/testthat/test-interpolate.R
+++ b/tests/testthat/test-interpolate.R
@@ -52,3 +52,10 @@ test_that("can interpolate from a package", {
 
   expect_equal(interpolate_package("test", "bar.md", x = 1), ellmer_prompt("1"))
 })
+
+test_that("errors if the path does not exist", {
+  expect_snapshot(error = TRUE, {
+    interpolate_file("does-not-exist.md", x = 1)
+    interpolate_package("ellmer", "does-not-exist.md", x = 1)
+  })
+})


### PR DESCRIPTION
* Updates the `interpolate_package()` docs to correct `inst/prompts` path
* Adds a check that the package prompt path exists and throw with informative error if not.
* Adds checks that `path` is scalar in `interpolate_package()` and `interpolate_file()`.

## Before

Before this PR, `interpolate_package()` falis with an error about `invalid "nchars" argument` because `system.file()` returns `""` for a missing path and `file.size("")` returns `NA`.

``` r
library(ellmer)

interpolate_package("btw", "missing.md")
#> Warning in file(con, "rb"): file("") only supports open = "w+" and open =
#> "w+b": using the former
#> Warning in readChar(path, file.size(path)): text connection used with
#> readChar(), results may be incorrect
#> Error in readChar(path, file.size(path)): invalid 'nchars' argument
```

In Positron at least, you typically only see the `nchars` part, like this

```
Error in `readChar()`:
! invalid 'nchars' argument
```

which is confusing -- my first thought is usually that I've done something wrong with the template strings.

## After

``` r
pkgload::load_all()
#> ℹ Loading ellmer

interpolate_package("btw", "missing.md")
#> Error in `interpolate_package()`:
#> ! btw does not have "missing.md" in its prompts/ directory.
#> ℹ Run `dir(system.file("prompts", package = "btw"))` to see available prompts.
```
