### PR TITLE
Add `finish_reason` property to `AssistantTurn`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # ellmer (development version)
 
-* `AssistantTurn` gains a `finish_reason` property that reports why the model stopped generating. This is populated automatically after each chat response (@thisisnic, #3).
+* `AssistantTurn` gains a `finish_reason` property that reports why the model stopped generating (@thisisnic, #3).
 * `chat_google_gemini()` now defaults to the `gemini-2.5-flash` model (@thisisnic, #885).
 * `chat_portkey()` no longer errors when when using a custom Portkey gateway without the `PORTKEY_VIRTUAL_KEY` env var being set (@thisisnic, #872).
 * `chat_google_vertex()` and `models_google_vertex()` now default `location` and `project_id` to the `GOOGLE_CLOUD_LOCATION` and `GOOGLE_CLOUD_PROJECT` environment variables, no longer incorrectly use `GOOGLE_API_KEY` for authentication, and give a clearer error when cached credentials are invalid (@thisisnic, #994).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ellmer (development version)
 
+* `AssistantTurn` gains a `finish_reason` property that reports why the model stopped generating. This is populated automatically after each chat response (@thisisnic, #3).
 * `chat_google_gemini()` now defaults to the `gemini-2.5-flash` model (@thisisnic, #885).
 * `chat_portkey()` no longer errors when when using a custom Portkey gateway without the `PORTKEY_VIRTUAL_KEY` env var being set (@thisisnic, #872).
 * `chat_google_vertex()` and `models_google_vertex()` now default `location` and `project_id` to the `GOOGLE_CLOUD_LOCATION` and `GOOGLE_CLOUD_PROJECT` environment variables, no longer incorrectly use `GOOGLE_API_KEY` for authentication, and give a clearer error when cached credentials are invalid (@thisisnic, #994).

--- a/R/chat.R
+++ b/R/chat.R
@@ -981,15 +981,12 @@ TurnAccumulator <- R6::R6Class(
     },
 
     value_turn = function(result, type, duration = NA_real_) {
-      finish_reason <- value_finish_reason(self$provider, result)
-
       turn <- value_turn(
         self$provider,
         result,
         has_type = !is.null(type)
       )
       turn@duration <- duration
-      turn@finish_reason <- finish_reason
       match_tools(turn, self$chat$get_tools())
     }
   )

--- a/R/chat.R
+++ b/R/chat.R
@@ -981,12 +981,15 @@ TurnAccumulator <- R6::R6Class(
     },
 
     value_turn = function(result, type, duration = NA_real_) {
+      finish_reason <- value_finish_reason(self$provider, result)
+
       turn <- value_turn(
         self$provider,
         result,
         has_type = !is.null(type)
       )
       turn@duration <- duration
+      turn@finish_reason <- finish_reason
       match_tools(turn, self$chat$get_tools())
     }
   )

--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -392,7 +392,8 @@ method(stream_merge_chunks, ProviderAWSBedrock) <- function(
     result <- list(
       output = list(
         message = result
-      )
+      ),
+      stopReason = chunk$stopReason
     )
   } else if (chunk$event_type == "metadata") {
     result$usage <- chunk$usage

--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -413,20 +413,6 @@ method(value_tokens, ProviderAWSBedrock) <- function(provider, json) {
   )
 }
 
-# https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
-method(value_finish_reason, ProviderAWSBedrock) <- function(provider, json) {
-  switch(
-    json$stopReason,
-    end_turn = "success",
-    max_tokens = "max_tokens",
-    model_context_window_exceeded = "context_window",
-    stop_sequence = "stop_sequence",
-    guardrail_intervened = ,
-    content_filtered = "content_filter",
-    "other"
-  )
-}
-
 method(value_turn, ProviderAWSBedrock) <- function(
   provider,
   result,
@@ -462,7 +448,26 @@ method(value_turn, ProviderAWSBedrock) <- function(
 
   tokens <- value_tokens(provider, result)
   cost <- get_token_cost(provider, tokens)
-  AssistantTurn(contents, json = result, tokens = unlist(tokens), cost = cost)
+
+  # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
+  finish_reason <- switch(
+    result$stopReason,
+    end_turn = "success",
+    max_tokens = "max_tokens",
+    model_context_window_exceeded = "context_window",
+    stop_sequence = "stop_sequence",
+    guardrail_intervened = ,
+    content_filtered = "content_filter",
+    result$stopReason
+  )
+
+  AssistantTurn(
+    contents,
+    json = result,
+    tokens = unlist(tokens),
+    cost = cost,
+    finish_reason = finish_reason
+  )
 }
 
 # ellmer -> Bedrock -------------------------------------------------------------

--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -414,6 +414,24 @@ method(value_tokens, ProviderAWSBedrock) <- function(provider, json) {
   )
 }
 
+# https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
+method(value_finish_reason, ProviderAWSBedrock) <- function(provider, result) {
+  reason <- result$stopReason
+  if (is.null(reason)) {
+    return(NA_character_)
+  }
+  switch(
+    reason,
+    end_turn = "success",
+    max_tokens = "max_tokens",
+    model_context_window_exceeded = "context_window",
+    stop_sequence = "stop_sequence",
+    guardrail_intervened = ,
+    content_filtered = "content_filter",
+    I(reason)
+  )
+}
+
 method(value_turn, ProviderAWSBedrock) <- function(
   provider,
   result,
@@ -450,24 +468,12 @@ method(value_turn, ProviderAWSBedrock) <- function(
   tokens <- value_tokens(provider, result)
   cost <- get_token_cost(provider, tokens)
 
-  # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
-  finish_reason <- switch(
-    result$stopReason,
-    end_turn = "success",
-    max_tokens = "max_tokens",
-    model_context_window_exceeded = "context_window",
-    stop_sequence = "stop_sequence",
-    guardrail_intervened = ,
-    content_filtered = "content_filter",
-    result$stopReason
-  )
-
   AssistantTurn(
     contents,
     json = result,
     tokens = unlist(tokens),
     cost = cost,
-    finish_reason = finish_reason
+    finish_reason = value_finish_reason(provider, result)
   )
 }
 

--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -418,8 +418,8 @@ method(value_finish_reason, ProviderAWSBedrock) <- function(provider, json) {
   switch(
     json$stopReason,
     end_turn = "success",
-    max_tokens = ,
-    model_context_window_exceeded = "max_tokens",
+    max_tokens = "max_tokens",
+    model_context_window_exceeded = "context_window",
     stop_sequence = "stop_sequence",
     guardrail_intervened = ,
     content_filtered = "content_filter",

--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -413,6 +413,20 @@ method(value_tokens, ProviderAWSBedrock) <- function(provider, json) {
   )
 }
 
+# https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
+method(value_finish_reason, ProviderAWSBedrock) <- function(provider, json) {
+  switch(
+    json$stopReason,
+    end_turn = "success",
+    max_tokens = ,
+    model_context_window_exceeded = "max_tokens",
+    stop_sequence = "stop_sequence",
+    guardrail_intervened = ,
+    content_filtered = "content_filter",
+    "other"
+  )
+}
+
 method(value_turn, ProviderAWSBedrock) <- function(
   provider,
   result,

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -382,8 +382,8 @@ method(value_finish_reason, ProviderAnthropic) <- function(provider, json) {
   switch(
     json$stop_reason,
     end_turn = "success",
-    max_tokens = ,
-    model_context_window_exceeded = "max_tokens",
+    max_tokens = "max_tokens",
+    model_context_window_exceeded = "context_window",
     stop_sequence = "stop_sequence",
     refusal = "content_filter",
     "other"

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -377,19 +377,6 @@ method(value_tokens, ProviderAnthropic) <- function(provider, json) {
   )
 }
 
-# https://docs.anthropic.com/en/api/handling-stop-reasons
-method(value_finish_reason, ProviderAnthropic) <- function(provider, json) {
-  switch(
-    json$stop_reason,
-    end_turn = "success",
-    max_tokens = "max_tokens",
-    model_context_window_exceeded = "context_window",
-    stop_sequence = "stop_sequence",
-    refusal = "content_filter",
-    "other"
-  )
-}
-
 method(value_turn, ProviderAnthropic) <- function(
   provider,
   result,
@@ -458,7 +445,24 @@ method(value_turn, ProviderAnthropic) <- function(
   cost_tokens <- tokens
   cost_tokens$input <- cost_tokens$input + cache_write * 0.25
   cost <- get_token_cost(provider, cost_tokens)
-  AssistantTurn(contents, json = result, tokens = unlist(tokens), cost = cost)
+  # https://docs.anthropic.com/en/api/handling-stop-reasons
+  finish_reason <- switch(
+    result$stop_reason,
+    end_turn = "success",
+    max_tokens = "max_tokens",
+    model_context_window_exceeded = "context_window",
+    stop_sequence = "stop_sequence",
+    refusal = "content_filter",
+    result$stop_reason
+  )
+
+  AssistantTurn(
+    contents,
+    json = result,
+    tokens = unlist(tokens),
+    cost = cost,
+    finish_reason = finish_reason
+  )
 }
 
 # ellmer -> Claude --------------------------------------------------------------

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -377,6 +377,23 @@ method(value_tokens, ProviderAnthropic) <- function(provider, json) {
   )
 }
 
+# https://docs.anthropic.com/en/api/handling-stop-reasons
+method(value_finish_reason, ProviderAnthropic) <- function(provider, result) {
+  reason <- result$stop_reason
+  if (is.null(reason)) {
+    return(NA_character_)
+  }
+  switch(
+    reason,
+    end_turn = "success",
+    max_tokens = "max_tokens",
+    model_context_window_exceeded = "context_window",
+    stop_sequence = "stop_sequence",
+    refusal = "content_filter",
+    I(reason)
+  )
+}
+
 method(value_turn, ProviderAnthropic) <- function(
   provider,
   result,
@@ -445,23 +462,12 @@ method(value_turn, ProviderAnthropic) <- function(
   cost_tokens <- tokens
   cost_tokens$input <- cost_tokens$input + cache_write * 0.25
   cost <- get_token_cost(provider, cost_tokens)
-  # https://docs.anthropic.com/en/api/handling-stop-reasons
-  finish_reason <- switch(
-    result$stop_reason,
-    end_turn = "success",
-    max_tokens = "max_tokens",
-    model_context_window_exceeded = "context_window",
-    stop_sequence = "stop_sequence",
-    refusal = "content_filter",
-    result$stop_reason
-  )
-
   AssistantTurn(
     contents,
     json = result,
     tokens = unlist(tokens),
     cost = cost,
-    finish_reason = finish_reason
+    finish_reason = value_finish_reason(provider, result)
   )
 }
 

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -377,6 +377,19 @@ method(value_tokens, ProviderAnthropic) <- function(provider, json) {
   )
 }
 
+# https://docs.anthropic.com/en/api/handling-stop-reasons
+method(value_finish_reason, ProviderAnthropic) <- function(provider, json) {
+  switch(
+    json$stop_reason,
+    end_turn = "success",
+    max_tokens = ,
+    model_context_window_exceeded = "max_tokens",
+    stop_sequence = "stop_sequence",
+    refusal = "content_filter",
+    "other"
+  )
+}
+
 method(value_turn, ProviderAnthropic) <- function(
   provider,
   result,

--- a/R/provider-google.R
+++ b/R/provider-google.R
@@ -332,6 +332,22 @@ method(value_tokens, ProviderGoogleGemini) <- function(provider, json) {
   )
 }
 
+# https://ai.google.dev/api/generate-content
+method(value_finish_reason, ProviderGoogleGemini) <- function(provider, json) {
+  reason <- json$candidates[[1]]$finishReason
+  switch(
+    reason,
+    STOP = "success",
+    MAX_TOKENS = "max_tokens",
+    SAFETY = ,
+    RECITATION = ,
+    BLOCKLIST = ,
+    PROHIBITED_CONTENT = ,
+    SPII = "content_filter",
+    "other"
+  )
+}
+
 method(value_turn, ProviderGoogleGemini) <- function(
   provider,
   result,

--- a/R/provider-google.R
+++ b/R/provider-google.R
@@ -332,22 +332,6 @@ method(value_tokens, ProviderGoogleGemini) <- function(provider, json) {
   )
 }
 
-# https://ai.google.dev/api/generate-content
-method(value_finish_reason, ProviderGoogleGemini) <- function(provider, json) {
-  reason <- json$candidates[[1]]$finishReason
-  switch(
-    reason,
-    STOP = "success",
-    MAX_TOKENS = "max_tokens",
-    SAFETY = ,
-    RECITATION = ,
-    BLOCKLIST = ,
-    PROHIBITED_CONTENT = ,
-    SPII = "content_filter",
-    "other"
-  )
-}
-
 method(value_turn, ProviderGoogleGemini) <- function(
   provider,
   result,
@@ -389,7 +373,28 @@ method(value_turn, ProviderGoogleGemini) <- function(
   contents <- compact(contents)
   tokens <- value_tokens(provider, result)
   cost <- get_token_cost(provider, tokens)
-  AssistantTurn(contents, json = result, tokens = unlist(tokens), cost = cost)
+
+  # https://ai.google.dev/api/generate-content
+  reason <- result$candidates[[1]]$finishReason
+  finish_reason <- switch(
+    reason,
+    STOP = "success",
+    MAX_TOKENS = "max_tokens",
+    SAFETY = ,
+    RECITATION = ,
+    BLOCKLIST = ,
+    PROHIBITED_CONTENT = ,
+    SPII = "content_filter",
+    reason
+  )
+
+  AssistantTurn(
+    contents,
+    json = result,
+    tokens = unlist(tokens),
+    cost = cost,
+    finish_reason = finish_reason
+  )
 }
 
 # ellmer -> Gemini --------------------------------------------------------------

--- a/R/provider-google.R
+++ b/R/provider-google.R
@@ -332,6 +332,28 @@ method(value_tokens, ProviderGoogleGemini) <- function(provider, json) {
   )
 }
 
+# https://ai.google.dev/api/generate-content
+method(value_finish_reason, ProviderGoogleGemini) <- function(
+  provider,
+  result
+) {
+  reason <- result$candidates[[1]]$finishReason
+  if (is.null(reason)) {
+    return(NA_character_)
+  }
+  switch(
+    reason,
+    STOP = "success",
+    MAX_TOKENS = "max_tokens",
+    SAFETY = ,
+    RECITATION = ,
+    BLOCKLIST = ,
+    PROHIBITED_CONTENT = ,
+    SPII = "content_filter",
+    I(reason)
+  )
+}
+
 method(value_turn, ProviderGoogleGemini) <- function(
   provider,
   result,
@@ -374,26 +396,12 @@ method(value_turn, ProviderGoogleGemini) <- function(
   tokens <- value_tokens(provider, result)
   cost <- get_token_cost(provider, tokens)
 
-  # https://ai.google.dev/api/generate-content
-  reason <- result$candidates[[1]]$finishReason
-  finish_reason <- switch(
-    reason,
-    STOP = "success",
-    MAX_TOKENS = "max_tokens",
-    SAFETY = ,
-    RECITATION = ,
-    BLOCKLIST = ,
-    PROHIBITED_CONTENT = ,
-    SPII = "content_filter",
-    reason
-  )
-
   AssistantTurn(
     contents,
     json = result,
     tokens = unlist(tokens),
     cost = cost,
-    finish_reason = finish_reason
+    finish_reason = value_finish_reason(provider, result)
   )
 }
 

--- a/R/provider-openai-compatible.R
+++ b/R/provider-openai-compatible.R
@@ -288,21 +288,6 @@ method(value_tokens, ProviderOpenAICompatible) <- function(provider, json) {
   )
 }
 
-# https://platform.openai.com/docs/api-reference/chat/create
-method(value_finish_reason, ProviderOpenAICompatible) <- function(
-  provider,
-  json
-) {
-  reason <- json$choices[[1]]$finish_reason
-  switch(
-    reason,
-    stop = "success",
-    length = "max_tokens",
-    content_filter = "content_filter",
-    "other"
-  )
-}
-
 method(value_turn, ProviderOpenAICompatible) <- function(
   provider,
   result,
@@ -357,7 +342,24 @@ method(value_turn, ProviderOpenAICompatible) <- function(
 
   tokens <- value_tokens(provider, result)
   cost <- get_token_cost(provider, tokens)
-  AssistantTurn(content, json = result, tokens = unlist(tokens), cost = cost)
+
+  # https://platform.openai.com/docs/api-reference/chat/create
+  reason <- result$choices[[1]]$finish_reason
+  finish_reason <- switch(
+    reason,
+    stop = "success",
+    length = "max_tokens",
+    content_filter = "content_filter",
+    reason
+  )
+
+  AssistantTurn(
+    content,
+    json = result,
+    tokens = unlist(tokens),
+    cost = cost,
+    finish_reason = finish_reason
+  )
 }
 
 # ellmer -> OpenAI --------------------------------------------------------------

--- a/R/provider-openai-compatible.R
+++ b/R/provider-openai-compatible.R
@@ -288,6 +288,21 @@ method(value_tokens, ProviderOpenAICompatible) <- function(provider, json) {
   )
 }
 
+# https://platform.openai.com/docs/api-reference/chat/create
+method(value_finish_reason, ProviderOpenAICompatible) <- function(
+  provider,
+  json
+) {
+  reason <- json$choices[[1]]$finish_reason
+  switch(
+    reason,
+    stop = "success",
+    length = "max_tokens",
+    content_filter = "content_filter",
+    "other"
+  )
+}
+
 method(value_turn, ProviderOpenAICompatible) <- function(
   provider,
   result,

--- a/R/provider-openai-compatible.R
+++ b/R/provider-openai-compatible.R
@@ -288,6 +288,24 @@ method(value_tokens, ProviderOpenAICompatible) <- function(provider, json) {
   )
 }
 
+# https://platform.openai.com/docs/api-reference/chat/create
+method(value_finish_reason, ProviderOpenAICompatible) <- function(
+  provider,
+  result
+) {
+  reason <- result$choices[[1]]$finish_reason
+  if (is.null(reason)) {
+    return(NA_character_)
+  }
+  switch(
+    reason,
+    stop = "success",
+    length = "max_tokens",
+    content_filter = "content_filter",
+    I(reason)
+  )
+}
+
 method(value_turn, ProviderOpenAICompatible) <- function(
   provider,
   result,
@@ -343,22 +361,12 @@ method(value_turn, ProviderOpenAICompatible) <- function(
   tokens <- value_tokens(provider, result)
   cost <- get_token_cost(provider, tokens)
 
-  # https://platform.openai.com/docs/api-reference/chat/create
-  reason <- result$choices[[1]]$finish_reason
-  finish_reason <- switch(
-    reason,
-    stop = "success",
-    length = "max_tokens",
-    content_filter = "content_filter",
-    reason
-  )
-
   AssistantTurn(
     content,
     json = result,
     tokens = unlist(tokens),
     cost = cost,
-    finish_reason = finish_reason
+    finish_reason = value_finish_reason(provider, result)
   )
 }
 

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -270,6 +270,28 @@ method(value_tokens, ProviderOpenAI) <- function(provider, json) {
   )
 }
 
+# https://platform.openai.com/docs/api-reference/responses/get
+method(value_finish_reason, ProviderOpenAI) <- function(provider, result) {
+  status <- result$status
+  if (is.null(status)) {
+    return(NA_character_)
+  }
+  if (identical(status, "completed")) {
+    return("success")
+  }
+  if (!identical(status, "incomplete")) {
+    return(I(status))
+  }
+
+  reason <- result$incomplete_details$reason %||% status
+  switch(
+    reason,
+    max_output_tokens = "max_tokens",
+    content_filter = "content_filter",
+    I(reason)
+  )
+}
+
 method(value_turn, ProviderOpenAI) <- function(
   provider,
   result,
@@ -319,28 +341,12 @@ method(value_turn, ProviderOpenAI) <- function(
   tokens <- value_tokens(provider, result)
   variant <- result$service_tier %||% "default"
   cost <- get_token_cost(provider, tokens, variant = variant)
-  # https://platform.openai.com/docs/api-reference/responses/get
-  if (identical(result$status, "completed")) {
-    finish_reason <- "success"
-  } else if (identical(result$status, "incomplete")) {
-    reason <- result$incomplete_details$reason
-    if (identical(reason, "max_output_tokens")) {
-      finish_reason <- "max_tokens"
-    } else if (identical(reason, "content_filter")) {
-      finish_reason <- "content_filter"
-    } else {
-      finish_reason <- reason %||% result$status
-    }
-  } else {
-    finish_reason <- result$status %||% NA_character_
-  }
-
   AssistantTurn(
     contents = contents,
     json = result,
     tokens = unlist(tokens),
     cost = cost,
-    finish_reason = finish_reason
+    finish_reason = value_finish_reason(provider, result)
   )
 }
 

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -246,8 +246,7 @@ method(stream_merge_chunks, ProviderOpenAI) <- function(
   result,
   chunk
 ) {
-  if (chunk$type == "response.completed") {
-    # https://platform.openai.com/docs/api-reference/responses-streaming/response/completed
+  if (chunk$type %in% c("response.completed", "response.incomplete")) {
     chunk$response
   } else if (chunk$type == "response.failed") {
     # https://platform.openai.com/docs/api-reference/responses-streaming/response/failed
@@ -269,6 +268,24 @@ method(value_tokens, ProviderOpenAI) <- function(provider, json) {
     output = usage$output_tokens %||% 0,
     cached_input = cached_tokens
   )
+}
+
+# https://platform.openai.com/docs/api-reference/responses/get
+method(value_finish_reason, ProviderOpenAI) <- function(provider, json) {
+  if (identical(json$status, "completed")) {
+    "success"
+  } else if (identical(json$status, "incomplete")) {
+    reason <- json$incomplete_details$reason
+    if (identical(reason, "max_output_tokens")) {
+      "max_tokens"
+    } else if (identical(reason, "content_filter")) {
+      "content_filter"
+    } else {
+      "other"
+    }
+  } else {
+    "other"
+  }
 }
 
 method(value_turn, ProviderOpenAI) <- function(

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -270,24 +270,6 @@ method(value_tokens, ProviderOpenAI) <- function(provider, json) {
   )
 }
 
-# https://platform.openai.com/docs/api-reference/responses/get
-method(value_finish_reason, ProviderOpenAI) <- function(provider, json) {
-  if (identical(json$status, "completed")) {
-    "success"
-  } else if (identical(json$status, "incomplete")) {
-    reason <- json$incomplete_details$reason
-    if (identical(reason, "max_output_tokens")) {
-      "max_tokens"
-    } else if (identical(reason, "content_filter")) {
-      "content_filter"
-    } else {
-      "other"
-    }
-  } else {
-    "other"
-  }
-}
-
 method(value_turn, ProviderOpenAI) <- function(
   provider,
   result,
@@ -337,11 +319,28 @@ method(value_turn, ProviderOpenAI) <- function(
   tokens <- value_tokens(provider, result)
   variant <- result$service_tier %||% "default"
   cost <- get_token_cost(provider, tokens, variant = variant)
+  # https://platform.openai.com/docs/api-reference/responses/get
+  if (identical(result$status, "completed")) {
+    finish_reason <- "success"
+  } else if (identical(result$status, "incomplete")) {
+    reason <- result$incomplete_details$reason
+    if (identical(reason, "max_output_tokens")) {
+      finish_reason <- "max_tokens"
+    } else if (identical(reason, "content_filter")) {
+      finish_reason <- "content_filter"
+    } else {
+      finish_reason <- reason %||% result$status
+    }
+  } else {
+    finish_reason <- result$status %||% NA_character_
+  }
+
   AssistantTurn(
     contents = contents,
     json = result,
     tokens = unlist(tokens),
-    cost = cost
+    cost = cost,
+    finish_reason = finish_reason
   )
 }
 

--- a/R/provider.R
+++ b/R/provider.R
@@ -193,6 +193,17 @@ method(value_tokens, Provider) <- function(provider, json) {
   tokens()
 }
 
+value_finish_reason <- new_generic(
+  "value_finish_reason",
+  "provider",
+  function(provider, result) {
+    S7_dispatch()
+  }
+)
+method(value_finish_reason, Provider) <- function(provider, result) {
+  NA_character_
+}
+
 # Convert to JSON
 as_json <- new_generic(
   "as_json",

--- a/R/provider.R
+++ b/R/provider.R
@@ -193,6 +193,17 @@ method(value_tokens, Provider) <- function(provider, json) {
   tokens()
 }
 
+value_finish_reason <- new_generic(
+  "value_finish_reason",
+  "provider",
+  function(provider, json) {
+    S7_dispatch()
+  }
+)
+method(value_finish_reason, Provider) <- function(provider, json) {
+  NA_character_
+}
+
 # Convert to JSON
 as_json <- new_generic(
   "as_json",

--- a/R/provider.R
+++ b/R/provider.R
@@ -193,17 +193,6 @@ method(value_tokens, Provider) <- function(provider, json) {
   tokens()
 }
 
-value_finish_reason <- new_generic(
-  "value_finish_reason",
-  "provider",
-  function(provider, json) {
-    S7_dispatch()
-  }
-)
-method(value_finish_reason, Provider) <- function(provider, json) {
-  NA_character_
-}
-
 # Convert to JSON
 as_json <- new_generic(
   "as_json",

--- a/R/turns.R
+++ b/R/turns.R
@@ -117,6 +117,7 @@ SystemTurn <- new_class(
 #'   used in this turn.
 #' @param cost The cost of the turn in dollars.
 #' @param duration The duration of the request in seconds.
+#' @param finish_reason A string describing why the model stopped generating.
 #' @export
 #' @rdname Turn
 #' @return An S7 `AssistantTurn` object
@@ -139,14 +140,16 @@ AssistantTurn <- new_class(
     role = new_property(
       class = class_character,
       getter = function(self) "assistant"
-    )
+    ),
+    finish_reason = prop_string(allow_na = TRUE)
   ),
   constructor = function(
     contents = list(),
     json = list(),
     tokens = c(NA_real_, NA_real_, NA_real_),
     cost = NA_real_,
-    duration = NA_real_
+    duration = NA_real_,
+    finish_reason = NA_character_
   ) {
     if (is.character(contents)) {
       contents <- list(ContentText(paste0(contents, collapse = "\n")))
@@ -158,7 +161,8 @@ AssistantTurn <- new_class(
       json = json,
       tokens = tokens,
       cost = cost,
-      duration = duration
+      duration = duration,
+      finish_reason = finish_reason
     )
   }
 )

--- a/R/turns.R
+++ b/R/turns.R
@@ -117,7 +117,11 @@ SystemTurn <- new_class(
 #'   used in this turn.
 #' @param cost The cost of the turn in dollars.
 #' @param duration The duration of the request in seconds.
-#' @param finish_reason Why the model stopped generating.
+#' @param finish_reason Why the model stopped generating. Standardized
+#'   across providers to one of: `"success"`, `"max_tokens"`,
+#'   `"stop_sequence"`, `"content_filter"`, or `"context_window"`.
+#'   Unrecognized provider-specific reasons are passed through as-is.
+#'   `NA` when not available.
 #' @export
 #' @rdname Turn
 #' @return An S7 `AssistantTurn` object

--- a/R/turns.R
+++ b/R/turns.R
@@ -117,7 +117,7 @@ SystemTurn <- new_class(
 #'   used in this turn.
 #' @param cost The cost of the turn in dollars.
 #' @param duration The duration of the request in seconds.
-#' @param finish_reason A string describing why the model stopped generating.
+#' @param finish_reason Why the model stopped generating.
 #' @export
 #' @rdname Turn
 #' @return An S7 `AssistantTurn` object

--- a/man/Turn.Rd
+++ b/man/Turn.Rd
@@ -52,7 +52,7 @@ that ellmer doesn't otherwise expose.}
 
 \item{duration}{The duration of the request in seconds.}
 
-\item{finish_reason}{A string describing why the model stopped generating.}
+\item{finish_reason}{Why the model stopped generating.}
 
 \item{reason}{A character string describing why the turn was interrupted.
 Defaults to \code{"interrupted"}.}

--- a/man/Turn.Rd
+++ b/man/Turn.Rd
@@ -52,7 +52,11 @@ that ellmer doesn't otherwise expose.}
 
 \item{duration}{The duration of the request in seconds.}
 
-\item{finish_reason}{Why the model stopped generating.}
+\item{finish_reason}{Why the model stopped generating. Standardized
+across providers to one of: \code{"success"}, \code{"max_tokens"},
+\code{"stop_sequence"}, \code{"content_filter"}, or \code{"context_window"}.
+Unrecognized provider-specific reasons are passed through as-is.
+\code{NA} when not available.}
 
 \item{reason}{A character string describing why the turn was interrupted.
 Defaults to \code{"interrupted"}.}

--- a/man/Turn.Rd
+++ b/man/Turn.Rd
@@ -19,7 +19,8 @@ AssistantTurn(
   json = list(),
   tokens = c(NA_real_, NA_real_, NA_real_),
   cost = NA_real_,
-  duration = NA_real_
+  duration = NA_real_,
+  finish_reason = NA_character_
 )
 
 AssistantPartialTurn(
@@ -28,6 +29,7 @@ AssistantPartialTurn(
   tokens = c(NA_real_, NA_real_, NA_real_),
   cost = NA_real_,
   duration = NA_real_,
+  finish_reason = NA_character_,
   reason = "interrupted"
 )
 }
@@ -49,6 +51,8 @@ that ellmer doesn't otherwise expose.}
 \item{cost}{The cost of the turn in dollars.}
 
 \item{duration}{The duration of the request in seconds.}
+
+\item{finish_reason}{A string describing why the model stopped generating.}
 
 \item{reason}{A character string describing why the turn was interrupted.
 Defaults to \code{"interrupted"}.}

--- a/tests/testthat/test-provider-openai-compatible.R
+++ b/tests/testthat/test-provider-openai-compatible.R
@@ -97,6 +97,7 @@ test_that("value_turn() treats empty content string as null", {
 
   result <- list(
     choices = list(list(
+      finish_reason = "stop",
       message = list(
         role = "assistant",
         content = "",
@@ -186,6 +187,7 @@ test_that("value_turn extracts reasoning_content and reasoning", {
 
   result_content <- list(
     choices = list(list(
+      finish_reason = "stop",
       message = list(
         role = "assistant",
         reasoning_content = "Let me think...",
@@ -202,6 +204,7 @@ test_that("value_turn extracts reasoning_content and reasoning", {
 
   result_reasoning <- list(
     choices = list(list(
+      finish_reason = "stop",
       message = list(
         role = "assistant",
         reasoning = "Let me think...",


### PR DESCRIPTION
Closes #3 - and should set things up nicely for #867

I went with collapsing common options a smaller subset so we can use those values to output error messages - planning to implement that in a follow-up PR

## Summary

- `AssistantTurn` gains a `finish_reason` property that standardizes provider-specific stop reasons into a common set: `"success"`, `"max_tokens"`, `"stop_sequence"`, `"content_filter"`, `"context_window"`. Unrecognized reasons are passed through as the raw provider string. `NA_character_` is the default when no provider method exists.
- Finish reason extraction is handled inline in each provider's `value_turn()` method, following the same pattern as `value_tokens()` and `get_token_cost()`.
- Providers implemented: Claude, OpenAI, OpenAI-compatible, Google Gemini, and AWS Bedrock.
- OpenAI streaming fix: added `response.incomplete` handler in `stream_merge_chunks` so truncated streaming responses are returned rather than silently dropped as `NULL`.

## Design decisions

- **Raw pass-through for unknown values:** Unrecognized stop reasons are returned as-is from the provider rather than mapped to `"other"`, so we have the option to add details to error messages without users needing to dig into `turn@json`.
- **`tool_use` excluded** from the standardized set because ellmer handles tool calls internally -- the user never sees those turns.
