### PR TITLE
Support Fable 5 fallback beta header

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # ellmer (development version)
 
 * `Chat` gains a `$token_count()` method that estimates the number of tokens in new input using the provider's token counting endpoint (@thisisnic, #814).
+* `chat_anthropic()` now correctly handles the `fallback` content block returned when a model's server-side refusal fallback (`server-side-fallback-2026-06-01`) is triggered (@simonpcouch, #1058).
 * `chat_aws_bedrock()` now supports bearer token authentication for enterprise API gateways (@thisisnic, #1002).
 * `chat_github()` and `models_github()` are now defunct because GitHub Models has been retired (@thisisnic, #1069).
 * `chat_openrouter()` now correctly preserves provider error messages (@xmarquez, #1059).

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -448,6 +448,9 @@ method(value_turn, ProviderAnthropic) <- function(
         content$thinking,
         extra = list(signature = content$signature)
       )
+    } else if (content$type == "fallback") {
+      # https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback
+      NULL
     } else {
       cli::cli_abort(
         "Unknown content type {.str {content$type}}.",
@@ -455,6 +458,7 @@ method(value_turn, ProviderAnthropic) <- function(
       )
     }
   })
+  contents <- compact(contents)
 
   tokens <- value_tokens(provider, result)
   cache_write <- result$usage$cache_creation_input_tokens %||% 0

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -466,7 +466,11 @@ method(value_turn, ProviderAnthropic) <- function(
   # already counts them at 1.0x, so add the 0.25x surcharge for pricing.
   cost_tokens <- tokens
   cost_tokens$input <- cost_tokens$input + cache_write * 0.25
-  cost <- get_token_cost(provider, cost_tokens)
+  cost <- get_token_cost(
+    provider,
+    cost_tokens,
+    model = serving_model(result) %||% provider@model
+  )
   AssistantTurn(
     contents,
     json = result,
@@ -542,6 +546,20 @@ method(count_tokens, ProviderAnthropic) <- function(
 
   resp <- req_perform(req)
   resp_body_json(resp)$input_tokens
+}
+
+# The model that produced the returned message. `result$model` is unreliable
+# for a mid-output fallback in a stream (it keeps the requested model named at
+# `message_start`), so prefer the last `fallback` block's `to.model`.
+serving_model <- function(result) {
+  to_models <- compact(lapply(result$content, function(content) {
+    if (identical(content$type, "fallback")) content$to$model
+  }))
+  if (length(to_models) > 0) {
+    to_models[[length(to_models)]]
+  } else {
+    result$model
+  }
 }
 
 # ellmer -> Claude --------------------------------------------------------------

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -117,12 +117,17 @@ has_cost <- function(provider, model) {
   vctrs::vec_in(needle, prices[c("provider", "model")])
 }
 
-get_token_cost <- function(provider, tokens, variant = "") {
+get_token_cost <- function(
+  provider,
+  tokens,
+  variant = "",
+  model = provider@model
+) {
   check_string(variant, .internal = TRUE)
 
   needle <- data.frame(
     provider = provider@name,
-    model = provider@model,
+    model = model,
     variant = variant
   )
   idx <- vctrs::vec_match(needle, prices[c("provider", "model", "variant")])

--- a/tests/testthat/test-provider-claude.R
+++ b/tests/testthat/test-provider-claude.R
@@ -256,6 +256,53 @@ test_that("value_turn() prices cache writes at 1.25x while reporting raw tokens"
   expect_equal(unclass(turn@cost), expected_cost)
 })
 
+test_that("value_turn() prices a refusal fallback at the serving model's rate", {
+  provider <- ProviderAnthropic(
+    name = "Anthropic",
+    base_url = "https://api.anthropic.com/v1",
+    model = "claude-fable-5",
+    params = list(),
+    extra_args = list(),
+    extra_headers = character(),
+    credentials = NULL,
+    beta_headers = character(),
+    cache = ""
+  )
+
+  result <- list(
+    model = "claude-opus-4-8",
+    content = list(
+      list(
+        type = "fallback",
+        from = list(model = "claude-fable-5"),
+        to = list(model = "claude-opus-4-8")
+      ),
+      list(type = "text", text = "ok")
+    ),
+    stop_reason = "end_turn",
+    usage = list(input_tokens = 1000, output_tokens = 50)
+  )
+
+  turn <- value_turn(provider, result)
+
+  # opus-4-8 rates ($5/$25 per 1M), not fable-5's ($10/$50).
+  expect_equal(unclass(turn@cost), (1000 * 5 + 50 * 25) / 1e6)
+})
+
+test_that("serving_model() prefers the last fallback block's to.model", {
+  expect_equal(serving_model(list(model = "a", content = list())), "a")
+  expect_equal(
+    serving_model(list(
+      model = "requested",
+      content = list(
+        list(type = "fallback", to = list(model = "served")),
+        list(type = "text", text = "hi")
+      )
+    )),
+    "served"
+  )
+})
+
 test_that("stream_merge_chunks() handles citations_delta", {
   provider <- ProviderAnthropic(
     name = "Anthropic",


### PR DESCRIPTION
Closes #1057.

A more complete version of this would revisit the `$get_cost()` machinery and make sure that the fallback tokens are billed at the appropriate rate. Right now, conversations that fall back would be reported as more expensive than they actually are. Happy to make those changes here if appreciated.