### PR TITLE
Update `tool_prompt.md` to instruct LLM to retain original language

### DIFF
--- a/inst/tool_prompt.md
+++ b/inst/tool_prompt.md
@@ -1,8 +1,10 @@
-You have a single purpose: take the documentation for an R function and turn it into a tool call definition. A tool call definition consists of a call to the `tool()` function with the following arguments:
+You have a single purpose: take the documentation for an R function and turn it into a tool call definition.
+
+A tool call definition consists of a call to the `tool()` function with the following arguments:
 
 * The first argument, which should be unnamed, is the function.
 * The second argument, `name`, is the name of the function as a string.
-* The third argument, `description`, is a brief description of the function.
+* The third argument, `description`, is a brief description of the function, in the same language as the provided documentation.
 * The fourth argument, `arguments`, is a named list that describes the types of each argument.
   It should have one element for each argument to the function. The name of the element should be the name of the argument, and the value of the element should be a type specification, as described below.
 
@@ -10,7 +12,7 @@ You have a single purpose: take the documentation for an R function and turn it 
 
 There are four basic types that represent scalars: `type_string()`, `type_number()`, `type_integer()` and `type_boolean()`. These can be combined with `type_array()` to represent vectors, e.g. `type_array(type_string())` for a character vector, `type_array(type_boolean())` for a logical vector and `type_array(type_number())` for a numeric vector.
 
-The first argument to each `type_` function is the `description`. It should include a 1-2 sentence description of the argument.
+The first argument to each `type_` function is the `description`. It should include a 1-2 sentence description of the argument, in the same language as the provided documentation.
 
 Any arguments that don't use one of these basic class should be given type `NULL`, indicating that it can't be easily used by the LLM.
 

--- a/inst/tool_prompt.md
+++ b/inst/tool_prompt.md
@@ -1,6 +1,4 @@
-You have a single purpose: take the documentation for an R function and turn it into a tool call definition.
-
-A tool call definition consists of a call to the `tool()` function with the following arguments:
+You have a single purpose: take the documentation for an R function and turn it into a tool call definition. A tool call definition consists of a call to the `tool()` function with the following arguments:
 
 * The first argument, which should be unnamed, is the function.
 * The second argument, `name`, is the name of the function as a string.


### PR DESCRIPTION
Closes #1016 

This PR updates the system prompt used by `create_tool_def()` instructing the model to retain the original language.  On the attached issue, it was reported that users had problems with it tending to default to English.

I think this is always going to vary depending on underlying model used, but doing some brief testing and it nudged things in the right direction with some weaker models. 