### PR TITLE
Make use of `finish_reason` and emit warning/error for truncated responses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # ellmer (development version)
 
-* `AssistantTurn` gains a `finish_reason` property that reports why the model stopped generating. `chat()` now warns when a response is truncated due to the `max_tokens` limit, and `chat_structured()` raises an error because truncated responses produce incomplete JSON (@thisisnic, #3).
+* `chat()` now warns when a response is truncated due to hitting the `max_tokens` limit, and `chat_structured()` raises an informative error. `AssistantTurn` gains a `finish_reason` property that you can inspect programmatically (@thisisnic, #3).
 * `chat_ollama()` now supports `params(reasoning_effort = ...)` to set thinking for reasoning models, and thinking content is now captured in turns (@thisisnic, #940).
 * `chat_google_gemini()` and `chat_google_vertex()` now support `params(reasoning_effort =)` (@thisisnic, #873).
 * `chat_anthropic()` now supports `params(reasoning_effort =)` for Claude's adaptive thinking mode (@thisisnic, #987).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ellmer (development version)
 
+* `AssistantTurn` gains a `finish_reason` property that reports why the model stopped generating. `chat()` now warns when a response is truncated due to the `max_tokens` limit, and `chat_structured()` raises an error because truncated responses produce incomplete JSON (@thisisnic, #3).
 * `chat_ollama()` now supports `params(reasoning_effort = ...)` to set thinking for reasoning models, and thinking content is now captured in turns (@thisisnic, #940).
 * `chat_google_gemini()` and `chat_google_vertex()` now support `params(reasoning_effort =)` (@thisisnic, #873).
 * `chat_anthropic()` now supports `params(reasoning_effort =)` for Claude's adaptive thinking mode (@thisisnic, #987).

--- a/R/chat-structured.R
+++ b/R/chat-structured.R
@@ -1,4 +1,12 @@
 extract_data <- function(turn, type, convert = TRUE, needs_wrapper = FALSE) {
+  if (identical(turn@finish_reason, "max_tokens")) {
+    cli::cli_abort(c(
+      "Structured data extraction failed because the response was truncated.",
+      "i" = "The response hit the {.arg max_tokens} limit before the JSON output was complete.",
+      "i" = "Increase {.arg max_tokens} to allow the model to generate the full response."
+    ))
+  }
+
   is_json <- map_lgl(turn@contents, S7_inherits, ContentJson)
   n <- sum(is_json)
   if (n == 0) {

--- a/R/chat.R
+++ b/R/chat.R
@@ -707,6 +707,12 @@ Chat <- R6::R6Class(
       }
 
       if (!is.null(turn) && !is_partial_turn(turn)) {
+        if (identical(turn@finish_reason, "max_tokens")) {
+          cli::cli_warn(
+            "Response was truncated because it hit the {.arg max_tokens} limit."
+          )
+        }
+
         # Ensure turns always end in a newline
         if (any_text) {
           emit("\n")
@@ -804,6 +810,12 @@ Chat <- R6::R6Class(
       }
 
       if (!is.null(turn) && !is_partial_turn(turn)) {
+        if (identical(turn@finish_reason, "max_tokens")) {
+          cli::cli_warn(
+            "Response was truncated because it hit the {.arg max_tokens} limit."
+          )
+        }
+
         # Ensure turns always end in a newline
         if (any_text) {
           emit("\n")
@@ -978,6 +990,7 @@ TurnAccumulator <- R6::R6Class(
         has_type = !is.null(type)
       )
       turn@duration <- duration
+      turn@finish_reason <- value_finish_reason(self$provider, result)
       match_tools(turn, self$chat$get_tools())
     }
   )

--- a/R/chat.R
+++ b/R/chat.R
@@ -707,12 +707,6 @@ Chat <- R6::R6Class(
       }
 
       if (!is.null(turn) && !is_partial_turn(turn)) {
-        if (identical(turn@finish_reason, "max_tokens")) {
-          cli::cli_warn(
-            "Response was truncated because it hit the {.arg max_tokens} limit."
-          )
-        }
-
         # Ensure turns always end in a newline
         if (any_text) {
           emit("\n")
@@ -810,12 +804,6 @@ Chat <- R6::R6Class(
       }
 
       if (!is.null(turn) && !is_partial_turn(turn)) {
-        if (identical(turn@finish_reason, "max_tokens")) {
-          cli::cli_warn(
-            "Response was truncated because it hit the {.arg max_tokens} limit."
-          )
-        }
-
         # Ensure turns always end in a newline
         if (any_text) {
           emit("\n")
@@ -984,13 +972,21 @@ TurnAccumulator <- R6::R6Class(
     },
 
     value_turn = function(result, type, duration = NA_real_) {
+      finish_reason <- value_finish_reason(self$provider, result)
+
+      if (identical(finish_reason, "max_tokens")) {
+        cli::cli_warn(
+          "Response was truncated because it hit the {.arg max_tokens} limit."
+        )
+      }
+
       turn <- value_turn(
         self$provider,
         result,
         has_type = !is.null(type)
       )
       turn@duration <- duration
-      turn@finish_reason <- value_finish_reason(self$provider, result)
+      turn@finish_reason <- finish_reason
       match_tools(turn, self$chat$get_tools())
     }
   )

--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -415,6 +415,18 @@ method(value_tokens, ProviderAWSBedrock) <- function(provider, json) {
   )
 }
 
+# https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
+method(value_finish_reason, ProviderAWSBedrock) <- function(provider, json) {
+  switch(
+    json$stopReason,
+    end_turn = "success",
+    max_tokens = "max_tokens",
+    stop_sequence = "stop_sequence",
+    guardrail_intervened = "content_filter",
+    "other"
+  )
+}
+
 method(value_turn, ProviderAWSBedrock) <- function(
   provider,
   result,

--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -420,9 +420,11 @@ method(value_finish_reason, ProviderAWSBedrock) <- function(provider, json) {
   switch(
     json$stopReason,
     end_turn = "success",
-    max_tokens = "max_tokens",
+    max_tokens = ,
+    model_context_window_exceeded = "max_tokens",
     stop_sequence = "stop_sequence",
-    guardrail_intervened = "content_filter",
+    guardrail_intervened = ,
+    content_filtered = "content_filter",
     "other"
   )
 }

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -378,6 +378,19 @@ method(value_tokens, ProviderAnthropic) <- function(provider, json) {
   )
 }
 
+# https://docs.anthropic.com/en/api/handling-stop-reasons
+method(value_finish_reason, ProviderAnthropic) <- function(provider, json) {
+  switch(
+    json$stop_reason,
+    end_turn = "success",
+    max_tokens = ,
+    model_context_window_exceeded = "max_tokens",
+    stop_sequence = "stop_sequence",
+    refusal = "content_filter",
+    "other"
+  )
+}
+
 method(value_turn, ProviderAnthropic) <- function(
   provider,
   result,

--- a/R/provider-google.R
+++ b/R/provider-google.R
@@ -332,6 +332,22 @@ method(value_tokens, ProviderGoogleGemini) <- function(provider, json) {
   )
 }
 
+# https://ai.google.dev/api/generate-content
+method(value_finish_reason, ProviderGoogleGemini) <- function(provider, json) {
+  reason <- json$candidates[[1]]$finishReason
+  switch(
+    reason,
+    STOP = "success",
+    MAX_TOKENS = "max_tokens",
+    SAFETY = ,
+    RECITATION = ,
+    BLOCKLIST = ,
+    PROHIBITED_CONTENT = ,
+    SPII = "content_filter",
+    "other"
+  )
+}
+
 method(value_turn, ProviderGoogleGemini) <- function(
   provider,
   result,

--- a/R/provider-openai-compatible.R
+++ b/R/provider-openai-compatible.R
@@ -288,6 +288,21 @@ method(value_tokens, ProviderOpenAICompatible) <- function(provider, json) {
   )
 }
 
+# https://platform.openai.com/docs/api-reference/chat/create
+method(value_finish_reason, ProviderOpenAICompatible) <- function(
+  provider,
+  json
+) {
+  reason <- json$choices[[1]]$finish_reason
+  switch(
+    reason,
+    stop = "success",
+    length = "max_tokens",
+    content_filter = "content_filter",
+    "other"
+  )
+}
+
 method(value_turn, ProviderOpenAICompatible) <- function(
   provider,
   result,

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -246,8 +246,7 @@ method(stream_merge_chunks, ProviderOpenAI) <- function(
   result,
   chunk
 ) {
-  if (chunk$type == "response.completed") {
-    # https://platform.openai.com/docs/api-reference/responses-streaming/response/completed
+  if (chunk$type %in% c("response.completed", "response.incomplete")) {
     chunk$response
   } else if (chunk$type == "response.failed") {
     # https://platform.openai.com/docs/api-reference/responses-streaming/response/failed
@@ -269,6 +268,22 @@ method(value_tokens, ProviderOpenAI) <- function(provider, json) {
     output = usage$output_tokens %||% 0,
     cached_input = cached_tokens
   )
+}
+
+# https://platform.openai.com/docs/api-reference/responses/get
+method(value_finish_reason, ProviderOpenAI) <- function(provider, json) {
+  if (identical(json$status, "completed")) {
+    "success"
+  } else if (identical(json$status, "incomplete")) {
+    reason <- json$incomplete_details$reason
+    if (identical(reason, "max_output_tokens")) {
+      "max_tokens"
+    } else {
+      "other"
+    }
+  } else {
+    "other"
+  }
 }
 
 method(value_turn, ProviderOpenAI) <- function(

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -278,6 +278,8 @@ method(value_finish_reason, ProviderOpenAI) <- function(provider, json) {
     reason <- json$incomplete_details$reason
     if (identical(reason, "max_output_tokens")) {
       "max_tokens"
+    } else if (identical(reason, "content_filter")) {
+      "content_filter"
     } else {
       "other"
     }

--- a/R/provider.R
+++ b/R/provider.R
@@ -193,6 +193,17 @@ method(value_tokens, Provider) <- function(provider, json) {
   tokens()
 }
 
+value_finish_reason <- new_generic(
+  "value_finish_reason",
+  "provider",
+  function(provider, json) {
+    S7_dispatch()
+  }
+)
+method(value_finish_reason, Provider) <- function(provider, json) {
+  NA_character_
+}
+
 # Convert to JSON
 as_json <- new_generic(
   "as_json",

--- a/R/turns.R
+++ b/R/turns.R
@@ -117,6 +117,7 @@ SystemTurn <- new_class(
 #'   used in this turn.
 #' @param cost The cost of the turn in dollars.
 #' @param duration The duration of the request in seconds.
+#' @param finish_reason A string describing why the model stopped generating.
 #' @export
 #' @rdname Turn
 #' @return An S7 `AssistantTurn` object
@@ -139,14 +140,16 @@ AssistantTurn <- new_class(
     role = new_property(
       class = class_character,
       getter = function(self) "assistant"
-    )
+    ),
+    finish_reason = prop_string(allow_na = TRUE)
   ),
   constructor = function(
     contents = list(),
     json = list(),
     tokens = c(NA_real_, NA_real_, NA_real_),
     cost = NA_real_,
-    duration = NA_real_
+    duration = NA_real_,
+    finish_reason = NA_character_
   ) {
     if (is.character(contents)) {
       contents <- list(ContentText(paste0(contents, collapse = "\n")))
@@ -158,7 +161,8 @@ AssistantTurn <- new_class(
       json = json,
       tokens = tokens,
       cost = cost,
-      duration = duration
+      duration = duration,
+      finish_reason = finish_reason
     )
   }
 )

--- a/man/Turn.Rd
+++ b/man/Turn.Rd
@@ -19,7 +19,8 @@ AssistantTurn(
   json = list(),
   tokens = c(NA_real_, NA_real_, NA_real_),
   cost = NA_real_,
-  duration = NA_real_
+  duration = NA_real_,
+  finish_reason = NA_character_
 )
 
 AssistantPartialTurn(
@@ -28,6 +29,7 @@ AssistantPartialTurn(
   tokens = c(NA_real_, NA_real_, NA_real_),
   cost = NA_real_,
   duration = NA_real_,
+  finish_reason = NA_character_,
   reason = "interrupted"
 )
 }
@@ -49,6 +51,8 @@ that ellmer doesn't otherwise expose.}
 \item{cost}{The cost of the turn in dollars.}
 
 \item{duration}{The duration of the request in seconds.}
+
+\item{finish_reason}{A string describing why the model stopped generating.}
 
 \item{reason}{A character string describing why the turn was interrupted.
 Defaults to \code{"interrupted"}.}

--- a/tests/testthat/_snaps/chat-structured.md
+++ b/tests/testthat/_snaps/chat-structured.md
@@ -22,3 +22,13 @@
       Warning:
       The `.additional_properties` argument of `type_object()` is deprecated as of ellmer 0.5.0.
 
+# extract_data() errors on truncated response
+
+    Code
+      extract_data(turn, type)
+    Condition
+      Error in `extract_data()`:
+      ! Structured data extraction failed because the response was truncated.
+      i The response hit the `max_tokens` limit before the JSON output was complete.
+      i Increase `max_tokens` to allow the model to generate the full response.
+

--- a/tests/testthat/test-chat-structured.R
+++ b/tests/testthat/test-chat-structured.R
@@ -306,3 +306,12 @@ test_that("can recursively convert objects contents", {
     list(x = 1, y = c(1, 2, 3))
   )
 })
+
+test_that("extract_data() errors on truncated response", {
+  turn <- AssistantTurn(
+    list(ContentJson(list(x = 1))),
+    finish_reason = "max_tokens"
+  )
+  type <- type_object(x = type_integer())
+  expect_snapshot(extract_data(turn, type), error = TRUE)
+})


### PR DESCRIPTION
Closes #3 and closes #867

PR description below is a little long, but there were a lot of weird details I needed to work around, and have included the reasoning for clarity.

## Summary

When a model response is truncated (e.g., because it hit the `max_tokens` limit), ellmer now detects this and surfaces it to the user.

This PR adds a `finish_reason` property to `AssistantTurn` that standardizes provider-specific stop reasons into a common set. A warning is emitted for any truncated response, and `chat_structured()` raises an error before attempting to parse incomplete JSON.

## Code examples

### Before/After for Anthropic

``` r
library(ellmer)

# Claude
chat <- chat_anthropic(
  model = "claude-sonnet-4-5-20250929",
  params = params(max_tokens = 1)
)
chat$chat_structured(
  "Generate a person with a name and age.",
  type = type_object(name = type_string(), age = type_number()),
  echo = "text"
)
#> {"
#> Error:
#> ! parse error: premature EOF
#>                                        {"
#>                      (right here) ------^
chat$chat("Generate a person with a name and age.")
#>
```

and now...

``` r
library(ellmer)

# Claude
chat <- chat_anthropic(
  model = "claude-sonnet-4-5-20250929",
  params = params(max_tokens = 1)
)
chat$chat_structured(
  "Generate a person with a name and age.",
  type = type_object(name = type_string(), age = type_number()),
  echo = "text"
)
#> Warning: Response was truncated because it hit the `max_tokens` limit.
#> {"
#> Error in `extract_data()`:
#> ! Structured data extraction failed because the response was truncated.
#> ℹ The response hit the `max_tokens` limit before the JSON output was complete.
#> ℹ Increase `max_tokens` to allow the model to generate the full response.
chat$chat("Generate a person with a name and age.")
#> Warning: Response was truncated because it hit the `max_tokens` limit.
#> Here
```


## Design decisions

- **Standardized finish reason values:** `"success"`, `"max_tokens"`, `"stop_sequence"`, `"content_filter"`, `"other"`. Each provider maps its API-specific values to this set. `NA_character_` is the default when no provider method exists.

- **`tool_use` excluded** from the standardized set because ellmer handles tool calls internally - the user never sees those turns.

- **`finish_reason` is a public property on `AssistantTurn`**, alongside `tokens`, `cost`, and `duration`. Users can inspect it on any turn.

- **Extraction follows the `value_tokens` pattern:** new S7 generic `value_finish_reason()` with a default method on `Provider` and per-provider overrides for Claude, OpenAI (Responses API), OpenAI-compatible (Chat Completions), Google Gemini, and AWS Bedrock. OpenRouter and Snowflake inherit from OpenAI-compatible.

- **Warning fires early in `TurnAccumulator$value_turn()`**, before the provider parses the response. This ensures the user is told about truncation even if JSON parsing blows up (which happens with OpenAI's eager parsing of structured output).

- **`extract_data()` errors on truncation** before attempting to parse JSON, giving a clear message about increasing `max_tokens`.

- **Both warning and error can fire** for structured chat (warning from `value_turn`, error from `extract_data`). The error is the important one; the warning provides context.

- **OpenAI streaming fix:** added `response.incomplete` handler in `stream_merge_chunks` so truncated streaming responses are returned rather than silently dropped as `NULL`.