### PR TITLE
Include tool use as an explicit stop reason so we don't warn on it

### DIFF
--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -423,6 +423,7 @@ method(value_finish_reason, ProviderAWSBedrock) <- function(provider, result) {
   switch(
     reason,
     end_turn = "success",
+    tool_use = "tool_use",
     max_tokens = "max_tokens",
     model_context_window_exceeded = "context_window",
     stop_sequence = "stop_sequence",

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -386,6 +386,7 @@ method(value_finish_reason, ProviderAnthropic) <- function(provider, result) {
   switch(
     reason,
     end_turn = "success",
+    tool_use = "tool_use",
     max_tokens = "max_tokens",
     model_context_window_exceeded = "context_window",
     stop_sequence = "stop_sequence",

--- a/R/provider-openai-compatible.R
+++ b/R/provider-openai-compatible.R
@@ -300,6 +300,7 @@ method(value_finish_reason, ProviderOpenAICompatible) <- function(
   switch(
     reason,
     stop = "success",
+    tool_calls = "tool_use",
     length = "max_tokens",
     content_filter = "content_filter",
     I(reason)

--- a/R/turns.R
+++ b/R/turns.R
@@ -118,8 +118,9 @@ SystemTurn <- new_class(
 #' @param cost The cost of the turn in dollars.
 #' @param duration The duration of the request in seconds.
 #' @param finish_reason Why the model stopped generating. Standardized
-#'   across providers to one of: `"success"`, `"max_tokens"`,
-#'   `"stop_sequence"`, `"content_filter"`, or `"context_window"`.
+#'   across providers to one of: `"success"`, `"tool_use"`,
+#'   `"max_tokens"`, `"stop_sequence"`, `"content_filter"`, or
+#'   `"context_window"`.
 #'   Unrecognized provider-specific reasons are passed through as-is.
 #'   `NA` when not available.
 #' @export

--- a/man/Turn.Rd
+++ b/man/Turn.Rd
@@ -53,8 +53,9 @@ that ellmer doesn't otherwise expose.}
 \item{duration}{The duration of the request in seconds.}
 
 \item{finish_reason}{Why the model stopped generating. Standardized
-across providers to one of: \code{"success"}, \code{"max_tokens"},
-\code{"stop_sequence"}, \code{"content_filter"}, or \code{"context_window"}.
+across providers to one of: \code{"success"}, \code{"tool_use"},
+\code{"max_tokens"}, \code{"stop_sequence"}, \code{"content_filter"}, or
+\code{"context_window"}.
 Unrecognized provider-specific reasons are passed through as-is.
 \code{NA} when not available.}
 


### PR DESCRIPTION
In #1029 we added functionality to raise warnings for unexpected stop sequences, with reasons which haven't been standardised raising warnings.

Most providers return "success" on successful tool use, but a subset give a specific stop reason for tool use, which is currently being handled like other undefined stop reasons and raising a warning.

This PR adds a standardised value "tool_use", so we no longer get those warnings.