### PR TITLE
Bump rlang version and regenerate hashes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     lifecycle,
     promises (>= 1.5.0),
     R6,
-    rlang (>= 1.1.0),
+    rlang (>= 1.3.0),
     S7 (>= 0.2.0),
     tibble,
     vctrs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,6 +64,8 @@ Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Config/testthat/start-first: chat, provider*
+Remotes:
+    r-lib/rlang
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Collate:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,8 +64,6 @@ Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Config/testthat/start-first: chat, provider*
-Remotes:
-    r-lib/rlang
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Collate:

--- a/tests/testthat/batch/state-capitals-anthropic.json
+++ b/tests/testthat/batch/state-capitals-anthropic.json
@@ -2,7 +2,7 @@
   "version": 1,
   "stage": "done",
   "batch": {
-    "id": "msgbatch_01WMP13Kun2n9SFxsUW7oUi4",
+    "id": "msgbatch_01NnXPbgjVXggkeJR2aeANYQ",
     "type": "message_batch",
     "processing_status": "ended",
     "request_counts": {
@@ -12,19 +12,19 @@
       "canceled": 0,
       "expired": 0
     },
-    "ended_at": "2026-06-28T11:20:22.405723+00:00",
-    "created_at": "2026-06-28T11:19:42.434607+00:00",
-    "expires_at": "2026-06-29T11:19:42.434607+00:00",
+    "ended_at": "2026-07-02T14:38:31.308336+00:00",
+    "created_at": "2026-07-02T14:37:36.471728+00:00",
+    "expires_at": "2026-07-03T14:37:36.471728+00:00",
     "archived_at": {},
     "cancel_initiated_at": {},
-    "results_url": "https://api.anthropic.com/v1/messages/batches/msgbatch_01WMP13Kun2n9SFxsUW7oUi4/results"
+    "results_url": "https://api.anthropic.com/v1/messages/batches/msgbatch_01NnXPbgjVXggkeJR2aeANYQ/results"
   },
   "results": [
     {
       "type": "succeeded",
       "message": {
         "model": "claude-sonnet-4-6",
-        "id": "msg_01VuNaVHmbjTYqhByGgSzkHY",
+        "id": "msg_0135vLESKjqLqkkze25gdKB3",
         "type": "message",
         "role": "assistant",
         "content": [
@@ -54,7 +54,7 @@
       "type": "succeeded",
       "message": {
         "model": "claude-sonnet-4-6",
-        "id": "msg_01GDF2sq4g4XRFbQNgVrqvTn",
+        "id": "msg_0187ThapvsVdASZppjZdcGo7",
         "type": "message",
         "role": "assistant",
         "content": [
@@ -84,7 +84,7 @@
       "type": "succeeded",
       "message": {
         "model": "claude-sonnet-4-6",
-        "id": "msg_01S4EU8bYr3ZBRXMEJVPaE8v",
+        "id": "msg_01BbzyjBrNd9s1QRwS1vijKT",
         "type": "message",
         "role": "assistant",
         "content": [
@@ -114,7 +114,7 @@
       "type": "succeeded",
       "message": {
         "model": "claude-sonnet-4-6",
-        "id": "msg_01Hyn4sYKqRTq5CTERvwMPA7",
+        "id": "msg_01Ew3va3ys7tdWUt29cbeH7t",
         "type": "message",
         "role": "assistant",
         "content": [
@@ -141,10 +141,10 @@
       }
     }
   ],
-  "started_at": 1782645582,
+  "started_at": 1783003056,
   "hash": {
-    "provider": "38239488168f12c81fc7df785c065329",
-    "prompts": "b8eafe281e3cc5113058d9722be3e295",
-    "user_turns": "d6990a1b8a9f5db0e97de86c2669de44"
+    "provider": "f9746ebbfa2cfc855eaf56dc7aefcf28",
+    "prompts": "ec58117fcf69ea639e59250f914cca8f",
+    "user_turns": "5c3ea26a1e046a3d3f5a574bf143ebd2"
   }
 }

--- a/tests/testthat/batch/state-capitals-gemini.json
+++ b/tests/testthat/batch/state-capitals-gemini.json
@@ -2,31 +2,31 @@
   "version": 1,
   "stage": "done",
   "batch": {
-    "name": "batches/hp3tanggzvthhnlw3gnj909kf56nq1ntpzyk",
+    "name": "batches/o6k1fq34vm2ou69wy5w72wqw56qjigbln6yy",
     "metadata": {
       "@type": "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatch",
       "model": "models/gemini-3.5-flash",
-      "displayName": "ellmer-1781707740",
+      "displayName": "ellmer-1783003258",
       "inputConfig": {
-        "fileName": "files/rx17ax0iv3zb"
+        "fileName": "files/9ipl31k7go00"
       },
       "output": {
-        "responsesFile": "files/batch-hp3tanggzvthhnlw3gnj909kf56nq1ntpzyk"
+        "responsesFile": "files/batch-o6k1fq34vm2ou69wy5w72wqw56qjigbln6yy"
       },
-      "createTime": "2026-06-17T14:49:01.429015220Z",
-      "endTime": "2026-06-17T14:49:50.441801900Z",
-      "updateTime": "2026-06-17T14:49:50.441801860Z",
+      "createTime": "2026-07-02T14:40:59.019821594Z",
+      "endTime": "2026-07-02T14:41:31.577846928Z",
+      "updateTime": "2026-07-02T14:41:31.577846901Z",
       "batchStats": {
         "requestCount": "4",
         "successfulRequestCount": "4"
       },
       "state": "BATCH_STATE_SUCCEEDED",
-      "name": "batches/hp3tanggzvthhnlw3gnj909kf56nq1ntpzyk"
+      "name": "batches/o6k1fq34vm2ou69wy5w72wqw56qjigbln6yy"
     },
     "done": true,
     "response": {
       "@type": "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatchOutput",
-      "responsesFile": "files/batch-hp3tanggzvthhnlw3gnj909kf56nq1ntpzyk"
+      "responsesFile": "files/batch-o6k1fq34vm2ou69wy5w72wqw56qjigbln6yy"
     }
   },
   "results": [
@@ -39,7 +39,7 @@
               "parts": [
                 {
                   "text": "Des Moines",
-                  "thoughtSignature": "EpgCCpUCAQw51sejSJTf1RN5bk517/YZmWqe1gy6CEDii6/N6o9wuBFNldc6xeYs4PAfIDe2J7SzVSe9/9+zlIq3En87KIXKplDK3NkPdxnuJubuLiU+XwVoiK9c15DLkrJdquLEwf4sOiB+n8jTW68WzN2Q9zcmY2Z7319uKvCYI3HKyjpXE04M74289CQDna3l0cVnRd9TGKbsvJCIu6r5uCRyaMmAJzKu379q0KHL1ZPkbS8ZkVjUzD2yDjImf6f1TogzyWcCS7jmQbaUrnGDNp9ayGsl+1KuZzowEuIj3qNvov2s0klq31f8VNFn+PfS7G98jB9O8ZJOuBZU5rt1t8k+OKGKN+iRnnaup35Fk/s8pQCEA9iNLg=="
+                  "thoughtSignature": "EpgCCpUCAQw51scATKE1eIjMV2yqGfWMipVKz6x9Lp31207TDc5nAP6bDk3mGU22mmIdm//apj+zBMX8pHYreGx76AhfU3YLXLfCzxA23tAiKswpDkJX0zQdq0vI6q+F2PojQpANIsC03l6oapQI1tmbunjX4aZSdC6F7bsTduNhMpz52wH4Xt3WtZlV5pVEBOSGcvcgYqZmRiI2in6eCngY0iowXKLaShyZL1k2Ap7ccBJVvKrfRymfkmtFTYWieFGfbftkbr1ojVmEu8SwLQgowgfzjWHnva4A0JPw+m4YYGR3MTZOVjrbPpo9FtA+qAvmhF49lhlXf6ZVHB6QCU+dhAs+EPJV9arbp/bpCrXWNre644mt4o5xnw=="
                 }
               ],
               "role": "model"
@@ -62,7 +62,7 @@
           "serviceTier": "SERVICE_TIER_STANDARD"
         },
         "modelVersion": "gemini-3.5-flash",
-        "responseId": "CbQyaua_KNnRz7IP2KW1eA"
+        "responseId": "mnhGavTtJvqf_uMP4rue8Qw"
       }
     },
     {
@@ -74,7 +74,7 @@
               "parts": [
                 {
                   "text": "Albany",
-                  "thoughtSignature": "EpsCCpgCAQw51scB4EdutC16DjlzsZF0wDuJhCwridUwZ8p23akJW2E3BqlXqk++bIARLC3fCzKDOxw9vc5ZcpAHoxEkC7ymeHU8EMpAFSWCcBwX+wMlv9vHbuAqFNMnCkcAKWlMOrXnxJupblfUvhVMkNKYB9/gkS6jVFTWO5Hokdsrq6y3n+BS5krGJXuh3eXXgxZAvo2ygv6qCMPNE/wN6QH+Bd1MEjOIIB1XSuRzy8VXDwITSEHQDrSmefyb6AF2LiFnwVyqE4XLBfiiGb+mdq56nkRp6hYtarwWgs5eYRP0yMHBWFvkjypHxfI3nP1lo4H8G9vBgeKIn1lC3tCweJt2WAdRLA3jwmKHoeBlIx1/8tkR3QNQ7+kcVA=="
+                  "thoughtSignature": "EpsCCpgCAQw51sek9uErgy3kFLAoGtj7Qtvg+ZnyeMw5qUMI03Nf8ggV9WYkm4rn4loRf8mDldQ4JqBi/fvbE6F53v28itywFJJe12IGZ4NO2BNq3ftSVpXfjrW3Hb2V9SV7gtxZ3Ep6UiHF059HRswTQooduQXFjifp3Bezx5bzXDZAUNIPSCRSDA2NJYeo5f3NIW3iNSvQliDotePZqj52LU8vv7pvo0H2MnR+13iu9da6g7mc6vwi7hLY4eAS616L5SG/amTfmtWCyiNt4JqFIrk2VIUuk/C9WWpe6FQplORagv3uBYM4+IqWuaU+14rSqQniQGgvydgsNMSfcjkL/NijSrxj5lHklH3/xbSiPN5+wmOs2mcW8nPAxw=="
                 }
               ],
               "role": "model"
@@ -97,7 +97,7 @@
           "serviceTier": "SERVICE_TIER_STANDARD"
         },
         "modelVersion": "gemini-3.5-flash",
-        "responseId": "CrQyauSiGvPsz7IPiK7UgQY"
+        "responseId": "mnhGatqbJcnW_uMPtfKK0Qs"
       }
     },
     {
@@ -109,7 +109,7 @@
               "parts": [
                 {
                   "text": "Sacramento",
-                  "thoughtSignature": "EqECCp4CAQw51scMuavyuYlzbizuD2Eam2bgc1G1ttOuL6RM0wbfp0gzYDPuqkELXMCKREi1AbQ8cCM+EhMSgonIomeMlJVhN6CTduFqxyYaGWHJt8OxxgeunBzxq9YMsCdwyGnRjYXcaGS0BoV7nul6dXBdv1aDcjKqTeo2ql5gMpsJgHkXlqFGJ+ze7QVakagJ+c4vDGRi3bFiv/VlIHZp1x14hXHle4Q3xT07LvYJEWVcVtehaommpAat4eSsAKXl37vYCCYp31vP73CVKFn3yeSVJ2ZKaPOjkV2BA322w2uIS5mgzfBAEH0HAaf/WNlgWTQ8IUsu0W/M2MiUYhry8WS64DXmCyMO8sirFOQWMvqN0OxO7hTLXmAMjV9BqJNaQw=="
+                  "thoughtSignature": "EqECCp4CAQw51sdDF7YRCPI0tqkLEkTVRnNM5eNAdr1C4HLCbmD5Sh3VHljZhIQn0iNZQq+MZF/nbBzfHtUFyjaeNGA9+qFLc2TxYanrlDoKUSsllssqNP1p1QtNyxoPniQyVhJFhcCz3aWsT9yxxtW74RwNYnOYJtX9sZBtZ0qlzNI2azV5Q+WcEf82zMUbNMLMWjtoC5YOxSWSBXlzT+uaqzMBGwT81ao0w3+r14hMskA4l46o4Gxu/3ksF1ndua+ueipkQPUjvcfLvcbLpkdvMoEVocAMvpySvvglPPvyzmjJ0ELpld5P2lMH7Vq95P6GHcxsRQ2He+SD+3rrDYXVWiBUIQj5k7cPI4RPRr9P4rK6/OVG7fdD+CD3xykNC79PYw=="
                 }
               ],
               "role": "model"
@@ -132,7 +132,7 @@
           "serviceTier": "SERVICE_TIER_STANDARD"
         },
         "modelVersion": "gemini-3.5-flash",
-        "responseId": "CbQyas3GENnRz7IP2KW1eA"
+        "responseId": "mnhGaqibJbHf_uMPvOGHmQQ"
       }
     },
     {
@@ -144,7 +144,7 @@
               "parts": [
                 {
                   "text": "Austin",
-                  "thoughtSignature": "EpICCo8CAQw51sdFQ85UKP2dYj+mmZBC+lf5Gbebv6elSkdV+gQXYlT27ryvyxoPmJh4J04U5rV/wh2Q8YJGMpdRFRkfWGCDtyfiC4KxULWnT4CqvqnyH8fNwjVc7G/M1/rkNN3FTEIjXGxCtgVVJGp8Z0NmV7cHUd/7SdShK9jx3rOlr/FlVVL79Vi/QSa9hsFL++WnUl41+HPOtZBapVTpMY9ZgByiqoPHHKqyslyFZAmEh+zg4y2dEABoaSyU37tehj7q2PGdMRkBshW1GhtmiTN0Q0rDbbCuaMaVLvBjOdsJgT5uBTEl07FKri+ctpx4gsZtFDUTOWUgr93LqCXn+uYXbMnlkAg2E/WI9ihGPaQYAQ=="
+                  "thoughtSignature": "EpICCo8CAQw51seWpPdN33ZBmLF5aSau4vDzY6uEcvw+JA5X7lT6XwOhcF1pEwyqB6F6B/E/t7tB8tR0sLo2Rd5w2ICzQ8ShRWdBylb0v2GEA+LHb/DbKb7NAQZ4otcYIkyXTzF9HCarUMQkkIjfX89eFQiDBG7NBHliBrPMv+p5ATXe9sdIC9tDVvAon4iNzL1w6stUQI+0E/dMReoaz4KfqKEJ2Z0ilPppsTBa4/WjMhWiNyBN0M+qBUQqLglzyVgS/BcJGOpkMxun3uKurnWdrcnwsA/FJKn+rg9ZHdBbMF9xX9ssQ0HSBCBAiUy/0e3bbkzwmAx8BSbwJUNGVCo8JJ8x9j8JbqGqqNsIZ1x2QztdUA=="
                 }
               ],
               "role": "model"
@@ -167,14 +167,14 @@
           "serviceTier": "SERVICE_TIER_STANDARD"
         },
         "modelVersion": "gemini-3.5-flash",
-        "responseId": "CrQyaunPA5PYz7IPgIndiAg"
+        "responseId": "mnhGatybJc-a_uMPu6Hd4As"
       }
     }
   ],
-  "started_at": 1781707738,
+  "started_at": 1783003256,
   "hash": {
-    "provider": "90a40229e1ce3371a541e36b95fb2239",
-    "prompts": "b8eafe281e3cc5113058d9722be3e295",
-    "user_turns": "d6990a1b8a9f5db0e97de86c2669de44"
+    "provider": "d38fdcfcdb8f7326fcd973cf4f87f1ba",
+    "prompts": "ec58117fcf69ea639e59250f914cca8f",
+    "user_turns": "5c3ea26a1e046a3d3f5a574bf143ebd2"
   }
 }

--- a/tests/testthat/batch/state-capitals-groq-structured.json
+++ b/tests/testthat/batch/state-capitals-groq-structured.json
@@ -196,8 +196,8 @@
   ],
   "started_at": 1779511975,
   "hash": {
-    "provider": "cb9e7ba7063cd2b349944bda3370e246",
-    "prompts": "b8eafe281e3cc5113058d9722be3e295",
-    "user_turns": "d6990a1b8a9f5db0e97de86c2669de44"
+    "provider": "bcf4b48c31f1f4646419355941879b4b",
+    "prompts": "ec58117fcf69ea639e59250f914cca8f",
+    "user_turns": "5c3ea26a1e046a3d3f5a574bf143ebd2"
   }
 }

--- a/tests/testthat/batch/state-capitals-groq.json
+++ b/tests/testthat/batch/state-capitals-groq.json
@@ -180,8 +180,8 @@
   ],
   "started_at": 1779512129,
   "hash": {
-    "provider": "15e4e540bae33450eee06e09bf585198",
-    "prompts": "b8eafe281e3cc5113058d9722be3e295",
-    "user_turns": "d6990a1b8a9f5db0e97de86c2669de44"
+    "provider": "b59b335990331810f2230ac50b959287",
+    "prompts": "ec58117fcf69ea639e59250f914cca8f",
+    "user_turns": "5c3ea26a1e046a3d3f5a574bf143ebd2"
   }
 }

--- a/tests/testthat/batch/state-capitals.json
+++ b/tests/testthat/batch/state-capitals.json
@@ -2,21 +2,21 @@
   "version": 1,
   "stage": "done",
   "batch": {
-    "id": "batch_690b96afe3c48190a331b74ab7ef7bf7",
+    "id": "batch_6a467790ff508190a1c2715898c1f8c8",
     "object": "batch",
     "endpoint": "/v1/responses",
     "model": "gpt-4.1-nano-2025-04-14",
     "errors": {},
-    "input_file_id": "file-VbvL6fz34Dyo7xxnqAPumD",
+    "input_file_id": "file-889ua152iPnLrfG378UDX2",
     "completion_window": "24h",
     "status": "completed",
-    "output_file_id": "file-BTv8VmKehjwHEdCgGyiGHn",
+    "output_file_id": "file-4wgQGqz38N5o8JwsXeStv4",
     "error_file_id": {},
-    "created_at": 1762367151,
-    "in_progress_at": 1762367153,
-    "expires_at": 1762453551,
-    "finalizing_at": 1762367247,
-    "completed_at": 1762367250,
+    "created_at": 1783003024,
+    "in_progress_at": 1783003087,
+    "expires_at": 1783089424,
+    "finalizing_at": 1783003155,
+    "completed_at": 1783003156,
     "failed_at": {},
     "expired_at": {},
     "cancelling_at": {},
@@ -42,25 +42,28 @@
   "results": [
     {
       "status_code": 200,
-      "request_id": "dbf67650f1d00963188e976a89869604",
+      "request_id": "7b0516d8-ec19-49a9-97d6-7f1bd7beba0f",
       "body": {
-        "id": "resp_0e4e58eb13a6a57d01690b96fb133081959fc08f97760c6426",
+        "id": "resp_06a2cfda6c2d52ab016a4677d4b41081959ec43701696a26ae",
         "object": "response",
-        "created_at": 1762367227,
+        "created_at": 1783003092,
         "status": "completed",
         "background": false,
         "billing": {
           "payer": "developer"
         },
+        "completed_at": 1783003093,
         "error": {},
+        "frequency_penalty": 0,
         "incomplete_details": {},
         "instructions": {},
         "max_output_tokens": {},
         "max_tool_calls": {},
         "model": "gpt-4.1-nano-2025-04-14",
+        "moderation": {},
         "output": [
           {
-            "id": "msg_0e4e58eb13a6a57d01690b96fbd5c08195bd6c312d128f2a17",
+            "id": "msg_06a2cfda6c2d52ab016a4677d5f4148195bfceaf47b57c2398",
             "type": "message",
             "status": "completed",
             "content": [
@@ -75,10 +78,12 @@
           }
         ],
         "parallel_tool_calls": true,
+        "presence_penalty": 0,
         "previous_response_id": {},
         "prompt_cache_key": {},
-        "prompt_cache_retention": {},
+        "prompt_cache_retention": "in_memory",
         "reasoning": {
+          "context": {},
           "effort": {},
           "summary": {}
         },
@@ -93,6 +98,24 @@
           "verbosity": "medium"
         },
         "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
         "tools": [],
         "top_logprobs": 0,
         "top_p": 1,
@@ -114,25 +137,28 @@
     },
     {
       "status_code": 200,
-      "request_id": "699268332d00c3d5324fdd2def7965c0",
+      "request_id": "4f53c74d-28c6-494b-bc9c-510aec5bc7e6",
       "body": {
-        "id": "resp_02c903048608daa501690b970c0454819589ac81e690a0472c",
+        "id": "resp_023f302bf080bc18016a4677e2ae0481979b20b8968cbea410",
         "object": "response",
-        "created_at": 1762367244,
+        "created_at": 1783003106,
         "status": "completed",
         "background": false,
         "billing": {
           "payer": "developer"
         },
+        "completed_at": 1783003107,
         "error": {},
+        "frequency_penalty": 0,
         "incomplete_details": {},
         "instructions": {},
         "max_output_tokens": {},
         "max_tool_calls": {},
         "model": "gpt-4.1-nano-2025-04-14",
+        "moderation": {},
         "output": [
           {
-            "id": "msg_02c903048608daa501690b970c4f008195982f945a6d18ee70",
+            "id": "msg_023f302bf080bc18016a4677e3bef88197a51fc486ba859a00",
             "type": "message",
             "status": "completed",
             "content": [
@@ -147,10 +173,12 @@
           }
         ],
         "parallel_tool_calls": true,
+        "presence_penalty": 0,
         "previous_response_id": {},
         "prompt_cache_key": {},
-        "prompt_cache_retention": {},
+        "prompt_cache_retention": "in_memory",
         "reasoning": {
+          "context": {},
           "effort": {},
           "summary": {}
         },
@@ -165,6 +193,24 @@
           "verbosity": "medium"
         },
         "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
         "tools": [],
         "top_logprobs": 0,
         "top_p": 1,
@@ -186,25 +232,28 @@
     },
     {
       "status_code": 200,
-      "request_id": "0ff64d6fddac213354b040b8cb91e713",
+      "request_id": "746f3c3d-19c2-4431-9553-581b58d81029",
       "body": {
-        "id": "resp_071b120dc863e77a01690b9708002881908bae32a9a7ed5915",
+        "id": "resp_0823f9670f8d4667016a4677dd926081948f67085853e06cef",
         "object": "response",
-        "created_at": 1762367240,
+        "created_at": 1783003101,
         "status": "completed",
         "background": false,
         "billing": {
           "payer": "developer"
         },
+        "completed_at": 1783003102,
         "error": {},
+        "frequency_penalty": 0,
         "incomplete_details": {},
         "instructions": {},
         "max_output_tokens": {},
         "max_tool_calls": {},
         "model": "gpt-4.1-nano-2025-04-14",
+        "moderation": {},
         "output": [
           {
-            "id": "msg_071b120dc863e77a01690b97087518819096966c25f97e89c2",
+            "id": "msg_0823f9670f8d4667016a4677de03408194aec59d6746059c8f",
             "type": "message",
             "status": "completed",
             "content": [
@@ -219,10 +268,12 @@
           }
         ],
         "parallel_tool_calls": true,
+        "presence_penalty": 0,
         "previous_response_id": {},
         "prompt_cache_key": {},
-        "prompt_cache_retention": {},
+        "prompt_cache_retention": "in_memory",
         "reasoning": {
+          "context": {},
           "effort": {},
           "summary": {}
         },
@@ -237,6 +288,24 @@
           "verbosity": "medium"
         },
         "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
         "tools": [],
         "top_logprobs": 0,
         "top_p": 1,
@@ -258,25 +327,28 @@
     },
     {
       "status_code": 200,
-      "request_id": "db47911aba3315792ca9c4720bb37886",
+      "request_id": "1d6c2d9a-70da-4a63-89e6-cdd91b56183b",
       "body": {
-        "id": "resp_05602933a7026bad01690b96cd6ad081969d582c4bd0d22bc3",
+        "id": "resp_04682c07073c71c2016a467810876c81958d4cceaf2c0a2697",
         "object": "response",
-        "created_at": 1762367181,
+        "created_at": 1783003152,
         "status": "completed",
         "background": false,
         "billing": {
           "payer": "developer"
         },
+        "completed_at": 1783003153,
         "error": {},
+        "frequency_penalty": 0,
         "incomplete_details": {},
         "instructions": {},
         "max_output_tokens": {},
         "max_tool_calls": {},
         "model": "gpt-4.1-nano-2025-04-14",
+        "moderation": {},
         "output": [
           {
-            "id": "msg_05602933a7026bad01690b96cf006c81969f8edb2c8481164c",
+            "id": "msg_04682c07073c71c2016a4678118c2c8195b5083e394f73806f",
             "type": "message",
             "status": "completed",
             "content": [
@@ -291,10 +363,12 @@
           }
         ],
         "parallel_tool_calls": true,
+        "presence_penalty": 0,
         "previous_response_id": {},
         "prompt_cache_key": {},
-        "prompt_cache_retention": {},
+        "prompt_cache_retention": "in_memory",
         "reasoning": {
+          "context": {},
           "effort": {},
           "summary": {}
         },
@@ -309,6 +383,24 @@
           "verbosity": "medium"
         },
         "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
         "tools": [],
         "top_logprobs": 0,
         "top_p": 1,
@@ -329,10 +421,10 @@
       }
     }
   ],
-  "started_at": 1762367151,
+  "started_at": 1783003022,
   "hash": {
-    "provider": "959dc7923e4dc3760a7690794dc41c2a",
-    "prompts": "b8eafe281e3cc5113058d9722be3e295",
-    "user_turns": "8c1302088b9bc30258d1191db0d35705"
+    "provider": "52a5237ecd4785eb9feb1e0088b4f83a",
+    "prompts": "ec58117fcf69ea639e59250f914cca8f",
+    "user_turns": "448e40d415a6931aa70d7fdaef3a1d8d"
   }
 }

--- a/tests/testthat/batch/state-name.json
+++ b/tests/testthat/batch/state-name.json
@@ -2,21 +2,21 @@
   "version": 1,
   "stage": "done",
   "batch": {
-    "id": "batch_690b96b808b88190884fea42d08a75d9",
+    "id": "batch_6a4678169ddc81909a5af5bbfb1fdab7",
     "object": "batch",
     "endpoint": "/v1/responses",
     "model": "gpt-4.1-nano-2025-04-14",
     "errors": {},
-    "input_file_id": "file-9CtJTHSjTfnC7SizgVNP1R",
+    "input_file_id": "file-3CvExZ6CMmy3PyCP1M9V1z",
     "completion_window": "24h",
     "status": "completed",
-    "output_file_id": "file-57mvPs5RGTLdNp3HhMFX3r",
+    "output_file_id": "file-WBDMNvBEBpAkS6BXkc8hoa",
     "error_file_id": {},
-    "created_at": 1762367160,
-    "in_progress_at": 1762367162,
-    "expires_at": 1762453560,
-    "finalizing_at": 1762367294,
-    "completed_at": 1762367297,
+    "created_at": 1783003158,
+    "in_progress_at": 1783003161,
+    "expires_at": 1783089558,
+    "finalizing_at": 1783003227,
+    "completed_at": 1783003228,
     "failed_at": {},
     "expired_at": {},
     "cancelling_at": {},
@@ -42,25 +42,28 @@
   "results": [
     {
       "status_code": 200,
-      "request_id": "180df1c185a6cc4275c51a4ae446bcfd",
+      "request_id": "cc5af3c0-a7f3-4c3a-b660-e7e1d632db9b",
       "body": {
-        "id": "resp_078507347be5a04201690b9719be648192bd444bd952ce3c8c",
+        "id": "resp_0a1b5d0ea7777d67016a46781b9d0c819c810c6e779a192c34",
         "object": "response",
-        "created_at": 1762367257,
+        "created_at": 1783003163,
         "status": "completed",
         "background": false,
         "billing": {
           "payer": "developer"
         },
+        "completed_at": 1783003166,
         "error": {},
+        "frequency_penalty": 0,
         "incomplete_details": {},
         "instructions": {},
         "max_output_tokens": {},
         "max_tool_calls": {},
         "model": "gpt-4.1-nano-2025-04-14",
+        "moderation": {},
         "output": [
           {
-            "id": "msg_078507347be5a04201690b971a14e88192bffe648223241807",
+            "id": "msg_0a1b5d0ea7777d67016a46781dd100819c83681cc0144a3c6c",
             "type": "message",
             "status": "completed",
             "content": [
@@ -75,10 +78,12 @@
           }
         ],
         "parallel_tool_calls": true,
+        "presence_penalty": 0,
         "previous_response_id": {},
         "prompt_cache_key": {},
-        "prompt_cache_retention": {},
+        "prompt_cache_retention": "in_memory",
         "reasoning": {
+          "context": {},
           "effort": {},
           "summary": {}
         },
@@ -110,6 +115,24 @@
           "verbosity": "medium"
         },
         "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
         "tools": [],
         "top_logprobs": 0,
         "top_p": 1,
@@ -131,25 +154,28 @@
     },
     {
       "status_code": 200,
-      "request_id": "3dcc108aca45cbb6d3fc00aeed575576",
+      "request_id": "26132048-a749-4e74-96e6-435950142cca",
       "body": {
-        "id": "resp_075417a755df206a01690b9733266c81a19dc4173eea758693",
+        "id": "resp_079582596f151fba016a4678573f4881a28e0793678704a8bc",
         "object": "response",
-        "created_at": 1762367283,
+        "created_at": 1783003223,
         "status": "completed",
         "background": false,
         "billing": {
           "payer": "developer"
         },
+        "completed_at": 1783003224,
         "error": {},
+        "frequency_penalty": 0,
         "incomplete_details": {},
         "instructions": {},
         "max_output_tokens": {},
         "max_tool_calls": {},
         "model": "gpt-4.1-nano-2025-04-14",
+        "moderation": {},
         "output": [
           {
-            "id": "msg_075417a755df206a01690b9733643081a1b4cbe41d08c3d058",
+            "id": "msg_079582596f151fba016a4678584e4881a29973b8062e13e873",
             "type": "message",
             "status": "completed",
             "content": [
@@ -164,10 +190,12 @@
           }
         ],
         "parallel_tool_calls": true,
+        "presence_penalty": 0,
         "previous_response_id": {},
         "prompt_cache_key": {},
-        "prompt_cache_retention": {},
+        "prompt_cache_retention": "in_memory",
         "reasoning": {
+          "context": {},
           "effort": {},
           "summary": {}
         },
@@ -199,6 +227,24 @@
           "verbosity": "medium"
         },
         "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
         "tools": [],
         "top_logprobs": 0,
         "top_p": 1,
@@ -220,25 +266,28 @@
     },
     {
       "status_code": 200,
-      "request_id": "5b77ac64f5e7c820d38bbd47b359475e",
+      "request_id": "dc457380-7ba5-43f2-aa74-cb4975046649",
       "body": {
-        "id": "resp_076f48a04238743e01690b96bdcbac819e9d9fd70c7c005387",
+        "id": "resp_0ec2da13b9392143016a4678575b6081a38d3fb03145c8835c",
         "object": "response",
-        "created_at": 1762367165,
+        "created_at": 1783003223,
         "status": "completed",
         "background": false,
         "billing": {
           "payer": "developer"
         },
+        "completed_at": 1783003225,
         "error": {},
+        "frequency_penalty": 0,
         "incomplete_details": {},
         "instructions": {},
         "max_output_tokens": {},
         "max_tool_calls": {},
         "model": "gpt-4.1-nano-2025-04-14",
+        "moderation": {},
         "output": [
           {
-            "id": "msg_076f48a04238743e01690b96be8854819ebad9414df74ef573",
+            "id": "msg_0ec2da13b9392143016a467858c7e081a3a3133e12d350ac99",
             "type": "message",
             "status": "completed",
             "content": [
@@ -253,10 +302,12 @@
           }
         ],
         "parallel_tool_calls": true,
+        "presence_penalty": 0,
         "previous_response_id": {},
         "prompt_cache_key": {},
-        "prompt_cache_retention": {},
+        "prompt_cache_retention": "in_memory",
         "reasoning": {
+          "context": {},
           "effort": {},
           "summary": {}
         },
@@ -288,6 +339,24 @@
           "verbosity": "medium"
         },
         "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
         "tools": [],
         "top_logprobs": 0,
         "top_p": 1,
@@ -309,25 +378,28 @@
     },
     {
       "status_code": 200,
-      "request_id": "d7527d95afa81e12791465c79d6d37a1",
+      "request_id": "de8223cd-63b6-4d55-8610-24e9a50cc72b",
       "body": {
-        "id": "resp_02332b9b0ee22ae801690b971c78a081a383dfc9b99c0bbaf2",
+        "id": "resp_04a21eef00d09d68016a467857ad1c8191b3228ccdeef3e82c",
         "object": "response",
-        "created_at": 1762367260,
+        "created_at": 1783003223,
         "status": "completed",
         "background": false,
         "billing": {
           "payer": "developer"
         },
+        "completed_at": 1783003225,
         "error": {},
+        "frequency_penalty": 0,
         "incomplete_details": {},
         "instructions": {},
         "max_output_tokens": {},
         "max_tool_calls": {},
         "model": "gpt-4.1-nano-2025-04-14",
+        "moderation": {},
         "output": [
           {
-            "id": "msg_02332b9b0ee22ae801690b971cfb7481a3ad145a506147a250",
+            "id": "msg_04a21eef00d09d68016a467858900c8191b86e1c1bba36e309",
             "type": "message",
             "status": "completed",
             "content": [
@@ -342,10 +414,12 @@
           }
         ],
         "parallel_tool_calls": true,
+        "presence_penalty": 0,
         "previous_response_id": {},
         "prompt_cache_key": {},
-        "prompt_cache_retention": {},
+        "prompt_cache_retention": "in_memory",
         "reasoning": {
+          "context": {},
           "effort": {},
           "summary": {}
         },
@@ -377,6 +451,24 @@
           "verbosity": "medium"
         },
         "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
         "tools": [],
         "top_logprobs": 0,
         "top_p": 1,
@@ -397,10 +489,10 @@
       }
     }
   ],
-  "started_at": 1762367159,
+  "started_at": 1783003157,
   "hash": {
-    "provider": "959dc7923e4dc3760a7690794dc41c2a",
-    "prompts": "b8eafe281e3cc5113058d9722be3e295",
-    "user_turns": "8c1302088b9bc30258d1191db0d35705"
+    "provider": "52a5237ecd4785eb9feb1e0088b4f83a",
+    "prompts": "ec58117fcf69ea639e59250f914cca8f",
+    "user_turns": "448e40d415a6931aa70d7fdaef3a1d8d"
   }
 }


### PR DESCRIPTION
Fixes #1046 

Bump rlang version to 1.3.0 and update the batch tests to use newer hashes.  We should include this in the 0.4.2 release.