### PR TITLE
Add `set_model()` method to `Chat`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ellmer (development version)
 
+* `Chat` gains a `set_model()` method for updating the model after chat creation. Unlike some `chat_*()` functions, the model name is not validated (#988).
 * `chat_perplexity()` now defaults to `model = "sonar"` since the previous default (`"llama-3.1-sonar-small-128k-online"`) has been removed by Perplexity (@thisisnic, #538).
 * `models_deepseek()` lists available models for `chat_deepseek()` (@jcrodriguez1989, #919).
 * `type_object(.additional_properties)` is deprecated. No supported provider can return additional properties when using structured output. Instead, use an array of name-value pairs (@thisisnic, #866).

--- a/R/chat.R
+++ b/R/chat.R
@@ -100,6 +100,16 @@ Chat <- R6::R6Class(
       private$provider@model
     },
 
+    #' @description Update the model name. Note that unlike some of the
+    #'   `chat_*()` functions, the model name is not validated against available
+    #'   models for the provider.
+    #' @param model A single string giving the new model name.
+    set_model = function(model) {
+      check_string(model)
+      private$provider@model <- model
+      invisible(self)
+    },
+
     #' @description Update the system prompt
     #' @param value A character vector giving the new system prompt
     set_system_prompt = function(value) {

--- a/man/Chat.Rd
+++ b/man/Chat.Rd
@@ -32,6 +32,7 @@ chat$chat("Tell me a funny joke")
     \item \href{#method-Chat-add_turn}{\code{Chat$add_turn()}}
     \item \href{#method-Chat-get_system_prompt}{\code{Chat$get_system_prompt()}}
     \item \href{#method-Chat-get_model}{\code{Chat$get_model()}}
+    \item \href{#method-Chat-set_model}{\code{Chat$set_model()}}
     \item \href{#method-Chat-set_system_prompt}{\code{Chat$set_system_prompt()}}
     \item \href{#method-Chat-get_tokens}{\code{Chat$get_tokens()}}
     \item \href{#method-Chat-get_cost}{\code{Chat$get_cost()}}
@@ -163,6 +164,27 @@ session counter?}
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Chat$get_model()}
+    \if{html}{\out{</div>}}
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Chat-set_model"></a>}}
+\if{latex}{\out{\hypertarget{method-Chat-set_model}{}}}
+\subsection{\code{Chat$set_model()}}{
+  Update the model name. Note that unlike some of the
+\verb{chat_*()} functions, the model name is not validated against available
+models for the provider.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Chat$set_model(model)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{model}}{A single string giving the new model name.}
+    }
     \if{html}{\out{</div>}}
   }
 }

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -60,6 +60,12 @@ test_that("can get model", {
   expect_equal(chat$get_model(), "abc")
 })
 
+test_that("can set model", {
+  chat <- chat_openai_test(model = "abc")
+  chat$set_model("def")
+  expect_equal(chat$get_model(), "def")
+})
+
 test_that("setting turns usually preserves, but can set system prompt", {
   chat <- chat_openai_test(system_prompt = "You're a funny guy")
   chat$set_turns(list())


### PR DESCRIPTION
Closes #988

## Summary

Adds a `set_model()` method to the `Chat` R6 class, complementing the existing `get_model()`. This lets users switch models mid-conversation without recreating the chat object.

Unlike the `chat_*()` constructors, `set_model()` does not validate the model name against available models for the provider — it accepts any string.

## Verification

```r
chat <- chat_openai(model = "gpt-5.3")
chat$chat("Tell me a joke about R programming")

# Switch to a different model for the next turn
chat$set_model("gpt-5.4")
chat$get_model()
#> [1] "gpt-5.4"

chat$chat("Now tell me a joke about Python")
```