### PR TITLE
Fix DeepSeek tool calling when assistant turn has no text

### DIFF
--- a/R/provider-deepseek.R
+++ b/R/provider-deepseek.R
@@ -118,9 +118,10 @@ method(as_json, list(ProviderDeepSeek, Turn)) <- function(provider, x, ...) {
     text <- detect(x@contents, S7_inherits, ContentText)
     tools <- keep(x@contents, is_tool_request)
 
+    content <- if (!is.null(text)) as_json(provider, text, ...)
     list(compact(list(
       role = "assistant",
-      content = as_json(provider, text, ...),
+      content = content,
       tool_calls = as_json(provider, tools, ...)
     )))
   } else {


### PR DESCRIPTION
`chat_deepseek()` errors on tool calls when the model's response contains only a tool request and no text. In this case, `detect()` returns `NULL` (no `ContentText` found), which is then passed to `as_json()`, which has no method for NULL.              
                                                                                                                              
This PR guards the `as_json()` call so it's only made when text is not `NULL`. When it is `NULL`, `compact()` drops the content field from the message, which is the correct shape for a tool-only assistant turn.                                          

Tested locally, and it fixes the failing test.

Fixes #1041  