### PR TITLE
Fix reversed params mappings for chat_openai() and chat_databricks()

### DIFF
--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -125,10 +125,10 @@ method(chat_params, ProviderDatabricks) <- function(provider, params) {
     params,
     c(
       temperature = "temperature",
-      top_p = "topP",
-      top_k = "topK",
-      max_tokens = "maxTokens",
-      stop_sequences = "stopSequences"
+      topP = "top_p",
+      topK = "top_k",
+      maxTokens = "max_tokens",
+      stopSequences = "stop_sequences"
     )
   )
 }

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -216,7 +216,7 @@ method(chat_params, ProviderOpenAI) <- function(provider, params) {
       temperature = "temperature",
       top_p = "top_p",
       frequency_penalty = "frequency_penalty",
-      max_tokens = "max_output_tokens",
+      max_output_tokens = "max_tokens",
       log_probs = "log_probs",
       top_logprobs = "top_k",
       reasoning_effort = "reasoning_effort"


### PR DESCRIPTION
Fixes #1018 

Some `param()` mappings were reversed; this PR puts them back to being the right way round.

Haven't added tests as figured it might be a bit too granular, but happy to add. Tested locally with `chat_openai()` and it works with this fix.