### PR TITLE
Fix #754: remove hard-coded 1:2 column limit in chat.R

### DIFF
--- a/R/chat.R
+++ b/R/chat.R
@@ -132,7 +132,7 @@ Chat <- R6::R6Class(
       # Combine counts for input tokens (cached and uncached)
       tokens_acc[, 1] <- tokens_acc[, 1] + tokens_acc[, 3]
       # Then drop cached tokens counts
-      tokens_acc <- tokens_acc[, 1:2]
+      tokens_acc <- tokens_acc[, , drop = FALSE]
 
       tokens <- tokens_acc
       if (n > 1) {


### PR DESCRIPTION
Previously, the code `tokens_acc[, 1:2]` truncated the output to only the first two columns, causing chat_structured_parallel() and convert_from_type() to return only two rows.  

The change removes this hard-coded limit, ensuring all columns are retained. 

Closes #754.
