### PR TITLE
Fix tool calling in Snowflake provider

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * `chat_ollama()` now supports `params(top_k = )` (@frankiethull, #896).
 * `chat_openai()` no longer fails when streaming web search results for `web_search_call` action types other than `search` (e.g. `open_page`, `find_in_page`) (#941).
 * `chat_openai()` now uses the default prices if the service tier is missing (@trangdata, #903).
+* `chat_snowflake()` now correctly handles tool calling. Previously, when Snowflake's streaming API sent a tool-use chunk as the very first response (with no preceding text), the chunk merging logic produced malformed content, causing "argument is of length zero" errors (#938).
 * `default_google_credentials()` no longer skips application default credentials (e.g. `GOOGLE_APPLICATION_CREDENTIALS`) in interactive sessions, instead falling through to the OAuth browser flow only when no gargle token is available (@stefanlinner, #922).
 * `models_anthropic()` (and `models_claude()`) gains a `credentials` argument for consistency with `chat_anthropic()` and other `models_*()` functions (@jcrodriguez1989, #917).
 * New `stream_controller()` enables programmatic cancellation of streaming chat responses, e.g. from a Shiny "Cancel" button with `chat$stream()` or `chat$stream_async()`. Streaming turns are now saved incrementally so that partial responses survive cancellation, interrupts (Ctrl-C), and errors. Incomplete turns are recorded as `AssistantPartialTurn` objects, display as interrupted in the chat history, and are included in subsequent model context like complete turns (#643).

--- a/R/provider-snowflake.R
+++ b/R/provider-snowflake.R
@@ -323,6 +323,9 @@ method(as_json, list(ProviderSnowflakeCortex, Turn)) <- function(
     # tool result in textual format here, too -- otherwise it gets confused,
     # like it can't see the output.
     content <- tool_string(x@contents[[1]])
+  } else if (S7_inherits(x@contents[[1]], ContentToolRequest)) {
+    # Tool-only response (no preceding text).
+    content <- "<empty>"
   } else {
     cli::cli_abort("Unsupported content type: {.cls {class(x@contents[[1]])}}.")
   }

--- a/R/provider-snowflake.R
+++ b/R/provider-snowflake.R
@@ -160,6 +160,21 @@ method(chat_params, ProviderSnowflakeCortex) <- function(provider, params) {
 
 # Snowflake -> ellmer --------------------------------------------------------
 
+method(stream_content, ProviderSnowflakeCortex) <- function(provider, event) {
+  if (length(event$choices) == 0) {
+    return(NULL)
+  }
+  delta <- event$choices[[1]]$delta
+  if (is.null(delta) || !identical(delta$type, "text")) {
+    return(NULL)
+  }
+  text <- delta[["content"]] %||% delta[["text"]]
+  if (is.null(text) || !nzchar(text)) {
+    return(NULL)
+  }
+  ContentText(text)
+}
+
 method(stream_merge_chunks, ProviderSnowflakeCortex) <- function(
   provider,
   result,

--- a/R/provider-snowflake.R
+++ b/R/provider-snowflake.R
@@ -266,32 +266,37 @@ method(value_turn, ProviderSnowflakeCortex) <- function(
   has_type = FALSE
 ) {
   raw_content <- result$choices[[1]]$message$content_list
-  contents <- lapply(raw_content, function(content) {
-    if (identical(content$type, "text")) {
-      if (has_type) {
-        ContentJson(string = content$text)
+  contents <- compact(
+    lapply(raw_content, function(content) {
+      if (identical(content$type, "text")) {
+        if (!nzchar(content$text %||% "")) {
+          return(NULL)
+        }
+        if (has_type) {
+          ContentJson(string = content$text)
+        } else {
+          ContentText(content$text)
+        }
+      } else if (identical(content$type, "tool_use")) {
+        # Streaming produces flat format; non-streaming has nested tool_use
+        if (!is.null(content[["tool_use"]])) {
+          content <- content[["tool_use"]]
+        }
+        input <- content[["input"]] %||% ""
+        id <- content[["tool_use_id"]]
+        name <- content[["name"]]
+        if (is_string(input)) {
+          input <- jsonlite::parse_json(input)
+        }
+        ContentToolRequest(id, name, input %||% list())
       } else {
-        ContentText(content$text)
+        cli::cli_abort(
+          "Unknown content type {.str {content$type}}.",
+          .internal = TRUE
+        )
       }
-    } else if (identical(content$type, "tool_use")) {
-      # Streaming produces flat format; non-streaming has nested tool_use
-      if (!is.null(content[["tool_use"]])) {
-        content <- content[["tool_use"]]
-      }
-      input <- content[["input"]] %||% ""
-      id <- content[["tool_use_id"]]
-      name <- content[["name"]]
-      if (is_string(input)) {
-        input <- jsonlite::parse_json(input)
-      }
-      ContentToolRequest(id, name, input %||% list())
-    } else {
-      cli::cli_abort(
-        "Unknown content type {.str {content$type}}.",
-        .internal = TRUE
-      )
-    }
-  })
+    })
+  )
   tokens <- value_tokens(provider, result)
   cost <- get_token_cost(provider, tokens)
   AssistantTurn(contents, json = result, tokens = unlist(tokens), cost = cost)

--- a/R/provider-snowflake.R
+++ b/R/provider-snowflake.R
@@ -116,14 +116,16 @@ method(chat_body, ProviderSnowflakeCortex) <- function(
   }
 
   params <- chat_params(provider, provider@params)
-  compact(list2(
-    messages = messages,
-    model = provider@model,
-    !!!params,
-    stream = stream,
-    tools = tools,
-    response_format = response_format
-  ))
+  compact(
+    list2(
+      messages = messages,
+      model = provider@model,
+      !!!params,
+      stream = stream,
+      tools = tools,
+      response_format = response_format
+    )
+  )
 }
 
 method(as_json, list(ProviderSnowflakeCortex, TypeObject)) <- function(
@@ -163,46 +165,65 @@ method(stream_merge_chunks, ProviderSnowflakeCortex) <- function(
   result,
   chunk
 ) {
-  # We're aiming to make Snowflake's chunk format look the same as their non-
-  # chunked format here so downstream processing logic can be uniform. We are
-  # *not* trying to make it more sane.
-  if (is.null(result)) {
-    # Avoid multiple encodings for text content.
-    if (chunk$choices[[1]]$delta$type == "text") {
-      chunk$choices[[1]]$delta$type <- NULL
-      chunk$choices[[1]]$delta$text <- NULL
-    }
-    # Non-streaming responses use "message" instead of "delta".
-    chunk$choices[[1]]$message <- chunk$choices[[1]]$delta
-    chunk$choices[[1]]$delta <- NULL
-    return(chunk)
-  }
-  # Note: most fields are immutable between chunks and we can ignored updates.
-  # We only care about changes to `choices[[1]]$delta` and `usage`.
-  #
-  # Note also: there is no index support in Snowflake's chunk format, so we're
-  # always assuming we can operate on the first one, except in the special
-  # case of tool calls.
-  current <- result$choices[[1]]$message
   delta <- chunk$choices[[1]]$delta
-  if (delta$type == "text") {
-    paste(current$content_list[[1]]$text) <- delta$text
-    current[["content"]] <- current$content_list[[1]]$text
-  } else if (delta$type == "tool_use") {
-    # When we get a tool call, we need to append a second entry to the content
-    # list (again, since there is no index tracking).
-    if (length(current$content_list) == 1) {
-      current$content_list[[2]] <- list(
-        type = "tool_use",
-        tool_use = list(
+
+  if (is.null(result)) {
+    if (delta$type == "tool_use") {
+      content_list <- list(
+        list(
+          type = "tool_use",
           tool_use_id = delta$tool_use_id,
           name = delta$name,
-          input = delta$input
+          input = delta$input %||% ""
         )
       )
     } else {
-      # Otherwise we're appending to existing input.
-      paste(current$content_list[[2]]$tool_use$input) <- delta$input
+      content_list <- list(
+        list(
+          type = "text",
+          text = delta$text %||% ""
+        )
+      )
+    }
+    # Non-streaming responses use "message" instead of "delta".
+    chunk$choices[[1]]$message <- list(content_list = content_list)
+    chunk$choices[[1]]$delta <- NULL
+    return(chunk)
+  }
+
+  content_list <- result$choices[[1]]$message$content_list
+
+  if (delta$type == "text") {
+    text_idx <- NULL
+    for (i in rev(seq_along(content_list))) {
+      if (identical(content_list[[i]]$type, "text")) {
+        text_idx <- i
+        break
+      }
+    }
+    if (is.null(text_idx)) {
+      content_list[[length(content_list) + 1L]] <- list(
+        type = "text",
+        text = delta$text %||% ""
+      )
+    } else {
+      paste(content_list[[text_idx]]$text) <- delta$text %||% ""
+    }
+  } else if (delta$type == "tool_use") {
+    if (!is.null(delta$tool_use_id)) {
+      content_list[[length(content_list) + 1L]] <- list(
+        type = "tool_use",
+        tool_use_id = delta$tool_use_id,
+        name = delta$name,
+        input = delta$input %||% ""
+      )
+    } else if (!is.null(delta$input)) {
+      for (i in rev(seq_along(content_list))) {
+        if (identical(content_list[[i]]$type, "tool_use")) {
+          paste(content_list[[i]]$input) <- delta$input
+          break
+        }
+      }
     }
   } else {
     cli::cli_abort(
@@ -210,7 +231,8 @@ method(stream_merge_chunks, ProviderSnowflakeCortex) <- function(
       .internal = TRUE
     )
   }
-  result$choices[[1]]$message <- current
+
+  result$choices[[1]]$message$content_list <- content_list
   result$usage <- chunk$usage
   result
 }
@@ -230,22 +252,24 @@ method(value_turn, ProviderSnowflakeCortex) <- function(
 ) {
   raw_content <- result$choices[[1]]$message$content_list
   contents <- lapply(raw_content, function(content) {
-    if (content$type == "text") {
+    if (identical(content$type, "text")) {
       if (has_type) {
         ContentJson(string = content$text)
       } else {
         ContentText(content$text)
       }
-    } else if (content$type == "tool_use") {
-      content <- content$tool_use
-      if (is_string(content$input)) {
-        content$input <- jsonlite::parse_json(content$input)
+    } else if (identical(content$type, "tool_use")) {
+      # Streaming produces flat format; non-streaming has nested tool_use
+      if (!is.null(content[["tool_use"]])) {
+        content <- content[["tool_use"]]
       }
-      ContentToolRequest(
-        content$tool_use_id,
-        content$name,
-        content$input %||% list()
-      )
+      input <- content[["input"]] %||% ""
+      id <- content[["tool_use_id"]]
+      name <- content[["name"]]
+      if (is_string(input)) {
+        input <- jsonlite::parse_json(input)
+      }
+      ContentToolRequest(id, name, input %||% list())
     } else {
       cli::cli_abort(
         "Unknown content type {.str {content$type}}.",
@@ -301,12 +325,14 @@ method(as_json, list(ProviderSnowflakeCortex, ToolDef)) <- function(
   ...
 ) {
   list(
-    tool_spec = compact(list(
-      type = "generic",
-      name = x@name,
-      description = x@description,
-      input_schema = as_json(provider, x@arguments, ...)
-    ))
+    tool_spec = compact(
+      list(
+        type = "generic",
+        name = x@name,
+        description = x@description,
+        input_schema = as_json(provider, x@arguments, ...)
+      )
+    )
   )
 }
 
@@ -339,15 +365,17 @@ method(as_json, list(ProviderSnowflakeCortex, ContentToolResult)) <- function(
 ) {
   list(
     type = "tool_results",
-    tool_results = compact(list(
-      tool_use_id = x@request@id,
-      name = x@request@name,
-      content = list(
-        list(type = "text", text = tool_string(x))
-      ),
-      # TODO: Is this the correct format?
-      status = if (tool_errored(x)) "error"
-    ))
+    tool_results = compact(
+      list(
+        tool_use_id = x@request@id,
+        name = x@request@name,
+        content = list(
+          list(type = "text", text = tool_string(x))
+        ),
+        # TODO: Is this the correct format?
+        status = if (tool_errored(x)) "error"
+      )
+    )
   )
 }
 

--- a/tests/testthat/test-provider-snowflake.R
+++ b/tests/testthat/test-provider-snowflake.R
@@ -331,9 +331,9 @@ test_that("we can merge Snowflake's tool_use chunk format", {
     )
   )
 
-  # value_turn produces the tool request from the merged result
+  # value_turn filters empty text and produces only the tool request
   turn <- value_turn(provider, result)
-  expect_length(turn@contents, 2)
+  expect_length(turn@contents, 1)
   expect_s3_class(turn@contents[[1]], "ellmer::ContentToolRequest")
   expect_equal(turn@contents[[1]]@id, "toolu_123")
   expect_equal(turn@contents[[1]]@name, "my_tool")

--- a/tests/testthat/test-provider-snowflake.R
+++ b/tests/testthat/test-provider-snowflake.R
@@ -340,6 +340,59 @@ test_that("we can merge Snowflake's tool_use chunk format", {
   expect_equal(turn@contents[[1]]@arguments, list(x = 5))
 })
 
+test_that("stream_content extracts text from Snowflake's delta format", {
+  withr::local_envvar(
+    SNOWFLAKE_ACCOUNT = "testorg-test_account",
+    SNOWFLAKE_TOKEN = "token"
+  )
+  chat <- chat_snowflake()
+  provider <- chat$get_provider()
+
+  # Text chunk with content yields ContentText
+  text_event <- list(
+    choices = list(
+      list(
+        delta = list(type = "text", content = "hello", text = "hello")
+      )
+    )
+  )
+  result <- stream_content(provider, text_event)
+  expect_s3_class(result, "ellmer::ContentText")
+  expect_equal(result@text, "hello")
+
+  # Text chunk using delta$text (no delta$content)
+  text_event2 <- list(
+    choices = list(
+      list(
+        delta = list(type = "text", text = "world")
+      )
+    )
+  )
+  result2 <- stream_content(provider, text_event2)
+  expect_s3_class(result2, "ellmer::ContentText")
+  expect_equal(result2@text, "world")
+
+  # Tool_use chunk returns NULL (not text)
+  tool_event <- list(
+    choices = list(
+      list(
+        delta = list(type = "tool_use", tool_use_id = "id", name = "fn")
+      )
+    )
+  )
+  expect_null(stream_content(provider, tool_event))
+
+  # Empty text chunk returns NULL
+  empty_event <- list(
+    choices = list(
+      list(
+        delta = list(type = "text", text = "")
+      )
+    )
+  )
+  expect_null(stream_content(provider, empty_event))
+})
+
 test_that("chat_snowflake() supports parameters", {
   # Setting a dummy account ensures we don't skip this test, even if there are
   # no Snowflake credentials available.

--- a/tests/testthat/test-provider-snowflake.R
+++ b/tests/testthat/test-provider-snowflake.R
@@ -190,30 +190,36 @@ test_that("we can merge Snowflake's chunk format", {
   chunk1 <- list(
     id = "id",
     model = "claude-3-5-sonnet",
-    choices = list(list(
-      delta = list(
-        type = "text",
-        content = "I",
-        content_list = list(list(type = "text", text = "I")),
-        text = "I"
+    choices = list(
+      list(
+        delta = list(
+          type = "text",
+          content = "I",
+          content_list = list(list(type = "text", text = "I")),
+          text = "I"
+        )
       )
-    )),
+    ),
     usage = structure(list(), names = character(0))
   )
   chunk2 <- list(
     id = "id",
     model = "claude-3-5-sonnet",
-    choices = list(list(
-      delta = list(
-        type = "text",
-        content = " aim to be direct and honest: I don't actually",
-        content_list = list(list(
+    choices = list(
+      list(
+        delta = list(
           type = "text",
+          content = " aim to be direct and honest: I don't actually",
+          content_list = list(
+            list(
+              type = "text",
+              text = " aim to be direct and honest: I don't actually"
+            )
+          ),
           text = " aim to be direct and honest: I don't actually"
-        )),
-        text = " aim to be direct and honest: I don't actually"
+        )
       )
-    )),
+    ),
     usage = structure(list(), names = character(0))
   )
   expect_equal(
@@ -225,20 +231,113 @@ test_that("we can merge Snowflake's chunk format", {
     list(
       id = "id",
       model = "claude-3-5-sonnet",
-      choices = list(list(
-        message = list(
-          content = "I aim to be direct and honest: I don't actually",
-          content_list = list(
-            list(
-              type = "text",
-              text = "I aim to be direct and honest: I don't actually"
+      choices = list(
+        list(
+          message = list(
+            content_list = list(
+              list(
+                type = "text",
+                text = "I aim to be direct and honest: I don't actually"
+              )
             )
           )
         )
-      )),
+      ),
       usage = structure(list(), names = character(0))
     )
   )
+})
+
+test_that("we can merge Snowflake's tool_use chunk format", {
+  withr::local_envvar(
+    SNOWFLAKE_ACCOUNT = "testorg-test_account",
+    SNOWFLAKE_TOKEN = "token"
+  )
+  chat <- chat_snowflake()
+  provider <- chat$get_provider()
+
+  # Simulate a response that starts with a tool call (no preceding text).
+  # This is the scenario that triggers the bug in #938.
+  chunk1 <- list(
+    choices = list(
+      list(
+        delta = list(
+          type = "tool_use",
+          tool_use_id = "toolu_123",
+          name = "my_tool",
+          content_list = list(
+            list(tool_use_id = "toolu_123", name = "my_tool")
+          ),
+          text = ""
+        )
+      )
+    ),
+    usage = structure(list(), names = character(0))
+  )
+  chunk2 <- list(
+    choices = list(
+      list(
+        delta = list(
+          type = "tool_use",
+          input = "{\"x\":",
+          content_list = list(list(input = "{\"x\":")),
+          text = ""
+        )
+      )
+    ),
+    usage = structure(list(), names = character(0))
+  )
+  chunk3 <- list(
+    choices = list(
+      list(
+        delta = list(
+          type = "tool_use",
+          input = " 5}",
+          content_list = list(list(input = " 5}")),
+          text = ""
+        )
+      )
+    ),
+    usage = structure(list(), names = character(0))
+  )
+  chunk4 <- list(
+    choices = list(
+      list(
+        delta = list(
+          type = "text",
+          content_list = list(list(type = "text", text = "")),
+          text = ""
+        )
+      )
+    ),
+    usage = list(prompt_tokens = 10, completion_tokens = 5)
+  )
+
+  result <- stream_merge_chunks(provider, NULL, chunk1)
+  result <- stream_merge_chunks(provider, result, chunk2)
+  result <- stream_merge_chunks(provider, result, chunk3)
+  result <- stream_merge_chunks(provider, result, chunk4)
+
+  expect_equal(
+    result$choices[[1]]$message$content_list,
+    list(
+      list(
+        type = "tool_use",
+        tool_use_id = "toolu_123",
+        name = "my_tool",
+        input = "{\"x\": 5}"
+      ),
+      list(type = "text", text = "")
+    )
+  )
+
+  # value_turn produces the tool request from the merged result
+  turn <- value_turn(provider, result)
+  expect_length(turn@contents, 2)
+  expect_s3_class(turn@contents[[1]], "ellmer::ContentToolRequest")
+  expect_equal(turn@contents[[1]]@id, "toolu_123")
+  expect_equal(turn@contents[[1]]@name, "my_tool")
+  expect_equal(turn@contents[[1]]@arguments, list(x = 5))
 })
 
 test_that("chat_snowflake() supports parameters", {

--- a/tests/testthat/test-provider-snowflake.R
+++ b/tests/testthat/test-provider-snowflake.R
@@ -393,6 +393,27 @@ test_that("stream_content extracts text from Snowflake's delta format", {
   expect_null(stream_content(provider, empty_event))
 })
 
+test_that("as_json handles tool-only assistant turns", {
+  withr::local_envvar(
+    SNOWFLAKE_ACCOUNT = "testorg-test_account",
+    SNOWFLAKE_TOKEN = "token"
+  )
+  chat <- chat_snowflake()
+  provider <- chat$get_provider()
+
+  # An assistant turn with only a tool request (no preceding text)
+  turn <- Turn(
+    "assistant",
+    contents = list(
+      ContentToolRequest("toolu_123", "my_tool", list(x = 5))
+    )
+  )
+  result <- as_json(provider, turn)
+  expect_equal(result$role, "assistant")
+  expect_equal(result$content_list[[1]]$type, "tool_use")
+  expect_equal(result$content_list[[1]]$tool_use$tool_use_id, "toolu_123")
+})
+
 test_that("chat_snowflake() supports parameters", {
   # Setting a dummy account ensures we don't skip this test, even if there are
   # no Snowflake credentials available.


### PR DESCRIPTION
The PR fixes tool calling in `chat_snowflake()`, which is currently completely broken. Any use of tools (including via querychat) errors with:

```
Error in `if (content$type == "text") ...`:
! argument is of length zero
```

**Reprex** (fails on main, passes on this branch):

```r
library(ellmer)

chat <- chat_snowflake(
  system_prompt = "Always use your tools when asked.",
  account = Sys.getenv("SNOWFLAKE_ACCOUNT")
)
chat$register_tool(tool(
  function(x) paste("result:", x * 2),
  name = "double_number",
  description = "Doubles a number",
  arguments = list(x = type_number("The number to double"))
))

chat$chat("Double the number 5")
```

**Root cause:** Snowflake's streaming API can send `tool_use` as the very first chunk (with no preceding text). The old `stream_merge_chunks` assumed responses always started with text. When they didn't, `content_list` entries ended up without a `type` field, which crashed `value_turn()`.

We didn't catch this because `test_tools_simple(chat_snowflake)` requires live credentials and is always skipped in CI (via `default_snowflake_credentials()` → `testthat::skip()` at `R/provider-snowflake.R:470`).

**Fixes (each a separate commit for clarity):**

1. **Fix `stream_merge_chunks`** — Handle tool_use-first responses; use positional search instead of hardcoded indices; normalize `content_list` entries with explicit `type` fields.
2. **Add `stream_content` override** — Snowflake uses `delta$text`, not `delta$content`. Without this, `stream = "content"` mode (used by querychat) never yielded text during streaming.
3. **Handle tool-only turns in `as_json`** — Once tools parse correctly, the follow-up request failed because serializing a `ContentToolRequest`-first turn was unhandled.
4. **Filter empty text in `value_turn`** — Snowflake sends a final empty text delta; if included in the Turn and sent back as history, the API rejects it with "text content blocks must be non-empty".

Closes #938

## Test plan

- [x] Existing offline chunk-merge test updated for new format
- [x] New offline test for tool_use-first chunk merging (the #938 scenario)
- [x] New offline test for `stream_content` extraction from Snowflake's delta format
- [x] New offline test for `as_json` with tool-only assistant turns
- [x] Verified end-to-end against live Snowflake API (non-streaming + streaming + content mode)