### PR TITLE
fix: handle NULL service_tier in get_token_cost (#903)

### DIFF
--- a/R/tokens.R
+++ b/R/tokens.R
@@ -115,6 +115,9 @@ has_cost <- function(provider, model) {
 }
 
 get_token_cost <- function(provider, tokens, variant = "") {
+  # FIX: Ensure variant is not NULL (Fixes #903)
+  variant <- variant %||% ""
+
   needle <- data.frame(
     provider = provider@name,
     model = provider@model,


### PR DESCRIPTION
This PR fixes issue #903 where get_token_cost() crashes if the API response contains a NULL service_tier. Added a fallback to ensure variant is initialized to "".