### PR TITLE
Fix URL encoding in AWS Bedrock inference profile ARNs

### DIFF
--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -252,11 +252,10 @@ method(chat_request, ProviderAWSBedrock) <- function(
   type = NULL
 ) {
   req <- base_request(provider)
+  suffix <- if (stream) "converse-stream" else "converse"
   req <- req_url_path_append(
     req,
-    "model",
-    provider@model,
-    if (stream) "converse-stream" else "converse"
+    paste0("model/", curl::curl_escape(provider@model), "/", suffix)
   )
 
   if (length(turns) >= 1 && is_system_turn(turns[[1]])) {

--- a/tests/testthat/test-provider-aws.R
+++ b/tests/testthat/test-provider-aws.R
@@ -270,3 +270,15 @@ test_that("AWS credential caching works as expected", {
   expect_false(identical(creds1, paws_credentials(profile = "test")))
   expect_false(identical(creds2, paws_credentials(profile = "test")))
 })
+
+test_that("inference profile ARN slash is encoded in URL (#792)", {
+  arn <- "arn:aws:bedrock:us-east-1:123456789:application-inference-profile/abc123"
+  provider <- test_aws_bedrock_provider(model = arn)
+  local_mocked_bindings(
+    paws_credentials = function(...) {
+      list(access_key_id = "x", secret_access_key = "x", session_token = "x")
+    }
+  )
+  req <- chat_request(provider, stream = FALSE, turns = list())
+  expect_match(req$url, "inference-profile%2Fabc123", fixed = TRUE)
+})


### PR DESCRIPTION
Fixes #792 

Marking as draft for now as I don't have Bedrock credentials yet and I'd like to properly test it out before submitting for review - changes suggested by Claude, though all seem relatively reasonable for now.