### PR TITLE
fix: when using batch_chat and batch_chat_structured, return `NULL` when job incomplete and `wait=FALSE`

### DIFF
--- a/R/batch-chat.R
+++ b/R/batch-chat.R
@@ -89,9 +89,8 @@ batch_chat <- function(chat, prompts, path, wait = TRUE, ignore_hash = FALSE) {
     wait = wait,
     ignore_hash = ignore_hash
   )
-  result <- job$step_until_done()
-  if (is.null(result)) {
-    return(NULL)
+  if (is.null(job$step_until_done())) {
+    return()
   }
 
   assistant_turns <- job$result_turns()
@@ -153,9 +152,8 @@ batch_chat_structured <- function(
     wait = wait,
     ignore_hash = ignore_hash
   )
-  result <- job$step_until_done()
-  if (is.null(result)) {
-    return(NULL)
+  if (is.null(job$step_until_done())) {
+    return()
   }
   turns <- job$result_turns()
 

--- a/R/batch-chat.R
+++ b/R/batch-chat.R
@@ -89,7 +89,10 @@ batch_chat <- function(chat, prompts, path, wait = TRUE, ignore_hash = FALSE) {
     wait = wait,
     ignore_hash = ignore_hash
   )
-  job$step_until_done()
+  result <- job$step_until_done()
+  if (is.null(result)) {
+    return(NULL)
+  }
 
   assistant_turns <- job$result_turns()
   map2(job$user_turns, assistant_turns, function(user, assistant) {
@@ -150,7 +153,10 @@ batch_chat_structured <- function(
     wait = wait,
     ignore_hash = ignore_hash
   )
-  job$step_until_done()
+  result <- job$step_until_done()
+  if (is.null(result)) {
+    return(NULL)
+  }
   turns <- job$result_turns()
 
   multi_convert(

--- a/tests/testthat/test-batch-chat.R
+++ b/tests/testthat/test-batch-chat.R
@@ -130,7 +130,7 @@ test_that("can run all steps at once", {
   expect_equal(job$results, list(x = 1))
 })
 
-test_that("errors if wait = FALSE and not complete", {
+test_that("step_until_done returns NULL when wait = FALSE and not complete", {
   local_mocked_bindings(
     batch_submit = function(...) list(id = "123"),
     batch_poll = function(...) list(id = "123", results = TRUE),
@@ -144,7 +144,42 @@ test_that("errors if wait = FALSE and not complete", {
     path = path,
     wait = FALSE
   )
-  expect_equal(job$step_until_done(), NULL)
+  expect_null(job$step_until_done())
+})
+
+test_that("batch_chat returns NULL when wait = FALSE and not complete", {
+  local_mocked_bindings(
+    batch_submit = function(...) list(id = "123"),
+    batch_poll = function(...) list(id = "123", results = TRUE),
+    batch_status = function(...) list(working = TRUE)
+  )
+
+  path <- withr::local_tempfile()
+  result <- batch_chat(
+    chat_openai_test(),
+    list("What's your name"),
+    path = path,
+    wait = FALSE
+  )
+  expect_null(result)
+})
+
+test_that("batch_chat_structured returns NULL when wait = FALSE and not complete", {
+  local_mocked_bindings(
+    batch_submit = function(...) list(id = "123"),
+    batch_poll = function(...) list(id = "123", results = TRUE),
+    batch_status = function(...) list(working = TRUE)
+  )
+
+  path <- withr::local_tempfile()
+  result <- batch_chat_structured(
+    chat_openai_test(),
+    list("What's your name"),
+    path = path,
+    type = type_string(),
+    wait = FALSE
+  )
+  expect_null(result)
 })
 
 test_that("informative error for bad inputs", {

--- a/tests/testthat/test-batch-chat.R
+++ b/tests/testthat/test-batch-chat.R
@@ -147,7 +147,7 @@ test_that("step_until_done returns NULL when wait = FALSE and not complete", {
   expect_null(job$step_until_done())
 })
 
-test_that("batch_chat returns NULL when wait = FALSE and not complete", {
+test_that("batch_chat/batch_chat_structured return NULL when wait = FALSE and not complete", {
   local_mocked_bindings(
     batch_submit = function(...) list(id = "123"),
     batch_poll = function(...) list(id = "123", results = TRUE),
@@ -155,31 +155,22 @@ test_that("batch_chat returns NULL when wait = FALSE and not complete", {
   )
 
   path <- withr::local_tempfile()
-  result <- batch_chat(
+  result_chat <- batch_chat(
     chat_openai_test(),
     list("What's your name"),
     path = path,
     wait = FALSE
   )
-  expect_null(result)
-})
+  expect_null(result_chat)
 
-test_that("batch_chat_structured returns NULL when wait = FALSE and not complete", {
-  local_mocked_bindings(
-    batch_submit = function(...) list(id = "123"),
-    batch_poll = function(...) list(id = "123", results = TRUE),
-    batch_status = function(...) list(working = TRUE)
-  )
-
-  path <- withr::local_tempfile()
-  result <- batch_chat_structured(
+  result_structured <- batch_chat_structured(
     chat_openai_test(),
     list("What's your name"),
     path = path,
     type = type_string(),
     wait = FALSE
   )
-  expect_null(result)
+  expect_null(result_structured)
 })
 
 test_that("informative error for bad inputs", {


### PR DESCRIPTION
Fixes #891

This PR adds an early return of `NULL` when a job is not completed, as described in the docs.