### PR TITLE
Add allow-unsafe-pr-checkout flag

### DIFF
--- a/.github/workflows/format-suggest.yaml
+++ b/.github/workflows/format-suggest.yaml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Install
         uses: posit-dev/setup-air@v1


### PR DESCRIPTION
[`actions/checkout@v4.4.0` was released by GitHub on Jul 20, 2026](https://github.com/actions/checkout/releases/tag/v4.4.0), and added an `allow-unsafe-pr-checkout` check defaulting to `false`

The linter workflow now fails with this error

```
Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

A possible fix is to add `allow-unsafe-pr-checkout: true` to the checkout step - this isn't problematic as we're only running the formatter and not the code.

Reported upstream at https://github.com/posit-dev/setup-air/issues/99

