### PR TITLE
Ensure `merge_dicts()` handles numeric values 

### DIFF
--- a/R/utils-merge.R
+++ b/R/utils-merge.R
@@ -15,7 +15,7 @@ merge_dicts <- function(left, right) {
       next
     } else if (is.character(left_v)) {
       left[[right_k]] <- paste0(left_v, right_v)
-    } else if (is.integer(left_v)) {
+    } else if (is.numeric(left_v)) {
       left[[right_k]] <- right_v
     } else if (is.list(left_v)) {
       if (!is.null(names(right_v))) {


### PR DESCRIPTION
Fixes #1035, a Perplexity streaming error where `total_cost` (a double) in streaming chunks caused `merge_dicts()` to error. 

Changes `is.integer()` to `is.numeric()` which covers both integers (existing behavior) and doubles - similar to #851 which we didn't fix as the provider had fixed their API before we got to it.
