### PR TITLE
default base_url to OLLAMA_BASE_URL for all ollama funcs

### DIFF
--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -164,7 +164,7 @@ skip_if_no_ollama <- function() {
 #' @export
 #' @rdname chat_ollama
 models_ollama <- function(
-  base_url = "http://localhost:11434",
+  base_url = Sys.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
   credentials = NULL
 ) {
   credentials <- as_credentials(
@@ -236,7 +236,7 @@ ollama_model_capabilities <- function(
 
 
 has_ollama <- function(
-  base_url = "http://localhost:11434",
+  base_url = Sys.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
   credentials = ollama_credentials()
 ) {
   check_credentials(credentials)


### PR DESCRIPTION
Set default for base_url to Sys.getenv("OLLAMA_BASE_URL", "http://localhost:11434") instead of just "http://localhost:11434" in models_ollama() and has_ollama() so they match the default value in chat_ollama()