### PR TITLE
fix(ellmer_prompt): Truncate lines and items individually

### DIFF
--- a/tests/testthat/_snaps/interpolate.md
+++ b/tests/testthat/_snaps/interpolate.md
@@ -31,7 +31,6 @@
     Output
       [1] | x
           | y
-          | ...
       ... and 1 more.
     Code
       print(prompt, max_lines = 3)
@@ -39,7 +38,14 @@
       [1] | x
           | y
       [2] | a
-          | ...
+          | ...and 4 more lines.
+    Code
+      print(ellmer_prompt("a\nb\nc\nd\ne"), max_lines = 3)
+    Output
+      [1] | a
+          | b
+          | c
+          | ...and 2 more lines.
 
 # errors if the path does not exist
 

--- a/tests/testthat/test-interpolate.R
+++ b/tests/testthat/test-interpolate.R
@@ -22,6 +22,7 @@ test_that("print method truncates many elements", {
     print(prompt, max_items = 1)
     print(prompt, max_lines = 2)
     print(prompt, max_lines = 3)
+    print(ellmer_prompt("a\nb\nc\nd\ne"), max_lines = 3)
   })
 })
 


### PR DESCRIPTION
Fixes a small bug in `print.ellmer_prompt()` to correctly truncate lines and items independently.

I noticed this by using `ellmer::interpolate_file()` to read in a prompt with >200 lines.

## Before

```r
ellmer::interpolate(paste(letters, collapse = "\n")) |> 
  print(max_lines = 3)
#> [1] │ a
#>     │ b
#>     │ c
#>     │ ...
#> Error in if (n_extra > 0) {: missing value where TRUE/FALSE needed
```

## After

```r
ellmer::interpolate(paste(letters, collapse = "\n")) |> 
  print(max_lines = 3)
#> [1] │ a
#>     │ b
#>     │ c
#>     │ ...and 23 more lines.
```