### PR TITLE
feat(aws): Support reasoning/thinking content for extended thinking

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ellmer (development version)
 
+* `chat_aws_bedrock()` now supports reasoning/thinking content. To enable thinking in Anthropic Claude models, see the `api_args` argument in `?chat_aws_bedrock` for an example (#964).
 * New `chat_lmstudio()` and `models_lmstudio()` provide support for [LM Studio](https://lmstudio.ai), a local model server with an OpenAI-compatible API (#963).
 * Fixed three bugs that caused errors when streaming web search results: Claude's `citations_delta` events were mishandled, `server_tool_use` input wasn't parsed from JSON during streaming, and OpenAI's `web_search_call` failed for non-search action types like `open_page` (#941).
 * `chat_aws_bedrock()` gains a `cache` parameter for prompt caching. The default, `"auto"`, enables caching for models known to support it (Anthropic Claude and Amazon Nova) and disables it otherwise (#954).

--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -53,18 +53,21 @@ NULL
 #'   `model="us.anthropic.claude-sonnet-4-5-20250929-v1:0"`.
 #' @param params Common model parameters, usually created by [params()].
 #' @param api_args Named list of arbitrary extra arguments appended to the body
-#'   of every chat API call. Some useful arguments include:
+#'   of every chat API call. Use `params` for common parameters. Model-specific
+#'   inference parameters can be provided using the
+#'   `additionalModelRequestFields` field, for example to enable thinking effort
+#'   in Anthropic Claude models:
 #'
 #'   ```R
 #'   api_args = list(
-#'     inferenceConfig = list(
-#'       maxTokens = 100,
-#'       temperature = 0.7,
-#'       topP = 0.9,
-#'       topK = 20
+#'     additionalModelRequestFields = list(
+#'       thinking = list(type = "enabled", budget_tokens = 4000)
 #'     )
 #'   )
 #'   ```
+#'
+#'   See <https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-call.html>
+#'   for more details.
 #' @inheritParams chat_openai
 #' @inherit chat_openai return
 #' @family chatbots
@@ -337,14 +340,26 @@ method(stream_merge_chunks, ProviderAWSBedrock) <- function(
   } else if (chunk$event_type == "contentBlockStart") {
     result$content[[i]] <- list(toolUse = chunk$start$toolUse)
   } else if (chunk$event_type == "contentBlockDelta") {
+    if (i > length(result$content)) {
+      result$content[[i]] <- list()
+    }
     if (has_name(chunk$delta, "text")) {
-      if (i > length(result$content)) {
-        result$content[[i]] <- list(text = chunk$delta$text)
-      } else {
-        paste(result$content[[i]]$text) <- chunk$delta$text
-      }
+      paste(result$content[[i]]$text) <- chunk$delta$text
     } else if (has_name(chunk$delta, "toolUse")) {
       paste(result$content[[i]]$toolUse$input) <- chunk$delta$toolUse$input
+    } else if (has_name(chunk$delta, "reasoningContent")) {
+      if (is.null(result$content[[i]]$reasoningContent)) {
+        result$content[[i]]$reasoningContent <- list(reasoningText = list())
+      }
+      # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlockDelta.html
+      delta <- chunk$delta$reasoningContent
+      if (has_name(delta, "text")) {
+        paste(result$content[[i]]$reasoningContent$reasoningText$text) <-
+          delta$text
+      } else if (has_name(delta, "signature")) {
+        result$content[[i]]$reasoningContent$reasoningText$signature <-
+          delta$signature
+      }
     } else {
       cli::cli_abort(
         "Unknown chunk type {names(chunk$delta)}",
@@ -403,6 +418,13 @@ method(value_turn, ProviderAWSBedrock) <- function(
           id = content$toolUse$toolUseId
         )
       }
+    } else if (has_name(content, "reasoningContent")) {
+      ContentThinking(
+        content$reasoningContent$reasoningText$text,
+        extra = list(
+          signature = content$reasoningContent$reasoningText$signature
+        )
+      )
     } else {
       cli::cli_abort(
         "Unknown content type {.str {names(content)}}.",
@@ -542,6 +564,25 @@ method(as_json, list(ProviderAWSBedrock, ToolDef)) <- function(
       name = x@name,
       description = x@description,
       inputSchema = list(json = compact(as_json(provider, x@arguments, ...)))
+    )
+  )
+}
+
+method(as_json, list(ProviderAWSBedrock, ContentThinking)) <- function(
+  provider,
+  x,
+  ...
+) {
+  if (identical(x@thinking, "")) {
+    return()
+  }
+
+  list(
+    reasoningContent = list(
+      reasoningText = list(
+        text = x@thinking,
+        signature = x@extra$signature
+      )
     )
   )
 }

--- a/man/chat_aws_bedrock.Rd
+++ b/man/chat_aws_bedrock.Rd
@@ -48,17 +48,20 @@ See details below.}
 \item{params}{Common model parameters, usually created by \code{\link[=params]{params()}}.}
 
 \item{api_args}{Named list of arbitrary extra arguments appended to the body
-of every chat API call. Some useful arguments include:
+of every chat API call. Use \code{params} for common parameters. Model-specific
+inference parameters can be provided using the
+\code{additionalModelRequestFields} field, for example to enable thinking effort
+in Anthropic Claude models:
 
 \if{html}{\out{<div class="sourceCode R">}}\preformatted{api_args = list(
-  inferenceConfig = list(
-    maxTokens = 100,
-    temperature = 0.7,
-    topP = 0.9,
-    topK = 20
+  additionalModelRequestFields = list(
+    thinking = list(type = "enabled", budget_tokens = 4000)
   )
 )
-}\if{html}{\out{</div>}}}
+}\if{html}{\out{</div>}}
+
+See \url{https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-call.html}
+for more details.}
 
 \item{api_headers}{Named character vector of arbitrary extra headers appended
 to every chat API call.}

--- a/man/chat_lmstudio.Rd
+++ b/man/chat_lmstudio.Rd
@@ -60,15 +60,18 @@ A \link{Chat} object.
 \description{
 To use \code{chat_lmstudio()} first download and install
 \href{https://lmstudio.ai}{LM Studio}. Then load a model using the LM Studio
-GUI and start the local server.
+GUI and start the local server. To learn more about running LM Studio
+locally, see \url{https://lmstudio.ai/docs/developer/core/server}/.
 
 Built on top of \code{\link[=chat_openai_compatible]{chat_openai_compatible()}}.
 }
 \examples{
 \dontrun{
-chat <- chat_lmstudio(model = "llama3.2")
+# https://lmstudio.ai/models/zai-org/glm-4.7-flash
+chat <- chat_lmstudio(model = "zai-org/glm-4.7-flash")
 chat$chat("Tell me three jokes about statisticians")
 }
+
 }
 \seealso{
 Other chatbots: 

--- a/tests/testthat/_vcr/aws-bedrock-thinking.yml
+++ b/tests/testthat/_vcr/aws-bedrock-thinking.yml
@@ -1,0 +1,41 @@
+http_interactions:
+- request:
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/converse
+    body:
+      string: '{"messages":[{"role":"user","content":[{"text":"Create a riddle for
+        data scientists"},{"cachePoint":{"type":"default"}}]}],"additionalModelRequestFields":{"thinking":{"type":"enabled","budget_tokens":4000}},"inferenceConfig":{"temperature":1}}'
+  response:
+    status: 200
+    headers:
+      date: Wed, 15 Apr 2026 13:52:22 GMT
+      content-type: application/json
+      content-length: '3614'
+      x-amzn-requestid: 99d9f126-4521-4354-a939-0fc0e161b473
+    body:
+      string: "{\"metrics\":{\"latencyMs\":9542},\"output\":{\"message\":{\"content\":[{\"reasoningContent\":{\"reasoningText\":{\"signature\":\"EpUJCkgIDBABGAIqQO8yqu3hAS47hyuJXjCieM6EpFjWLF4a2XvrLmPjpypVu19GUDZKYIctRGB8h002b+SqO5RP+MmioErKla/FEPgSDHBtdC+ajvWsjM8KpRoMnKXRO6OjPyh0eBiZIjDBJATdB6Ifi31ykjv30U6hyRTNyavjAxe0LCR0UdnHRrqRk7o4x3P51sQBQWkexp8q+gdRwtEMsmU5VOaAa9RhcMXAhKmah+72b2yjNxKzs8oe4v/JcGwm5Pzb48SkB5bzl9Q5XIocukX+yZYMn0wd1vfTDcWVqe9Ya+AHYl2MWjhN0f3Res/lEJ8lyvC6W0Y/gDjuaQ+TaYptoyHJ4rBDWad5JR0Rre3bBKdhnsmSvYlnTCl9pfrXClppGnDzqZH5MpilLp/7eaym7/7ah1mA1sqTTeN7Z6p3rB8H7Sanm8eerkLsxkFq2EfFsIwpjr17ZvYVoL/mwKLLujYcDEyGVXFJTd61MWc2IWRk0NXN/MxEqS3nW9H761uGPe+aOpKZ6r25yo0AvOJoqYioZv8rHlmF7+Z33mrdq1t7HIllbdtnt9bjEiHuqYSpIBuoJKugp5ebMfQz0xnrogHlI+EKQ0ryUgCOgcHmQCsgBVRxvhHRjlDskV9bkGwlR/Ag969efUcj5+39joUlO7+Z+i2gZyIqjF0UncJuP6kRFnyv7IppSY6sIT+912L7Acg7Xe6RonzPQmAWiMzK2Ca8II23Y4tFAme7VNaiAxSf98OO3a06E/bEpfVOrozFLGJp6x7Yl2bvEDbElxjPgVRJ9Fw5tkiBd0VuTmQtfuchZCycAUzKn3JLWJlbGqN212sEKQdN0baXmPL3z5ROPHnsGGxvoZ/iXn15/duO2QtLQMeBXXgS03eb/YTOLERExP0FGAc1akU6AepQaWRbp+wyVEuKvTcCaM75vbaNRChJ2eD2gsP/yG2c9hdUMA3TFFn1113Xy3pYQ+1kJ2+U9utugw0kD3ZKTL2IjYxst6ixVt4/pN7/Oz7rt2I4o8SvoZjigSK/pm0OpUjsFz2niMAR9XcEUrGIqLTvk/GfKpRqngyqXAMchLG0WXGnuys3H4v6hNKow7zGJdvUCO6zopP/gjnX7UUv3ARDyCusI1a71YoL51COqxwB5tLnbwbKTyFvhEI/58rRH8XjArKheNYZon2fhURurDunyG54zD1mVzZJ/HQtUOfHvJKCzUzt70uXRyzoACwRZFk60VQHQ2b3GceK7Hf0VXSJdMV1WHiZ5gSR+0c/LQwedpIxRyuf2QhGX4Zuv6KNW53vGkZOFl94MVZcb1uWBMl0BwsJX2yeC6UXoZ4mwqNZ5F0pV4vje77Ep6aIKR2/lPkf7DZEAMTpJHU+n1017v/AcNc4w9MYW71j5/eIUyeD6cypBWmZTzN1nr6oZPuEIOxTr0xyMZHVZB3S4NuuEg68Vs2AnUPMAofbjnx7Opj8QFzdlPCPcPmvtFnVMy5rPXpeIMU+wCK96336171FLyup4FlUwBcf2vIgES/NTuvA9VfZRIxYJ5QRtrXPMVPLLC7dZdQkrA81GAE=\",\"text\":\"I'll
+        create a riddle that incorporates data science concepts and terminology in
+        a clever way. Let me think of something that would appeal to data scientists
+        and uses their domain knowledge.\\n\\nHere's my riddle:\\n\\nI have no bias,
+        yet I overfit with ease,\\nI branch out widely, but I'm not the trees.\\nPrune
+        me back gently to help me generalize,\\nRandom forests need me, despite my
+        size.\\n\\nWhat am I?\\n\\nAnswer: A Decision Tree\\n\\nLet me make sure this
+        works:\\n- \\\"No bias\\\" - decision trees can have low bias\\n- \\\"Overfit
+        with ease\\\" - they're prone to overfitting\\n- \\\"Branch out widely\\\"
+        - they have branches/splits\\n- \\\"Not the trees\\\" - misdirection, but
+        also referencing that a single tree isn't a forest\\n- \\\"Prune me back\\\"
+        - pruning is a technique to reduce overfitting in decision trees\\n- \\\"Help
+        me generalize\\\" - pruning helps with generalization\\n- \\\"Random forests
+        need me\\\" - random forests are made of decision trees\\n\\nThis seems like
+        a good riddle for data scientists! It uses their jargon and concepts in a
+        playful way.\"}}},{\"text\":\"# A Data Science Riddle\\n\\n*I have no bias,
+        yet overfit with ease,*  \\n*I branch out widely, but I'm not the trees.*
+        \ \\n*Prune me back gently to help me generalize,*  \\n*Random forests need
+        me, despite my size.*\\n\\n**What am I?**\\n\\n<details>\\n<summary>Click
+        for answer</summary>\\n\\n**A Decision Tree** \U0001F333\\n\\n</details>\\n\\n---\\n\\n**Bonus
+        riddle:**\\n\\n*I'm measured but never touched,*  \\n*Without me, your model's
+        a crutch.*  \\n*Split me three ways if you're being cautious,*  \\n*Train,
+        validate, test—though the order might nauseous.*\\n\\n<details>\\n<summary>Click
+        for answer</summary>\\n\\n**Data/Dataset**\\n\\n</details>\"}],\"role\":\"assistant\"}},\"stopReason\":\"end_turn\",\"usage\":{\"cacheReadInputTokenCount\":0,\"cacheReadInputTokens\":0,\"cacheWriteInputTokenCount\":0,\"cacheWriteInputTokens\":0,\"inputTokens\":43,\"outputTokens\":459,\"serverToolUsage\":{},\"totalTokens\":502}}"
+  recorded_at: 2026-04-15 13:52:22
+recorded_with: VCR-vcr/2.0.0

--- a/tests/testthat/test-provider-aws.R
+++ b/tests/testthat/test-provider-aws.R
@@ -192,6 +192,29 @@ test_that("bedrock_cache_point() is added to the system prompt", {
   expect_equal(bedrock_cache_point(provider_none), list())
 })
 
+# Reasoning / thinking content --------------------------------------------
+
+test_that("can use extended thinking", {
+  vcr::local_cassette("aws-bedrock-thinking")
+
+  chat <- chat_aws_bedrock_test(
+    params = params(temperature = 1),
+    api_args = list(
+      additionalModelRequestFields = list(
+        thinking = list(type = "enabled", budget_tokens = 4000)
+      )
+    ),
+    model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+  )
+  resp <- chat$chat("Create a riddle for data scientists", echo = FALSE)
+
+  contents <- chat$last_turn()@contents
+  thinking <- Filter(\(x) S7::S7_inherits(x, ContentThinking), contents)
+  expect_length(thinking, 1)
+  expect_gt(nchar(thinking[[1]]@thinking), 0)
+  expect_match(resp, "\\S")
+})
+
 # Provider idiosynchronies -----------------------------------------------
 
 test_that("continues to work after whitespace only outputs (#376)", {


### PR DESCRIPTION
Fixes #964

## Summary

Adds support for `reasoningContent` blocks in the AWS Bedrock provider, enabling extended thinking in Anthropic Claude models hosted on Bedrock.

- **Streaming:** `stream_merge_chunks()` now handles `reasoningContent` deltas (both `text` and `signature` sub-fields), accumulating them alongside text and tool-use blocks.
- **Turn parsing:** `value_turn()` converts `reasoningContent` blocks in Bedrock responses into `ContentThinking` objects, making thinking content accessible on `chat$last_turn()@contents`.
- **Round-trip serialization:** A new `as_json(ProviderAWSBedrock, ContentThinking)` method serializes `ContentThinking` back to the `reasoningContent` wire format (including the opaque `signature` field required by Bedrock for multi-turn conversations).
- **Documentation:** Updates `?chat_aws_bedrock` `api_args` example to show how to enable thinking via `additionalModelRequestFields`.

## Verification

Enable extended thinking by passing `additionalModelRequestFields` in `api_args`:

```r
chat <- chat_aws_bedrock(
  params = params(temperature = 1),
  api_args = list(
    additionalModelRequestFields = list(
      thinking = list(type = "enabled", budget_tokens = 4000)
    )
  ),
  model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
)
```

Unfortunately, I think the shape of `additionalModelRequestFields` is going depend on the specific model being used, which is why I did not try to wire this up through `params()`.

```r
# Streaming
chat$chat("Create a riddle for data scientists")
chat
#> <Chat AWS/Bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0 turns=2 input=43 output=520>
#> ── user ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
#> Create a riddle for data scientists
#> ── assistant [input=43 output=520] ──────────────────────────────────────────────────────────────────────────────────────────────────────────
#> <thinking>
#> Let me create a riddle that would appeal to data scientists...
#> </thinking>
#>
#> I live in forests but have no roots...

# Conversation can be continued
chat$chat("that was funny!")

# Non-streaming
chat$set_turns(list())
chat$chat("Create a riddle for data scientists", echo = "none")
```