### PR TITLE
Add ContentThinking support to OpenAI-compatible providers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -131,3 +131,4 @@ Collate:
     'utils.R'
     'zzz.R'
 Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -131,4 +131,3 @@ Collate:
     'utils.R'
     'zzz.R'
 Config/roxygen2/version: 8.0.0
-RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ellmer (development version)
 
+* `chat_openai_compatible()` now extracts `reasoning_content` from model responses (both streaming and non-streaming) as `ContentThinking` objects. A new `preserve_thinking` parameter controls whether reasoning content is sent back to the API in multi-turn conversations; it defaults to `FALSE` (matching DeepSeek's requirement) but is set to `TRUE` for `chat_openrouter()` (#972).
 * ellmer is now instrumented with OpenTelemetry, so that traces are emitted whenever the (suggested) `otel` package is installed and a tracer is active.
 
   Each call to `$chat()`, `$chat_async()`, `$stream()`, or `$stream_async()` produces a top-level `invoke_agent` span that wraps one or more child `chat <model>` spans (one per request to the provider) and `execute_tool <tool>` spans (one per tool invocation). Chat spans record the provider name, request model, response model, and response id, plus input and output token usage; tool spans record the tool name, description, call id, and any error raised during execution. HTTP spans from httr2 are automatically nested under the chat spans (#526).
@@ -11,7 +12,6 @@
 * `chat_anthropic()` no longer applies a hidden 1.25x pricing weight to cache-creation tokens; the input token counts reported by `token_usage()` and `parallel_chat()` are now raw counts. Cost calculations are unchanged.
 * `chat_aws_bedrock()` now supports reasoning/thinking content. To enable thinking in Anthropic Claude models, see the `api_args` argument in `?chat_aws_bedrock` for an example (#964).
 * `chat_aws_bedrock()` gains a `cache` parameter for prompt caching. The default, `"auto"`, enables caching for models known to support it (Anthropic Claude and Amazon Nova) and disables it otherwise (#954).
-* `chat_openai_compatible()` now extracts `reasoning_content` from model responses (both streaming and non-streaming) as `ContentThinking` objects. A new `preserve_thinking` parameter controls whether reasoning content is sent back to the API in multi-turn conversations; it defaults to `FALSE` (matching DeepSeek's requirement) but is set to `TRUE` for `chat_openrouter()` (#972).
 * `chat_databricks()` (and other `chat_openai_compatible()` providers) no longer fail with HTTP 400 when the conversation history contains empty `ContentText("")` objects, which can occur during tool calling (@JamesHWade, #932).
 * `chat_github()` now uses `chat_openai_compatible()` for improved compatibility and `models_github()` now supports custom `base_url` configuration (@D-M4rk, #877).
 * `chat_groq()` now supports structured chat (@CoryMcCartan, #930).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,5 @@
 # ellmer (development version)
 
-* `chat_openai_compatible()` now extracts `reasoning_content` from model responses (both streaming and non-streaming) as `ContentThinking` objects. A new `preserve_thinking` parameter controls whether reasoning content is sent back to the API in multi-turn conversations; it defaults to `FALSE` (matching DeepSeek's requirement) but is set to `TRUE` for `chat_openrouter()` (#972).
 * ellmer is now instrumented with OpenTelemetry, so that traces are emitted whenever the (suggested) `otel` package is installed and a tracer is active.
 
   Each call to `$chat()`, `$chat_async()`, `$stream()`, or `$stream_async()` produces a top-level `invoke_agent` span that wraps one or more child `chat <model>` spans (one per request to the provider) and `execute_tool <tool>` spans (one per tool invocation). Chat spans record the provider name, request model, response model, and response id, plus input and output token usage; tool spans record the tool name, description, call id, and any error raised during execution. HTTP spans from httr2 are automatically nested under the chat spans (#526).
@@ -12,6 +11,7 @@
 * `chat_anthropic()` no longer applies a hidden 1.25x pricing weight to cache-creation tokens; the input token counts reported by `token_usage()` and `parallel_chat()` are now raw counts. Cost calculations are unchanged.
 * `chat_aws_bedrock()` now supports reasoning/thinking content. To enable thinking in Anthropic Claude models, see the `api_args` argument in `?chat_aws_bedrock` for an example (#964).
 * `chat_aws_bedrock()` gains a `cache` parameter for prompt caching. The default, `"auto"`, enables caching for models known to support it (Anthropic Claude and Amazon Nova) and disables it otherwise (#954).
+* `chat_openai_compatible()` now extracts `reasoning_content` from model responses (both streaming and non-streaming) as `ContentThinking` objects. A new `preserve_thinking` parameter controls whether reasoning content is sent back to the API in multi-turn conversations; it defaults to `FALSE` (matching DeepSeek's requirement) but is set to `TRUE` for `chat_openrouter()` (#972).
 * `chat_databricks()` (and other `chat_openai_compatible()` providers) no longer fail with HTTP 400 when the conversation history contains empty `ContentText("")` objects, which can occur during tool calling (@JamesHWade, #932).
 * `chat_github()` now uses `chat_openai_compatible()` for improved compatibility and `models_github()` now supports custom `base_url` configuration (@D-M4rk, #877).
 * `chat_groq()` now supports structured chat (@CoryMcCartan, #930).

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * `chat_anthropic()` no longer applies a hidden 1.25x pricing weight to cache-creation tokens; the input token counts reported by `token_usage()` and `parallel_chat()` are now raw counts. Cost calculations are unchanged.
 * `chat_aws_bedrock()` now supports reasoning/thinking content. To enable thinking in Anthropic Claude models, see the `api_args` argument in `?chat_aws_bedrock` for an example (#964).
 * `chat_aws_bedrock()` gains a `cache` parameter for prompt caching. The default, `"auto"`, enables caching for models known to support it (Anthropic Claude and Amazon Nova) and disables it otherwise (#954).
+* `chat_openai_compatible()` now extracts `reasoning_content` from model responses (both streaming and non-streaming) as `ContentThinking` objects. A new `preserve_thinking` parameter controls whether reasoning content is sent back to the API in multi-turn conversations; it defaults to `FALSE` (matching DeepSeek's requirement) but is set to `TRUE` for `chat_openrouter()` (#972).
 * `chat_databricks()` (and other `chat_openai_compatible()` providers) no longer fail with HTTP 400 when the conversation history contains empty `ContentText("")` objects, which can occur during tool calling (@JamesHWade, #932).
 * `chat_github()` now uses `chat_openai_compatible()` for improved compatibility and `models_github()` now supports custom `base_url` configuration (@D-M4rk, #877).
 * `chat_groq()` now supports structured chat (@CoryMcCartan, #930).

--- a/R/provider-openai-compatible.R
+++ b/R/provider-openai-compatible.R
@@ -242,7 +242,14 @@ method(stream_content, ProviderOpenAICompatible) <- function(provider, event) {
   if (length(event$choices) == 0) {
     return(NULL)
   }
-  text <- event$choices[[1]]$delta[["content"]]
+  delta <- event$choices[[1]]$delta
+
+  reasoning <- delta[["reasoning_content"]]
+  if (!is.null(reasoning)) {
+    return(ContentThinking(reasoning))
+  }
+
+  text <- delta[["content"]]
   if (is.null(text)) {
     return(NULL)
   }
@@ -283,6 +290,12 @@ method(value_turn, ProviderOpenAICompatible) <- function(
     message <- result$choices[[1]]$message
   }
 
+  thinking <- list()
+  reasoning <- message$reasoning_content
+  if (is_string(reasoning) && nzchar(reasoning)) {
+    thinking <- list(ContentThinking(reasoning))
+  }
+
   if (has_type) {
     if (is_string(message$content)) {
       content <- list(ContentJson(string = message$content[[1]]))
@@ -310,6 +323,8 @@ method(value_turn, ProviderOpenAICompatible) <- function(
     })
     content <- c(content, calls)
   }
+
+  content <- c(thinking, content)
 
   tokens <- value_tokens(provider, result)
   cost <- get_token_cost(provider, tokens)
@@ -359,14 +374,23 @@ method(as_json, list(ProviderOpenAICompatible, Turn)) <- function(
     if (length(contents) == 0) {
       return(NULL)
     }
-    # Tool requests come out of content and go into own argument
+    # Thinking and tool requests come out of content
+    is_thinking <- map_lgl(contents, S7_inherits, ContentThinking)
     is_tool <- map_lgl(contents, is_tool_request)
-    content <- as_json(provider, contents[!is_tool], ...)
+    other <- contents[!is_thinking & !is_tool]
+    content <- as_json(provider, other, ...)
     tool_calls <- as_json(provider, contents[is_tool], ...)
+
+    reasoning_content <- NULL
+    thinking_texts <- map_chr(contents[is_thinking], function(c) c@thinking)
+    if (length(thinking_texts) > 0) {
+      reasoning_content <- paste0(thinking_texts, collapse = "")
+    }
 
     list(
       compact(list(
         role = "assistant",
+        reasoning_content = reasoning_content,
         content = content,
         tool_calls = tool_calls
       ))

--- a/R/provider-openai-compatible.R
+++ b/R/provider-openai-compatible.R
@@ -31,6 +31,11 @@ NULL
 #'   with [modifyList()].
 #' @param api_headers Named character vector of arbitrary extra headers appended
 #'   to every chat API call.
+#' @param preserve_thinking If `TRUE`, reasoning content returned by the model
+#'   is included when sending conversation history back to the API. If `FALSE`
+#'   (the default), reasoning content is still captured in the turn but dropped
+#'   from subsequent requests. Set to `TRUE` if your provider requires or
+#'   benefits from seeing prior reasoning in multi-turn conversations.
 #' @param echo One of the following options:
 #'   * `none`: don't emit any output (default when running in a function).
 #'   * `output`: echo text and tool-calling output as it streams in (default
@@ -60,6 +65,7 @@ chat_openai_compatible <- function(
   params = NULL,
   api_args = list(),
   api_headers = character(),
+  preserve_thinking = FALSE,
   echo = c("none", "output", "all")
 ) {
   if (missing(base_url)) {
@@ -95,7 +101,8 @@ chat_openai_compatible <- function(
     params = params %||% params(),
     extra_args = api_args,
     extra_headers = api_headers,
-    credentials = credentials
+    credentials = credentials,
+    preserve_thinking = preserve_thinking
   )
   Chat$new(provider = provider, system_prompt = system_prompt, echo = echo)
 }
@@ -126,7 +133,10 @@ chat_openai_compatible_test <- function(
 
 ProviderOpenAICompatible <- new_class(
   "ProviderOpenAICompatible",
-  parent = Provider
+  parent = Provider,
+  properties = list(
+    preserve_thinking = new_property(class_logical, default = FALSE)
+  )
 )
 
 openai_key_exists <- function() {
@@ -382,9 +392,11 @@ method(as_json, list(ProviderOpenAICompatible, Turn)) <- function(
     tool_calls <- as_json(provider, contents[is_tool], ...)
 
     reasoning_content <- NULL
-    thinking_texts <- map_chr(contents[is_thinking], function(c) c@thinking)
-    if (length(thinking_texts) > 0) {
-      reasoning_content <- paste0(thinking_texts, collapse = "")
+    if (provider@preserve_thinking) {
+      thinking_texts <- map_chr(contents[is_thinking], function(c) c@thinking)
+      if (length(thinking_texts) > 0) {
+        reasoning_content <- paste0(thinking_texts, collapse = "")
+      }
     }
 
     list(

--- a/R/provider-openrouter.R
+++ b/R/provider-openrouter.R
@@ -51,7 +51,8 @@ chat_openrouter <- function(
     params = params,
     extra_args = api_args,
     credentials = credentials,
-    extra_headers = api_headers
+    extra_headers = api_headers,
+    preserve_thinking = TRUE
   )
   Chat$new(provider = provider, system_prompt = system_prompt, echo = echo)
 }

--- a/man/chat_openai_compatible.Rd
+++ b/man/chat_openai_compatible.Rd
@@ -14,6 +14,7 @@ chat_openai_compatible(
   params = NULL,
   api_args = list(),
   api_headers = character(),
+  preserve_thinking = FALSE,
   echo = c("none", "output", "all")
 )
 }
@@ -41,6 +42,12 @@ with \code{\link[=modifyList]{modifyList()}}.}
 
 \item{api_headers}{Named character vector of arbitrary extra headers appended
 to every chat API call.}
+
+\item{preserve_thinking}{If \code{TRUE}, reasoning content returned by the model
+is included when sending conversation history back to the API. If \code{FALSE}
+(the default), reasoning content is still captured in the turn but dropped
+from subsequent requests. Set to \code{TRUE} if your provider requires or
+benefits from seeing prior reasoning in multi-turn conversations.}
 
 \item{echo}{One of the following options:
 \itemize{

--- a/tests/testthat/test-provider-openai-compatible.R
+++ b/tests/testthat/test-provider-openai-compatible.R
@@ -194,8 +194,28 @@ test_that("value_turn extracts reasoning_content", {
   expect_equal(turn@contents[[2]]@text, "The answer is 42.")
 })
 
-test_that("as_json includes reasoning_content from ContentThinking", {
+test_that("as_json drops reasoning_content by default", {
   stub <- ProviderOpenAICompatible(name = "", base_url = "", model = "")
+
+  turn <- AssistantTurn(list(
+    ContentThinking("Let me think..."),
+    ContentText("The answer is 42.")
+  ))
+  result <- as_json(stub, turn)
+  expect_null(result[[1]]$reasoning_content)
+  expect_equal(
+    result[[1]]$content,
+    list(list(type = "text", text = "The answer is 42."))
+  )
+})
+
+test_that("as_json preserves reasoning_content when preserve_thinking = TRUE", {
+  stub <- ProviderOpenAICompatible(
+    name = "",
+    base_url = "",
+    model = "",
+    preserve_thinking = TRUE
+  )
 
   turn <- AssistantTurn(list(
     ContentThinking("Let me think..."),

--- a/tests/testthat/test-provider-openai-compatible.R
+++ b/tests/testthat/test-provider-openai-compatible.R
@@ -158,6 +158,57 @@ test_that("empty ContentText is stripped but tool requests are preserved", {
   expect_null(result[[1]]$content)
 })
 
+test_that("stream_content extracts reasoning_content", {
+  stub <- ProviderOpenAICompatible(name = "", base_url = "", model = "")
+
+  event <- list(choices = list(list(delta = list(reasoning_content = "think"))))
+  result <- stream_content(stub, event)
+  expect_s3_class(result, "ellmer::ContentThinking")
+  expect_equal(result@thinking, "think")
+
+  event <- list(choices = list(list(delta = list(content = "hello"))))
+  result <- stream_content(stub, event)
+
+  expect_s3_class(result, "ellmer::ContentText")
+  expect_equal(result@text, "hello")
+})
+
+test_that("value_turn extracts reasoning_content", {
+  stub <- ProviderOpenAICompatible(name = "", base_url = "", model = "")
+
+  result <- list(
+    choices = list(list(
+      message = list(
+        role = "assistant",
+        reasoning_content = "Let me think...",
+        content = "The answer is 42."
+      )
+    ))
+  )
+
+  turn <- value_turn(stub, result)
+  expect_equal(length(turn@contents), 2)
+  expect_s3_class(turn@contents[[1]], "ellmer::ContentThinking")
+  expect_equal(turn@contents[[1]]@thinking, "Let me think...")
+  expect_s3_class(turn@contents[[2]], "ellmer::ContentText")
+  expect_equal(turn@contents[[2]]@text, "The answer is 42.")
+})
+
+test_that("as_json includes reasoning_content from ContentThinking", {
+  stub <- ProviderOpenAICompatible(name = "", base_url = "", model = "")
+
+  turn <- AssistantTurn(list(
+    ContentThinking("Let me think..."),
+    ContentText("The answer is 42.")
+  ))
+  result <- as_json(stub, turn)
+  expect_equal(result[[1]]$reasoning_content, "Let me think...")
+  expect_equal(
+    result[[1]]$content,
+    list(list(type = "text", text = "The answer is 42."))
+  )
+})
+
 test_that("as_json specialised for OpenAI", {
   stub <- ProviderOpenAI(name = "", base_url = "", model = "")
 


### PR DESCRIPTION
## Summary

- Extract `reasoning_content` from streaming deltas and non-streaming responses in `ProviderOpenAICompatible`, producing `ContentThinking` objects in the assistant turn.
- Add a `preserve_thinking` parameter (default `FALSE`) that controls whether reasoning content is sent back to the API in multi-turn conversations. When `FALSE`, thinking is captured in the turn but filtered from subsequent requests.
- Set `preserve_thinking = TRUE` for OpenRouter, which recommends including reasoning traces in conversation history.

## Motivation

Providers disagree on whether reasoning traces should be included in multi-turn conversation history:

| Provider | Requirement |
|----------|------------|
| DeepSeek | **Must exclude** — returns 400 if `reasoning_content` is included in input messages |
| Fireworks AI | **Must include** — required for multi-turn tool-calling with thinking models |
| OpenRouter | **Should include** — recommended for quality, especially with tool-calling |
| Groq | Not documented |
| Together AI | Not documented |
| Azure, Cloudflare, Databricks, Portkey, Snowflake | Don't return `reasoning_content` in chat completions (N/A) |

The `preserve_thinking` parameter (default `FALSE`) lets each provider wrapper choose the correct behavior. The default matches DeepSeek's requirement since it's the most common reasoning model accessed via OpenAI-compatible APIs.

## Verification

```r
library(ellmer)

# With a reasoning model via OpenRouter
chat <- chat_openrouter(model = "deepseek/deepseek-r1")
chat$chat("What is 2+2? Think step by step.")
# ContentThinking appears in the turn
chat$last_turn()@contents
```