### PR TITLE
Github openai compatibility 

### DIFF
--- a/R/provider-github.R
+++ b/R/provider-github.R
@@ -51,7 +51,8 @@ chat_github <- function(
   # https://docs.github.com/en/rest/models/inference?apiVersion=2022-11-28
   params <- params %||% params()
 
-  chat_openai(
+  chat_openai_compatible(
+    name = "GitHub",
     system_prompt = system_prompt,
     base_url = base_url,
     credentials = credentials,
@@ -92,7 +93,8 @@ models_github <- function(
   provider <- ProviderOpenAI(
     name = "github",
     model = "",
-    credentials = credentials
+    credentials = credentials,
+    base_url = base_url
   )
 
   req <- base_request(provider)


### PR DESCRIPTION
This pull request updates the GitHub provider integration to improve compatibility and configuration flexibility. The main changes involve switching to a more compatible chat function and ensuring the provider is initialized with the correct base URL.

Provider compatibility and configuration:

* Updated the `chat_github` function to use `chat_openai_compatible` instead of `chat_openai`, and explicitly set the provider name to "GitHub" for better compatibility.
* Modified the `models_github` function to pass the `base_url` parameter when initializing the `ProviderOpenAI` object, ensuring requests are directed to the correct endpoint.