### PR TITLE
Use provider-specific reasoning content field

### DIFF
--- a/R/provider-openai-compatible.R
+++ b/R/provider-openai-compatible.R
@@ -446,9 +446,7 @@ method(as_json, list(ProviderOpenAICompatible, Turn)) <- function(
       content = content,
       tool_calls = tool_calls
     ))
-    if (!is.null(reasoning_content)) {
-      result[[reasoning_content_field(provider)]] <- reasoning_content
-    }
+    result[[reasoning_content_field(provider)]] <- reasoning_content
     list(result)
   } else {
     cli::cli_abort("Unknown role {x@role}", .internal = TRUE)

--- a/R/provider-openai-compatible.R
+++ b/R/provider-openai-compatible.R
@@ -373,6 +373,18 @@ method(value_turn, ProviderOpenAICompatible) <- function(
 
 # ellmer -> OpenAI --------------------------------------------------------------
 
+# Most providers use "reasoning" but a subset use "reasoning_content" (#1004)
+reasoning_content_field <- function(provider) {
+  if (
+    S7_inherits(provider, ProviderLMStudio) ||
+      S7_inherits(provider, ProviderDeepSeek)
+  ) {
+    "reasoning_content"
+  } else {
+    "reasoning"
+  }
+}
+
 method(as_json, list(ProviderOpenAICompatible, Turn)) <- function(
   provider,
   x,
@@ -429,14 +441,15 @@ method(as_json, list(ProviderOpenAICompatible, Turn)) <- function(
       }
     }
 
-    list(
-      compact(list(
-        role = "assistant",
-        reasoning_content = reasoning_content,
-        content = content,
-        tool_calls = tool_calls
-      ))
-    )
+    result <- compact(list(
+      role = "assistant",
+      content = content,
+      tool_calls = tool_calls
+    ))
+    if (!is.null(reasoning_content)) {
+      result[[reasoning_content_field(provider)]] <- reasoning_content
+    }
+    list(result)
   } else {
     cli::cli_abort("Unknown role {x@role}", .internal = TRUE)
   }

--- a/tests/testthat/test-provider-openai-compatible.R
+++ b/tests/testthat/test-provider-openai-compatible.R
@@ -248,7 +248,7 @@ test_that("as_json preserves reasoning_content when preserve_thinking = TRUE", {
     ContentText("The answer is 42.")
   ))
   result <- as_json(stub, turn)
-  expect_equal(result[[1]]$reasoning_content, "Let me think...")
+  expect_equal(result[[1]]$reasoning, "Let me think...")
   expect_equal(
     result[[1]]$content,
     list(list(type = "text", text = "The answer is 42."))


### PR DESCRIPTION
Fixes #1004 

Due to inconsistencies between OpenAICompatible providers, I've added a new `reasoning_content_field()` function that returns "reasoning_content" for DeepSeek/LM Studio and "reasoning" for everything else. The `as_json()` write path uses it instead of hardcoding "reasoning_content".

It felt like maybe this could have been a generic but it feels like overkill for such a small thing?