### PR TITLE
Raise a warning or error when a turn is incomplete

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # ellmer (development version)
-* `chat()` now warns when a response is truncated due to the token limit or filtered by the provider's content moderation policy. `chat_structured()` raises an informative error in both cases (@thisisnic, #867).
+* `chat()` now raises a warning and `chat_structured()` raises an informative error when a response is truncated, filtered, or otherwise incomplete (@thisisnic, #867).
 * `AssistantTurn` gains a `finish_reason` property that reports why the model stopped generating (@thisisnic, #3).
 * `chat_google_gemini()` now defaults to the `gemini-2.5-flash` model (@thisisnic, #885).
 * `chat_portkey()` no longer errors when when using a custom Portkey gateway without the `PORTKEY_VIRTUAL_KEY` env var being set (@thisisnic, #872).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # ellmer (development version)
-
+* `chat()` now warns when a response is truncated due to the token limit or filtered by the provider's content moderation policy. `chat_structured()` raises an informative error in both cases (@thisisnic, #867).
 * `AssistantTurn` gains a `finish_reason` property that reports why the model stopped generating (@thisisnic, #3).
 * `chat_google_gemini()` now defaults to the `gemini-2.5-flash` model (@thisisnic, #885).
 * `chat_portkey()` no longer errors when when using a custom Portkey gateway without the `PORTKEY_VIRTUAL_KEY` env var being set (@thisisnic, #872).

--- a/R/chat.R
+++ b/R/chat.R
@@ -984,7 +984,7 @@ TurnAccumulator <- R6::R6Class(
       # Check before value_turn() so structured extraction errors before
       # trying to parse truncated JSON
       finish_reason <- value_finish_reason(self$provider, result)
-     check_finish_reason(finish_reason, if (is.null(type) "warn" else "error")
+      check_finish_reason(finish_reason, if (is.null(type)) "warn" else "error")
 
       turn <- value_turn(
         self$provider,

--- a/R/chat.R
+++ b/R/chat.R
@@ -981,10 +981,9 @@ TurnAccumulator <- R6::R6Class(
     },
 
     value_turn = function(result, type, duration = NA_real_) {
-      finish_reason <- value_finish_reason(self$provider, result)
-
       # Check before value_turn() so structured extraction errors before
       # trying to parse truncated JSON
+      finish_reason <- value_finish_reason(self$provider, result)
       if (is.null(type)) {
         check_finish_reason(finish_reason, "warn")
       } else {

--- a/R/chat.R
+++ b/R/chat.R
@@ -984,11 +984,7 @@ TurnAccumulator <- R6::R6Class(
       # Check before value_turn() so structured extraction errors before
       # trying to parse truncated JSON
       finish_reason <- value_finish_reason(self$provider, result)
-      if (is.null(type)) {
-        check_finish_reason(finish_reason, "warn")
-      } else {
-        check_finish_reason(finish_reason, "error")
-      }
+     check_finish_reason(finish_reason, if (is.null(type) "warn" else "error")
 
       turn <- value_turn(
         self$provider,

--- a/R/chat.R
+++ b/R/chat.R
@@ -983,9 +983,11 @@ TurnAccumulator <- R6::R6Class(
     value_turn = function(result, type, duration = NA_real_) {
       finish_reason <- value_finish_reason(self$provider, result)
 
-      # Error early for structured extraction so we don't try to parse
-      # truncated JSON in value_turn()
-      if (!is.null(type)) {
+      # Check before value_turn() so structured extraction errors before
+      # trying to parse truncated JSON
+      if (is.null(type)) {
+        check_finish_reason(finish_reason, "warn")
+      } else {
         check_finish_reason(finish_reason, "error")
       }
 
@@ -995,9 +997,6 @@ TurnAccumulator <- R6::R6Class(
         has_type = !is.null(type)
       )
       turn@duration <- duration
-
-      check_finish_reason(finish_reason, "warn")
-
       match_tools(turn, self$chat$get_tools())
     }
   )

--- a/R/chat.R
+++ b/R/chat.R
@@ -981,12 +981,23 @@ TurnAccumulator <- R6::R6Class(
     },
 
     value_turn = function(result, type, duration = NA_real_) {
+      finish_reason <- value_finish_reason(self$provider, result)
+
+      # Error early for structured extraction so we don't try to parse
+      # truncated JSON in value_turn()
+      if (!is.null(type)) {
+        check_finish_reason(finish_reason, "error")
+      }
+
       turn <- value_turn(
         self$provider,
         result,
         has_type = !is.null(type)
       )
       turn@duration <- duration
+
+      check_finish_reason(finish_reason, "warn")
+
       match_tools(turn, self$chat$get_tools())
     }
   )

--- a/R/turns.R
+++ b/R/turns.R
@@ -336,25 +336,22 @@ check_finish_reason <- function(finish_reason, signal = c("error", "warn")) {
   signal <- arg_match(signal)
   signal_fn <- switch(signal, error = cli::cli_abort, warn = cli::cli_warn)
 
-  if (identical(finish_reason, "max_tokens")) {
-    signal_fn(c(
-      "Response was truncated because it hit the {.arg max_tokens} limit.",
-      "i" = "Increase {.arg max_tokens} to allow the model to generate the full response."
-    ))
-  }
-  if (identical(finish_reason, "context_window")) {
-    signal_fn(
-      "Response was truncated because it exceeded the model's context window."
+  msg <- if (inherits(finish_reason, "AsIs")) {
+    "Response may be incomplete, unexpected finish reason: {.val {finish_reason}}."
+  } else {
+    switch(
+      finish_reason,
+      max_tokens = c(
+        "Response was truncated because it hit the {.arg max_tokens} limit.",
+        "i" = "Increase {.arg max_tokens} to allow the model to generate the full response."
+      ),
+      context_window = "Response was truncated because it exceeded the model's context window.",
+      content_filter = "Response was filtered by the provider's content moderation policy.",
+      NULL
     )
   }
-  if (identical(finish_reason, "content_filter")) {
-    signal_fn(
-      "Response was filtered by the provider's content moderation policy."
-    )
-  }
-  if (inherits(finish_reason, "AsIs")) {
-    signal_fn(
-      "Response may be incomplete, unexpected finish reason: {.val {finish_reason}}."
-    )
+
+  if (!is.null(msg)) {
+    signal_fn(msg, call = NULL)
   }
 }

--- a/R/turns.R
+++ b/R/turns.R
@@ -331,3 +331,30 @@ turn_contents_preview <- function(turn) {
   })
   paste(contents, collapse = ", ")
 }
+
+check_finish_reason <- function(finish_reason, signal = c("error", "warn")) {
+  signal <- arg_match(signal)
+  signal_fn <- switch(signal, error = cli::cli_abort, warn = cli::cli_warn)
+
+  if (identical(finish_reason, "max_tokens")) {
+    signal_fn(c(
+      "Response was truncated because it hit the {.arg max_tokens} limit.",
+      "i" = "Increase {.arg max_tokens} to allow the model to generate the full response."
+    ))
+  }
+  if (identical(finish_reason, "context_window")) {
+    signal_fn(
+      "Response was truncated because it exceeded the model's context window."
+    )
+  }
+  if (identical(finish_reason, "content_filter")) {
+    signal_fn(
+      "Response was filtered by the provider's content moderation policy."
+    )
+  }
+  if (inherits(finish_reason, "AsIs")) {
+    signal_fn(
+      "Response may be incomplete, unexpected finish reason: {.val {finish_reason}}."
+    )
+  }
+}

--- a/tests/testthat/_snaps/turns.md
+++ b/tests/testthat/_snaps/turns.md
@@ -78,7 +78,7 @@
     Code
       check_finish_reason("max_tokens", "error")
     Condition
-      Error in `check_finish_reason()`:
+      Error:
       ! Response was truncated because it hit the `max_tokens` limit.
       i Increase `max_tokens` to allow the model to generate the full response.
 
@@ -87,7 +87,7 @@
     Code
       check_finish_reason("context_window", "error")
     Condition
-      Error in `check_finish_reason()`:
+      Error:
       ! Response was truncated because it exceeded the model's context window.
 
 ---
@@ -95,7 +95,7 @@
     Code
       check_finish_reason("content_filter", "error")
     Condition
-      Error in `check_finish_reason()`:
+      Error:
       ! Response was filtered by the provider's content moderation policy.
 
 ---
@@ -103,7 +103,7 @@
     Code
       check_finish_reason(I("some_weird_reason"), "error")
     Condition
-      Error in `check_finish_reason()`:
+      Error:
       ! Response may be incomplete, unexpected finish reason: some_weird_reason.
 
 # check_finish_reason() warns on non-success finish reasons

--- a/tests/testthat/_snaps/turns.md
+++ b/tests/testthat/_snaps/turns.md
@@ -73,3 +73,69 @@
       <Turn: user>
       hello
 
+# check_finish_reason() errors on non-success finish reasons
+
+    Code
+      check_finish_reason("max_tokens", "error")
+    Condition
+      Error in `check_finish_reason()`:
+      ! Response was truncated because it hit the `max_tokens` limit.
+      i Increase `max_tokens` to allow the model to generate the full response.
+
+---
+
+    Code
+      check_finish_reason("context_window", "error")
+    Condition
+      Error in `check_finish_reason()`:
+      ! Response was truncated because it exceeded the model's context window.
+
+---
+
+    Code
+      check_finish_reason("content_filter", "error")
+    Condition
+      Error in `check_finish_reason()`:
+      ! Response was filtered by the provider's content moderation policy.
+
+---
+
+    Code
+      check_finish_reason(I("some_weird_reason"), "error")
+    Condition
+      Error in `check_finish_reason()`:
+      ! Response may be incomplete, unexpected finish reason: some_weird_reason.
+
+# check_finish_reason() warns on non-success finish reasons
+
+    Code
+      check_finish_reason("max_tokens", "warn")
+    Condition
+      Warning:
+      Response was truncated because it hit the `max_tokens` limit.
+      i Increase `max_tokens` to allow the model to generate the full response.
+
+---
+
+    Code
+      check_finish_reason("context_window", "warn")
+    Condition
+      Warning:
+      Response was truncated because it exceeded the model's context window.
+
+---
+
+    Code
+      check_finish_reason("content_filter", "warn")
+    Condition
+      Warning:
+      Response was filtered by the provider's content moderation policy.
+
+---
+
+    Code
+      check_finish_reason(I("some_weird_reason"), "warn")
+    Condition
+      Warning:
+      Response may be incomplete, unexpected finish reason: some_weird_reason.
+

--- a/tests/testthat/test-turns.R
+++ b/tests/testthat/test-turns.R
@@ -141,7 +141,10 @@ test_that("check_finish_reason() errors on non-success finish reasons", {
   expect_snapshot(check_finish_reason("max_tokens", "error"), error = TRUE)
   expect_snapshot(check_finish_reason("context_window", "error"), error = TRUE)
   expect_snapshot(check_finish_reason("content_filter", "error"), error = TRUE)
-  expect_snapshot(check_finish_reason(I("some_weird_reason"), "error"), error = TRUE)
+  expect_snapshot(
+    check_finish_reason(I("some_weird_reason"), "error"),
+    error = TRUE
+  )
 })
 
 test_that("check_finish_reason() warns on non-success finish reasons", {

--- a/tests/testthat/test-turns.R
+++ b/tests/testthat/test-turns.R
@@ -134,3 +134,19 @@ test_that("non-text types just show type", {
     "ImageInline, ImageRemote"
   )
 })
+
+# check_finish_reason()
+
+test_that("check_finish_reason() errors on non-success finish reasons", {
+  expect_snapshot(check_finish_reason("max_tokens", "error"), error = TRUE)
+  expect_snapshot(check_finish_reason("context_window", "error"), error = TRUE)
+  expect_snapshot(check_finish_reason("content_filter", "error"), error = TRUE)
+  expect_snapshot(check_finish_reason(I("some_weird_reason"), "error"), error = TRUE)
+})
+
+test_that("check_finish_reason() warns on non-success finish reasons", {
+  expect_snapshot(check_finish_reason("max_tokens", "warn"))
+  expect_snapshot(check_finish_reason("context_window", "warn"))
+  expect_snapshot(check_finish_reason("content_filter", "warn"))
+  expect_snapshot(check_finish_reason(I("some_weird_reason"), "warn"))
+})


### PR DESCRIPTION
Now that #3 is closed and we are returning the `finish_reason` for each turn, we can raise warnings/errors for reasons other than "success".

The one "incomplete" condition I don't error/warn for is `stop_sequence`, as in when a user supplies their own string and the model should stop when it encounters it.

I had Claude take a look to see how other libraries handle it and the provider SDK Python libraries seem to be too thin wrappers to compare as they tend to be silent in these cases.  [Instructor](https://python.useinstructor.com/concepts/error_handling/) only errors on `max_tokens` and Pydantic AI errors on  `max_tokens` and `content_filter` but not `stop_sequence`, so in the absence of any users here requesting it, I think it's fine to leave it?

Closes #867 