### PR TITLE
Implement official Claude structured outputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ellmer (development version)
 
+* `type_object(.additional_properties)` is deprecated. No supported provider can return additional properties when using structured output. Instead, use an array of name-value pairs (@thisisnic, #866).
+
 # ellmer 0.4.1
 
 * ellmer is now instrumented with OpenTelemetry, so that traces are emitted whenever the (suggested) `otel` package is installed and a tracer is active.

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -201,17 +201,29 @@ method(chat_body, ProviderAnthropic) <- function(
   }))
 
   if (!is.null(type)) {
-    tool_def <- ToolDef(
-      function(...) {},
-      name = "_structured_tool_call",
-      description = "Extract structured data",
-      arguments = type_object(data = type)
-    )
-    tools[[tool_def@name]] <- tool_def
-    tool_choice <- list(type = "tool", name = tool_def@name)
-    stream <- FALSE
+    if (has_claude_structured_output(provider@model)) {
+      output_config <- list(
+        format = list(
+          type = "json_schema",
+          schema = as_json(provider, type)
+        )
+      )
+      tool_choice <- NULL
+    } else {
+      tool_def <- ToolDef(
+        function(...) {},
+        name = "_structured_tool_call",
+        description = "Extract structured data",
+        arguments = type_object(data = type)
+      )
+      tools[[tool_def@name]] <- tool_def
+      tool_choice <- list(type = "tool", name = tool_def@name)
+      stream <- FALSE
+      output_config <- NULL
+    }
   } else {
     tool_choice <- NULL
+    output_config <- NULL
   }
   tools <- as_json(provider, unname(tools))
 
@@ -234,6 +246,7 @@ method(chat_body, ProviderAnthropic) <- function(
     tools = tools,
     tool_choice = tool_choice,
     thinking = thinking,
+    output_config = output_config,
     !!!params
   ))
 }
@@ -358,7 +371,11 @@ method(value_turn, ProviderAnthropic) <- function(
 ) {
   contents <- lapply(result$content, function(content) {
     if (content$type == "text") {
-      ContentText(content$text)
+      if (has_type && has_claude_structured_output(provider@model)) {
+        ContentJson(string = content$text)
+      } else {
+        ContentText(content$text)
+      }
     } else if (content$type == "tool_use") {
       if (has_type) {
         ContentJson(data = content$input$data)
@@ -735,4 +752,11 @@ cache_control <- function(provider) {
       ttl = provider@cache
     )
   }
+}
+
+has_claude_structured_output <- function(model) {
+  # https://platform.claude.com/docs/en/build-with-claude/structured-outputs
+  grepl("^claude-opus-4-[567]", model) ||
+    grepl("^claude-sonnet-4-[56]", model) ||
+    grepl("^claude-haiku-4-5", model)
 }

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -201,7 +201,8 @@ method(chat_body, ProviderAnthropic) <- function(
   }))
 
   if (!is.null(type)) {
-    if (has_claude_structured_output(provider@model)) {
+    if (has_claude_structured_output(provider@model) &&
+        !type_has_additional_properties(type)) {
       output_config <- list(
         format = list(
           type = "json_schema",

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -758,8 +758,7 @@ cache_control <- function(provider) {
 }
 
 has_claude_structured_output <- function(model) {
+  # Matches Claude 4.5+ models
   # https://platform.claude.com/docs/en/build-with-claude/structured-outputs
-  grepl("^claude-opus-4-[567]", model) ||
-    grepl("^claude-sonnet-4-[56]", model) ||
-    grepl("^claude-haiku-4-5", model)
+  grepl("^claude-\\w+-4-[5-9](-|$)", model)
 }

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -201,8 +201,10 @@ method(chat_body, ProviderAnthropic) <- function(
   }))
 
   if (!is.null(type)) {
-    if (has_claude_structured_output(provider@model) &&
-        !type_has_additional_properties(type)) {
+    if (
+      has_claude_structured_output(provider@model) &&
+        !type_has_additional_properties(type)
+    ) {
       output_config <- list(
         format = list(
           type = "json_schema",

--- a/R/types.R
+++ b/R/types.R
@@ -191,16 +191,22 @@ type_array <- function(items, description = NULL, required = TRUE) {
 
 #' @param ... <[`dynamic-dots`][rlang::dyn-dots]> Name-type pairs defining
 #'   the components that the object must possess.
-#' @param .additional_properties Can the object have arbitrary additional
-#'   properties that are not explicitly listed? Only supported by Claude.
+#' @param .additional_properties `r lifecycle::badge("deprecated")` Can the
+#'   object have arbitrary additional properties that are not explicitly listed?
+#'   Only supported by Claude.
 #' @export
 #' @rdname type_boolean
 type_object <- function(
   .description = NULL,
   ...,
   .required = TRUE,
-  .additional_properties = FALSE
+  .additional_properties = deprecated()
 ) {
+  if (lifecycle::is_present(.additional_properties)) {
+    lifecycle::deprecate_warn("0.5.0", "type_object(.additional_properties)")
+  } else {
+    .additional_properties <- FALSE
+  }
   TypeObject(
     properties = list2(...),
     description = .description,

--- a/R/types.R
+++ b/R/types.R
@@ -228,3 +228,14 @@ type_from_schema <- function(text, path) {
 type_ignore <- function() {
   TypeIgnore()
 }
+
+type_has_additional_properties <- function(type) {
+  if (S7_inherits(type, TypeObject)) {
+    type@additional_properties ||
+      any(map_lgl(type@properties, type_has_additional_properties))
+  } else if (S7_inherits(type, TypeArray)) {
+    type_has_additional_properties(type@items)
+  } else {
+    FALSE
+  }
+}

--- a/man/Type.Rd
+++ b/man/Type.Rd
@@ -57,8 +57,9 @@ value, the default value will be used.}
 \item{properties}{Named list of properties stored inside the object.
 Each element should be an S7 \code{Type} object.`}
 
-\item{additional_properties}{Can the object have arbitrary additional
-properties that are not explicitly listed? Only supported by Claude.}
+\item{additional_properties}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Can the
+object have arbitrary additional properties that are not explicitly listed?
+Only supported by Claude.}
 }
 \value{
 S7 objects inheriting from \code{Type}

--- a/man/type_boolean.Rd
+++ b/man/type_boolean.Rd
@@ -28,7 +28,7 @@ type_object(
   .description = NULL,
   ...,
   .required = TRUE,
-  .additional_properties = FALSE
+  .additional_properties = deprecated()
 )
 
 type_from_schema(text, path)
@@ -60,8 +60,9 @@ value, the default value will be used.}
 \item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> Name-type pairs defining
 the components that the object must possess.}
 
-\item{.additional_properties}{Can the object have arbitrary additional
-properties that are not explicitly listed? Only supported by Claude.}
+\item{.additional_properties}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Can the
+object have arbitrary additional properties that are not explicitly listed?
+Only supported by Claude.}
 
 \item{text}{A JSON string.}
 

--- a/tests/testthat/_snaps/chat-structured.md
+++ b/tests/testthat/_snaps/chat-structured.md
@@ -14,3 +14,11 @@
       Warning:
       Found 3 JSON responses, using the first.
 
+# type_object(.additional_properties) is deprecated
+
+    Code
+      . <- type_object(.additional_properties = TRUE)
+    Condition
+      Warning:
+      The `.additional_properties` argument of `type_object()` is deprecated as of ellmer 0.5.0.
+

--- a/tests/testthat/_vcr/anthropic-structured-data.yml
+++ b/tests/testthat/_vcr/anthropic-structured-data.yml
@@ -6,41 +6,44 @@ http_interactions:
       string: '{"model":"claude-sonnet-4-5-20250929","messages":[{"role":"user","content":[{"type":"text","text":"\n    #
         Apples are tasty\n    By Hadley Wickham\n\n    Apples are delicious and tasty
         and I like to eat them.\n    Except for red delicious, that is. They are NOT
-        delicious.\n  ","cache_control":{"type":"ephemeral","ttl":"5m"}}]}],"stream":false,"tools":[{"name":"_structured_tool_call","description":"Extract
-        structured data","input_schema":{"type":"object","description":"","properties":{"data":{"type":"object","description":"Summary
+        delicious.\n  ","cache_control":{"type":"ephemeral","ttl":"5m"}}]}],"stream":false,"output_config":{"format":{"type":"json_schema","schema":{"type":"object","description":"Summary
         of the article. Preserve existing case.","properties":{"title":{"type":"string","description":"Content
-        title"},"author":{"type":"string","description":"Name of the author"}},"required":["title","author"],"additionalProperties":false}},"required":["data"],"additionalProperties":false}}],"tool_choice":{"type":"tool","name":"_structured_tool_call"},"temperature":0,"max_tokens":4096}'
+        title"},"author":{"type":"string","description":"Name of the author"}},"required":["title","author"],"additionalProperties":false}}},"temperature":0,"max_tokens":4096}'
   response:
     status: 200
     headers:
-      date: Thu, 06 Nov 2025 14:56:32 GMT
+      date: Sun, 10 May 2026 22:37:37 GMT
       content-type: application/json
-      content-encoding: gzip
-      anthropic-ratelimit-input-tokens-limit: '2000000'
-      anthropic-ratelimit-input-tokens-remaining: '2000000'
-      anthropic-ratelimit-input-tokens-reset: '2025-11-06T14:56:31Z'
-      anthropic-ratelimit-output-tokens-limit: '400000'
-      anthropic-ratelimit-output-tokens-remaining: '400000'
-      anthropic-ratelimit-output-tokens-reset: '2025-11-06T14:56:32Z'
-      anthropic-ratelimit-requests-limit: '4000'
-      anthropic-ratelimit-requests-remaining: '3999'
-      anthropic-ratelimit-requests-reset: '2025-11-06T14:56:29Z'
-      retry-after: '30'
-      anthropic-ratelimit-tokens-limit: '2400000'
-      anthropic-ratelimit-tokens-remaining: '2400000'
-      anthropic-ratelimit-tokens-reset: '2025-11-06T14:56:31Z'
-      request-id: req_011CUrq7wbHdfAWEpWUMRV2b
+      anthropic-ratelimit-input-tokens-limit: '800000'
+      anthropic-ratelimit-input-tokens-remaining: '800000'
+      anthropic-ratelimit-input-tokens-reset: '2026-05-10T22:37:36Z'
+      anthropic-ratelimit-output-tokens-limit: '160000'
+      anthropic-ratelimit-output-tokens-remaining: '160000'
+      anthropic-ratelimit-output-tokens-reset: '2026-05-10T22:37:36Z'
+      anthropic-ratelimit-requests-limit: '2000'
+      anthropic-ratelimit-requests-remaining: '1999'
+      anthropic-ratelimit-requests-reset: '2026-05-10T22:37:33Z'
+      anthropic-ratelimit-tokens-limit: '960000'
+      anthropic-ratelimit-tokens-remaining: '960000'
+      anthropic-ratelimit-tokens-reset: '2026-05-10T22:37:36Z'
+      request-id: req_011CaugvaCGMBcZUa8L8B2iB
       strict-transport-security: max-age=31536000; includeSubDomains; preload
-      anthropic-organization-id: bf3687d8-1b59-41eb-9761-a1fd70b24e7e
-      x-envoy-upstream-service-time: '2715'
-      cf-cache-status: DYNAMIC
-      x-robots-tag: none
+      anthropic-organization-id: 67bb8feb-7bca-4369-9e04-339d73646b40
+      traceresponse: 00-fcc9b312f8f02431c4310e21647f8a53-d9cbf22a7e3151f8-01
       server: cloudflare
-      cf-ray: 99a570198c6569d0-DFW
+      x-envoy-upstream-service-time: '3220'
+      content-encoding: gzip
+      vary: Accept-Encoding
+      cf-cache-status: DYNAMIC
+      set-cookie: _cfuvid=1zfWEzdXX9p_eNStyRddrz5jgnd_YBb3k90I3BZAglc-1778452653.647383-1.0.1.1-0T1g6Qbj8rU81TTJY3UxgoEO7hHQUKCdfE8anRqEzdk;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com
+      content-security-policy: default-src 'none'; frame-ancestors 'none'
+      x-robots-tag: none
+      cf-ray: 9f9c6ddd4cecfe40-VIE
     body:
-      string: '{"model":"claude-sonnet-4-5-20250929","id":"msg_01G8c8rPFym6gBoDELWsWGnz","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_01TL6NrFX7XEQzBDcx1Vsvf8","name":"_structured_tool_call","input":{"data":{"title":"Apples
-        are tasty","author":"Hadley Wickham"}}}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":792,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":54,"service_tier":"standard"}}'
-  recorded_at: 2025-11-06 14:56:32
+      string: '{"model":"claude-sonnet-4-5-20250929","id":"msg_01LhkLSTnTZwu4ymoD8iF6Zd","type":"message","role":"assistant","content":[{"type":"text","text":"{\"title\":\"Apples
+        are tasty\",\"author\":\"Hadley Wickham\"}"}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":262,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":22,"service_tier":"standard","inference_geo":"not_available"}}'
+  recorded_at: 2026-05-10 22:37:37
 - request:
     method: POST
     uri: https://api.anthropic.com/v1/messages
@@ -52,39 +55,42 @@ http_interactions:
         are tasty\",\"author\":\"Hadley Wickham\"}"}]},{"role":"user","content":[{"type":"text","text":"\n    #
         Apples are tasty\n    By Hadley Wickham\n\n    Apples are delicious and tasty
         and I like to eat them.\n    Except for red delicious, that is. They are NOT
-        delicious.\n  ","cache_control":{"type":"ephemeral","ttl":"5m"}}]}],"stream":false,"tools":[{"name":"_structured_tool_call","description":"Extract
-        structured data","input_schema":{"type":"object","description":"","properties":{"data":{"type":"object","description":"Summary
+        delicious.\n  ","cache_control":{"type":"ephemeral","ttl":"5m"}}]}],"stream":false,"output_config":{"format":{"type":"json_schema","schema":{"type":"object","description":"Summary
         of the article. Preserve existing case.","properties":{"title":{"type":"string","description":"Content
-        title"},"author":{"type":"string","description":"Name of the author"}},"required":["title","author"],"additionalProperties":false}},"required":["data"],"additionalProperties":false}}],"tool_choice":{"type":"tool","name":"_structured_tool_call"},"temperature":0,"max_tokens":4096}'
+        title"},"author":{"type":"string","description":"Name of the author"}},"required":["title","author"],"additionalProperties":false}}},"temperature":0,"max_tokens":4096}'
   response:
     status: 200
     headers:
-      date: Thu, 06 Nov 2025 14:56:35 GMT
+      date: Sun, 10 May 2026 22:37:39 GMT
       content-type: application/json
-      content-encoding: gzip
-      anthropic-ratelimit-input-tokens-limit: '2000000'
-      anthropic-ratelimit-input-tokens-remaining: '2000000'
-      anthropic-ratelimit-input-tokens-reset: '2025-11-06T14:56:35Z'
-      anthropic-ratelimit-output-tokens-limit: '400000'
-      anthropic-ratelimit-output-tokens-remaining: '400000'
-      anthropic-ratelimit-output-tokens-reset: '2025-11-06T14:56:35Z'
-      anthropic-ratelimit-requests-limit: '4000'
-      anthropic-ratelimit-requests-remaining: '3999'
-      anthropic-ratelimit-requests-reset: '2025-11-06T14:56:32Z'
-      retry-after: '25'
-      anthropic-ratelimit-tokens-limit: '2400000'
-      anthropic-ratelimit-tokens-remaining: '2400000'
-      anthropic-ratelimit-tokens-reset: '2025-11-06T14:56:35Z'
-      request-id: req_011CUrq89vwiaG9F6D4Q6WLN
+      anthropic-ratelimit-input-tokens-limit: '800000'
+      anthropic-ratelimit-input-tokens-remaining: '800000'
+      anthropic-ratelimit-input-tokens-reset: '2026-05-10T22:37:39Z'
+      anthropic-ratelimit-output-tokens-limit: '160000'
+      anthropic-ratelimit-output-tokens-remaining: '160000'
+      anthropic-ratelimit-output-tokens-reset: '2026-05-10T22:37:39Z'
+      anthropic-ratelimit-requests-limit: '2000'
+      anthropic-ratelimit-requests-remaining: '1999'
+      anthropic-ratelimit-requests-reset: '2026-05-10T22:37:37Z'
+      anthropic-ratelimit-tokens-limit: '960000'
+      anthropic-ratelimit-tokens-remaining: '960000'
+      anthropic-ratelimit-tokens-reset: '2026-05-10T22:37:39Z'
+      request-id: req_011CaugvrBwA2pnqgDcUT8Cg
       strict-transport-security: max-age=31536000; includeSubDomains; preload
-      anthropic-organization-id: bf3687d8-1b59-41eb-9761-a1fd70b24e7e
-      x-envoy-upstream-service-time: '3197'
-      cf-cache-status: DYNAMIC
-      x-robots-tag: none
+      anthropic-organization-id: 67bb8feb-7bca-4369-9e04-339d73646b40
+      traceresponse: 00-ebe8bb639af64695f89e818a4db7a6bc-6c66f3398e0eb5cf-01
       server: cloudflare
-      cf-ray: 99a5702baf0d69d0-DFW
+      x-envoy-upstream-service-time: '2287'
+      content-encoding: gzip
+      vary: Accept-Encoding
+      cf-cache-status: DYNAMIC
+      set-cookie: _cfuvid=SrTOLO2Ih_JXXN5KDHR1kv7FcmcbB2xVhM6uq6EbN94-1778452657.3837967-1.0.1.1-MXXfTE1SVb2piER9Ee0Lo9V9w92uL8W8UniRy86eNpw;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com
+      content-security-policy: default-src 'none'; frame-ancestors 'none'
+      x-robots-tag: none
+      cf-ray: 9f9c6df4abf2fe40-VIE
     body:
-      string: '{"model":"claude-sonnet-4-5-20250929","id":"msg_01GoxxFUPozvUG66BGrR8Z6b","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_01BGXTSbLiVWVFax94GWPaje","name":"_structured_tool_call","input":{"data":{"title":"Apples
-        are tasty","author":"Hadley Wickham"}}}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":874,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":54,"service_tier":"standard"}}'
-  recorded_at: 2025-11-06 14:56:35
-recorded_with: VCR-vcr/2.0.0
+      string: '{"model":"claude-sonnet-4-5-20250929","id":"msg_0162WsqkppbpDhbNHWUeiSdg","type":"message","role":"assistant","content":[{"type":"text","text":"{\"title\":\"Apples
+        are tasty\",\"author\":\"Hadley Wickham\"}"}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":344,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":22,"service_tier":"standard","inference_geo":"not_available"}}'
+  recorded_at: 2026-05-10 22:37:39
+recorded_with: VCR-vcr/2.1.0

--- a/tests/testthat/test-chat-structured.R
+++ b/tests/testthat/test-chat-structured.R
@@ -155,7 +155,13 @@ test_that("completely missing optional components become NULL", {
   )
 })
 
+test_that("type_object(.additional_properties) is deprecated", {
+  expect_snapshot(. <- type_object(.additional_properties = TRUE))
+})
+
 test_that("objects take order from type", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   x <- list(y = 1, x = 2)
   type1 <- type_object(x = type_integer(), y = type_integer())
   expect_equal(convert_from_type(x, type1), list(x = 2, y = 1))
@@ -165,6 +171,8 @@ test_that("objects take order from type", {
 })
 
 test_that("additional properties are ignored, unless specified by type", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   x <- list(y = 1, x = 2, z = 3)
   type <- type_object(x = type_integer())
   expect_equal(convert_from_type(x, type), list(x = 2))
@@ -217,6 +225,8 @@ test_that("arrays of enums are converted to factors", {
 })
 
 test_that("can convert arrays of objects to data frames", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   x <- list(list(x = 1, y = "x"), list(x = 3, y = "y"))
   type <- type_array(type_object(x = type_integer(), y = type_string()))
   expect_equal(

--- a/tests/testthat/test-provider-ollama.R
+++ b/tests/testthat/test-provider-ollama.R
@@ -55,6 +55,7 @@ test_that("supports tool calling", {
 # Custom -----------------------------------------------------------------
 
 test_that("as_json specialised for Ollama", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   stub <- ProviderOllama(name = "", base_url = "", model = "")
 
   expect_snapshot(

--- a/tests/testthat/test-provider-openai-compatible.R
+++ b/tests/testthat/test-provider-openai-compatible.R
@@ -230,6 +230,7 @@ test_that("as_json preserves reasoning_content when preserve_thinking = TRUE", {
 })
 
 test_that("as_json specialised for OpenAI", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   stub <- ProviderOpenAI(name = "", base_url = "", model = "")
 
   expect_snapshot(

--- a/vignettes/_vcr/structured-data-examples-unknown-keys.yml
+++ b/vignettes/_vcr/structured-data-examples-unknown-keys.yml
@@ -6,42 +6,42 @@ http_interactions:
       string: '{"model":"claude-sonnet-4-5-20250929","system":[{"type":"text","text":"Extract
         all characteristics of supplied character","cache_control":{"type":"ephemeral","ttl":"5m"}}],"messages":[{"role":"user","content":[{"type":"text","text":"\n  The
         man is tall, with a beard and a scar on his left cheek. He has a deep voice
-        and wears a black leather jacket.\n","cache_control":{"type":"ephemeral","ttl":"5m"}}]}],"stream":false,"tools":[{"name":"_structured_tool_call","description":"Extract
-        structured data","input_schema":{"type":"object","description":"","properties":{"data":{"type":"object","description":"All
-        characteristics","properties":{},"required":[],"additionalProperties":true}},"required":["data"],"additionalProperties":false}}],"tool_choice":{"type":"tool","name":"_structured_tool_call"},"max_tokens":4096}'
+        and wears a black leather jacket.\n","cache_control":{"type":"ephemeral","ttl":"5m"}}]}],"stream":false,"output_config":{"format":{"type":"json_schema","schema":{"type":"array","description":"All
+        characteristics","items":{"type":"object","description":"","properties":{"name":{"type":"string","description":""},"value":{"type":"string","description":""}},"required":["name","value"],"additionalProperties":false}}}},"max_tokens":4096}'
   response:
     status: 200
     headers:
-      date: Mon, 11 May 2026 07:31:30 GMT
+      date: Mon, 11 May 2026 15:42:06 GMT
       content-type: application/json
       anthropic-ratelimit-input-tokens-limit: '800000'
       anthropic-ratelimit-input-tokens-remaining: '800000'
-      anthropic-ratelimit-input-tokens-reset: '2026-05-11T07:31:29Z'
+      anthropic-ratelimit-input-tokens-reset: '2026-05-11T15:42:04Z'
       anthropic-ratelimit-output-tokens-limit: '160000'
       anthropic-ratelimit-output-tokens-remaining: '160000'
-      anthropic-ratelimit-output-tokens-reset: '2026-05-11T07:31:30Z'
+      anthropic-ratelimit-output-tokens-reset: '2026-05-11T15:42:06Z'
       anthropic-ratelimit-requests-limit: '2000'
       anthropic-ratelimit-requests-remaining: '1999'
-      anthropic-ratelimit-requests-reset: '2026-05-11T07:31:29Z'
+      anthropic-ratelimit-requests-reset: '2026-05-11T15:42:03Z'
       anthropic-ratelimit-tokens-limit: '960000'
       anthropic-ratelimit-tokens-remaining: '960000'
-      anthropic-ratelimit-tokens-reset: '2026-05-11T07:31:29Z'
-      request-id: req_011CavPe2sRgZyRHny1QHGaH
+      anthropic-ratelimit-tokens-reset: '2026-05-11T15:42:04Z'
+      request-id: req_011Caw33kzvfSzYpszeq5E5h
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       anthropic-organization-id: 67bb8feb-7bca-4369-9e04-339d73646b40
-      traceresponse: 00-e03b5d86c6af61d9a258672596e3b1f9-b21c05ccd11c24d0-01
+      traceresponse: 00-88d4a3ccee9b282d3ffaf767cb19175f-3c1819cdd9cd4f31-01
       server: cloudflare
-      x-envoy-upstream-service-time: '1716'
+      x-envoy-upstream-service-time: '2864'
       content-encoding: gzip
       vary: Accept-Encoding
-      set-cookie: _cfuvid=7Vqh3eRirgYFjvE1MfNsFwQuP4D.tB_xEbThRmz6oTg-1778484688.9917305-1.0.1.1-BLJyAFb8c7_RnyCCN_G4MDGs7sepX5izYFpodv52Ae8;
-        HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com
-      x-robots-tag: none
       cf-cache-status: DYNAMIC
+      set-cookie: _cfuvid=iWugYvs8yNyJh4BWrOIYGZhJ014tsv0gZtIw36_1t4w-1778514123.2274828-1.0.1.1-0ufobAV1L5PAMGklRoJFbFIwDU4UqAFXUu5Kjvrytfg;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com
       content-security-policy: default-src 'none'; frame-ancestors 'none'
-      cf-ray: 9f9f7bfa3fbfe80f-EWR
+      x-robots-tag: none
+      cf-ray: 9fa24a9628ea2565-LHR
     body:
-      string: '{"model":"claude-sonnet-4-5-20250929","id":"msg_01AWP4hwjqNHe8kNQHFm4wfB","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_01LrWPYcU8p3VmxehvvFJFzs","name":"_structured_tool_call","input":{"data":{"gender":"man","height":"tall","facial_hair":"beard","distinguishing_marks":"scar
-        on left cheek","voice":"deep voice","clothing":"black leather jacket"}},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":730,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":95,"service_tier":"standard","inference_geo":"not_available"}}'
-  recorded_at: 2026-05-11 07:31:30
+      string: '{"model":"claude-sonnet-4-5-20250929","id":"msg_01D8jnWrhpBmEFK89KmvBYDx","type":"message","role":"assistant","content":[{"type":"text","text":"[{\"name\":\"height\",\"value\":\"tall\"},{\"name\":\"facial_hair\",\"value\":\"beard\"},{\"name\":\"distinguishing_marks\",\"value\":\"scar
+        on left cheek\"},{\"name\":\"voice\",\"value\":\"deep\"},{\"name\":\"clothing\",\"value\":\"black
+        leather jacket\"}]"}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":254,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":65,"service_tier":"standard","inference_geo":"not_available"}}'
+  recorded_at: 2026-05-11 15:42:06
 recorded_with: VCR-vcr/2.1.0

--- a/vignettes/_vcr/structured-data-examples-unknown-keys.yml
+++ b/vignettes/_vcr/structured-data-examples-unknown-keys.yml
@@ -12,32 +12,36 @@ http_interactions:
   response:
     status: 200
     headers:
-      date: Thu, 06 Nov 2025 14:55:47 GMT
+      date: Mon, 11 May 2026 07:31:30 GMT
       content-type: application/json
-      content-encoding: gzip
-      anthropic-ratelimit-input-tokens-limit: '2000000'
-      anthropic-ratelimit-input-tokens-remaining: '2000000'
-      anthropic-ratelimit-input-tokens-reset: '2025-11-06T14:55:46Z'
-      anthropic-ratelimit-output-tokens-limit: '400000'
-      anthropic-ratelimit-output-tokens-remaining: '400000'
-      anthropic-ratelimit-output-tokens-reset: '2025-11-06T14:55:47Z'
-      anthropic-ratelimit-requests-limit: '4000'
-      anthropic-ratelimit-requests-remaining: '3999'
-      anthropic-ratelimit-requests-reset: '2025-11-06T14:55:44Z'
-      retry-after: '14'
-      anthropic-ratelimit-tokens-limit: '2400000'
-      anthropic-ratelimit-tokens-remaining: '2400000'
-      anthropic-ratelimit-tokens-reset: '2025-11-06T14:55:46Z'
-      request-id: req_011CUrq4Z678zLN83jRAzk7T
+      anthropic-ratelimit-input-tokens-limit: '800000'
+      anthropic-ratelimit-input-tokens-remaining: '800000'
+      anthropic-ratelimit-input-tokens-reset: '2026-05-11T07:31:29Z'
+      anthropic-ratelimit-output-tokens-limit: '160000'
+      anthropic-ratelimit-output-tokens-remaining: '160000'
+      anthropic-ratelimit-output-tokens-reset: '2026-05-11T07:31:30Z'
+      anthropic-ratelimit-requests-limit: '2000'
+      anthropic-ratelimit-requests-remaining: '1999'
+      anthropic-ratelimit-requests-reset: '2026-05-11T07:31:29Z'
+      anthropic-ratelimit-tokens-limit: '960000'
+      anthropic-ratelimit-tokens-remaining: '960000'
+      anthropic-ratelimit-tokens-reset: '2026-05-11T07:31:29Z'
+      request-id: req_011CavPe2sRgZyRHny1QHGaH
       strict-transport-security: max-age=31536000; includeSubDomains; preload
-      anthropic-organization-id: bf3687d8-1b59-41eb-9761-a1fd70b24e7e
-      x-envoy-upstream-service-time: '3842'
-      cf-cache-status: DYNAMIC
-      x-robots-tag: none
+      anthropic-organization-id: 67bb8feb-7bca-4369-9e04-339d73646b40
+      traceresponse: 00-e03b5d86c6af61d9a258672596e3b1f9-b21c05ccd11c24d0-01
       server: cloudflare
-      cf-ray: 99a56efa492f6326-DFW
+      x-envoy-upstream-service-time: '1716'
+      content-encoding: gzip
+      vary: Accept-Encoding
+      set-cookie: _cfuvid=7Vqh3eRirgYFjvE1MfNsFwQuP4D.tB_xEbThRmz6oTg-1778484688.9917305-1.0.1.1-BLJyAFb8c7_RnyCCN_G4MDGs7sepX5izYFpodv52Ae8;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com
+      x-robots-tag: none
+      cf-cache-status: DYNAMIC
+      content-security-policy: default-src 'none'; frame-ancestors 'none'
+      cf-ray: 9f9f7bfa3fbfe80f-EWR
     body:
-      string: '{"model":"claude-sonnet-4-5-20250929","id":"msg_01KnUUXvFUg8NP5rwcArQ52i","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_01MAEkjaVxetJe3a8zJR9wP4","name":"_structured_tool_call","input":{"data":{"gender":"male","height":"tall","facial_hair":"beard","distinguishing_marks":"scar
-        on left cheek","voice":"deep voice","clothing":"black leather jacket"}}}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":730,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":95,"service_tier":"standard"}}'
-  recorded_at: 2025-11-06 14:55:47
-recorded_with: VCR-vcr/2.0.0
+      string: '{"model":"claude-sonnet-4-5-20250929","id":"msg_01AWP4hwjqNHe8kNQHFm4wfB","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_01LrWPYcU8p3VmxehvvFJFzs","name":"_structured_tool_call","input":{"data":{"gender":"man","height":"tall","facial_hair":"beard","distinguishing_marks":"scar
+        on left cheek","voice":"deep voice","clothing":"black leather jacket"}},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":730,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":95,"service_tier":"standard","inference_geo":"not_available"}}'
+  recorded_at: 2026-05-11 07:31:30
+recorded_with: VCR-vcr/2.1.0

--- a/vignettes/structured-data.Rmd
+++ b/vignettes/structured-data.Rmd
@@ -360,9 +360,12 @@ data
 #| label: examples-unknown-keys
 #| cassette: true
 
-type_characteristics <- type_object(
-  "All characteristics",
-  .additional_properties = TRUE
+type_characteristics <- type_array(
+  type_object(
+    name = type_string(),
+    value = type_string()
+  ),
+  description = "All characteristics"
 )
 
 text <- "
@@ -370,10 +373,8 @@ text <- "
 "
 
 chat <- chat_anthropic("Extract all characteristics of supplied character")
-str(chat$chat_structured(text, type = type_characteristics))
+chat$chat_structured(text, type = type_characteristics)
 ```
-
-This example only works with Claude, not GPT or Gemini, because only Claude supports adding additional, arbitrary properties.
 
 ### Example 6: Extracting data from an image
 

--- a/vignettes/structured-data.Rmd
+++ b/vignettes/structured-data.Rmd
@@ -356,6 +356,8 @@ data
 
 ### Example 5: Working with unknown keys
 
+If you don't know the keys in advance, you can use an array of name-value pairs. This approach works with all providers, replacing the now-deprecated `.additional_properties` argument.
+
 ```{r}
 #| label: examples-unknown-keys
 #| cassette: true
@@ -375,8 +377,6 @@ text <- "
 chat <- chat_anthropic("Extract all characteristics of supplied character")
 chat$chat_structured(text, type = type_characteristics)
 ```
-
-This approach works with all providers, replacing the now-deprecated `.additional_properties` argument.
 
 ### Example 6: Extracting data from an image
 

--- a/vignettes/structured-data.Rmd
+++ b/vignettes/structured-data.Rmd
@@ -376,6 +376,8 @@ chat <- chat_anthropic("Extract all characteristics of supplied character")
 chat$chat_structured(text, type = type_characteristics)
 ```
 
+This approach works with all providers, replacing the now-deprecated `.additional_properties` argument.
+
 ### Example 6: Extracting data from an image
 
 The final example comes from [Dan Nguyen](https://gist.github.com/dannguyen/faaa56cebf30ad51108a9fe4f8db36d8) (you can see other interesting applications at that link). The goal is to extract structured data from this screenshot:


### PR DESCRIPTION
Implements native structured outputs for Claude.  This is only available for later models, so have retained the "spoof it via a tool call" path for older models.  Added a deprecation warning for `additional_properties` as well.

Closes #866 
