### PR TITLE
docs: add OpenAI-compatible gateway example

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -61,6 +61,20 @@ ellmer supports a wide variety of model providers:
 * Snowflake Cortex: `chat_snowflake()` and `chat_cortex_analyst()`.
 * VLLM: `chat_vllm()`.
 
+You can also use OpenAI-compatible gateways with `chat_openai_compatible()`.
+For example, Tuning Engines can route ellmer calls through a governed endpoint
+with centralized model access, policy checks, audit logs, traces, and usage/cost
+reporting:
+
+```{r}
+#| eval: false
+chat <- chat_openai_compatible(
+  base_url = "https://api.tuningengines.com/v1",
+  api_key = Sys.getenv("TUNING_ENGINES_API_KEY"),
+  model = "gpt-4o"
+)
+```
+
 ### Provider/model choice
 
 If you're using ellmer inside an organisation, you may have internal policies that limit you to models from big cloud providers, e.g. `chat_azure_openai()`, `chat_aws_bedrock()`, `chat_databricks()`, or `chat_snowflake()`.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ ellmer supports a wide variety of model providers:
 - Snowflake Cortex: `chat_snowflake()` and `chat_cortex_analyst()`.
 - VLLM: `chat_vllm()`.
 
+You can also use OpenAI-compatible gateways with
+`chat_openai_compatible()`. For example, Tuning Engines can route ellmer
+calls through a governed endpoint with centralized model access, policy
+checks, audit logs, traces, and usage/cost reporting:
+
+``` r
+chat <- chat_openai_compatible(
+  base_url = "https://api.tuningengines.com/v1",
+  api_key = Sys.getenv("TUNING_ENGINES_API_KEY"),
+  model = "gpt-4o"
+)
+```
+
 ### Provider/model choice
 
 If you’re using ellmer inside an organisation, you may have internal


### PR DESCRIPTION
## Summary
- add a Tuning Engines example for chat_openai_compatible()
- show base_url, API key, and model setup in README.Rmd and generated README.md
- keep the change in the existing provider overview section

## Why
We are an AI infrastructure team using ellmer with Tuning Engines. Since ellmer already supports OpenAI-compatible providers and gateways through chat_openai_compatible(), this gives R users a concrete setup for governed model access, policy checks, traces, audit logs, and usage/cost reporting. It would mean a lot to us if this helps your users, and I am happy to adjust wording or placement.

## Validation
- git diff --check