### PR TITLE
chore: Fix `.claude/settings.json`

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
       "Bash(R:*)",
       "Bash(rm:*)",
       "Bash(air format:*)",
-      "Edit(**)",
+      "Edit"
     ],
     "deny": []
   }


### PR DESCRIPTION
Fixes a trailing comma that causes a syntax error in the allowed tools array that makes Claude Code complain on startup