### PR TITLE
Update Perplexity default model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ellmer (development version)
 
+* `chat_perplexity()` now defaults to `model = "sonar"` since the previous default (`"llama-3.1-sonar-small-128k-online"`) has been removed by Perplexity (@thisisnic, #538).
 * `models_deepseek()` lists available models for `chat_deepseek()` (@jcrodriguez1989, #919).
 * `type_object(.additional_properties)` is deprecated. No supported provider can return additional properties when using structured output. Instead, use an array of name-value pairs (@thisisnic, #866).
 

--- a/R/provider-perplexity.R
+++ b/R/provider-perplexity.R
@@ -18,7 +18,7 @@ NULL
 #' @family chatbots
 #' @param api_key `r lifecycle::badge("deprecated")` Use `credentials` instead.
 #' @param credentials `r api_key_param("PERPLEXITY_API_KEY")`
-#' @param model `r param_model("llama-3.1-sonar-small-128k-online")`
+#' @param model `r param_model("sonar")`
 #' @param params Common model parameters, usually created by [params()].
 #' @inheritParams chat_openai
 #' @inherit chat_openai return
@@ -38,7 +38,7 @@ chat_perplexity <- function(
   echo = NULL,
   api_headers = character()
 ) {
-  model <- set_default(model, "llama-3.1-sonar-small-128k-online")
+  model <- set_default(model, "sonar")
   echo <- check_echo(echo)
 
   credentials <- as_credentials(

--- a/man/chat_perplexity.Rd
+++ b/man/chat_perplexity.Rd
@@ -28,7 +28,7 @@ which you can easily edit by calling \code{usethis::edit_r_environ()}.
 
 If you do need additional control, this argument takes a zero-argument function that returns either a string (the API key), or a named list (added as additional headers to every request).}
 
-\item{model}{The model to use for the chat (defaults to "llama-3.1-sonar-small-128k-online").
+\item{model}{The model to use for the chat (defaults to "sonar").
 We regularly update the default, so we strongly recommend explicitly specifying a model for anything other than casual use.}
 
 \item{params}{Common model parameters, usually created by \code{\link[=params]{params()}}.}


### PR DESCRIPTION
Fixes #989 - updating the default Perplexity model as the previous one was [deprecated a while ago](https://docs.perplexity.ai/docs/resources/changelog).