### PR TITLE
Defensively unwrap elements when converting R objects to scalar types and input is length-1 list

### DIFF
--- a/R/chat-structured.R
+++ b/R/chat-structured.R
@@ -81,6 +81,8 @@ convert_from_type <- function(x, type) {
         string = NA_character_,
         cli::cli_abort("Unknown type {type@type}", .internal = TRUE)
       )
+    } else if (is.list(x) && length(x) == 1) {
+      x[[1]]
     } else {
       x
     }

--- a/R/chat-structured.R
+++ b/R/chat-structured.R
@@ -82,6 +82,7 @@ convert_from_type <- function(x, type) {
         cli::cli_abort("Unknown type {type@type}", .internal = TRUE)
       )
     } else if (is.list(x) && length(x) == 1) {
+      # Some models intermittently wrap scalars in a JSON array (#931)
       x[[1]]
     } else {
       x

--- a/tests/testthat/test-chat-structured.R
+++ b/tests/testthat/test-chat-structured.R
@@ -65,7 +65,7 @@ test_that("optional base types (scalars) stay as NULL", {
   expect_equal(convert_from_type(NULL, type_string(required = FALSE)), NULL)
 })
 
-test_that("single-element arrays are unwrapped for scalar types", {
+test_that("single-element arrays are unwrapped for scalar types (#931)", {
   expect_equal(convert_from_type(list("hello"), type_string()), "hello")
   expect_equal(convert_from_type(list(42L), type_integer()), 42L)
   expect_equal(convert_from_type(list(3.14), type_number()), 3.14)

--- a/tests/testthat/test-chat-structured.R
+++ b/tests/testthat/test-chat-structured.R
@@ -65,6 +65,13 @@ test_that("optional base types (scalars) stay as NULL", {
   expect_equal(convert_from_type(NULL, type_string(required = FALSE)), NULL)
 })
 
+test_that("single-element arrays are unwrapped for scalar types", {
+  expect_equal(convert_from_type(list("hello"), type_string()), "hello")
+  expect_equal(convert_from_type(list(42L), type_integer()), 42L)
+  expect_equal(convert_from_type(list(3.14), type_number()), 3.14)
+  expect_equal(convert_from_type(list(TRUE), type_boolean()), TRUE)
+})
+
 test_that("can convert arrays of basic types to simple vectors", {
   expect_equal(
     convert_from_type(list(FALSE, TRUE), type_array(type_boolean())),


### PR DESCRIPTION
In #931, there is an error where models sometimes wrap tool call arguments in JSON array brackets even though the schema declares a scalar type, which causes the tool to fail. 

Although this is a model error, we can add in a check that when we know the expected type is scalar, then if a length 1 list is passed in, extract the first element.