### PR TITLE
Deprecate GitHub as a provider

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,6 @@ Suggests:
     connectcreds,
     curl (>= 6.0.1),
     gargle,
-    gitcreds,
     jose,
     knitr,
     magick,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # ellmer (development version)
 
 * `Chat` gains a `$token_count()` method that estimates the number of tokens in new input using the provider's token counting endpoint (@thisisnic, #814).
+* `chat_github()` and `models_github()` are now defunct because GitHub Models has been retired (@thisisnic, #1069).
 * `chat_openrouter()` now correctly preserves provider error messages (@xmarquez, #1059).
 
 

--- a/R/provider-github.R
+++ b/R/provider-github.R
@@ -1,17 +1,10 @@
 #' Chat with a model hosted on the GitHub model marketplace
 #'
 #' @description
-#' `r support_badge("official")`
+#' `r lifecycle::badge("deprecated")`
 #'
-#' GitHub Models hosts a number of open source and OpenAI models. To access the
-#' GitHub model marketplace, you will need to apply for and be accepted into the
-#' beta access program. See <https://github.com/marketplace/models> for details.
-#'
-#' The defaults are tweaked for the GitHub Models marketplace.
-#'
-#' GitHub also supports the Azure AI Inference SDK, which you can use by setting
-#' `base_url` to `"https://models.inference.ai.azure.com/"`. This endpoint was
-#' used in \pkg{ellmer} v0.3.0 and earlier.
+#' `chat_github()` and `models_github()` are defunct because GitHub Models
+#' was retired on 2026-07-30.
 #'
 #' @family chatbots
 #' @param api_key `r lifecycle::badge("deprecated")` Use `credentials` instead.
@@ -37,42 +30,13 @@ chat_github <- function(
   echo = NULL,
   api_headers = character()
 ) {
-  check_installed("gitcreds")
-
-  model <- set_default(model, "gpt-5")
-  echo <- check_echo(echo)
-
-  credentials <- as_credentials(
-    "chat_github",
-    function() github_key(),
-    credentials = credentials,
-    api_key = api_key
-  )
-
-  # https://docs.github.com/en/rest/models/inference?apiVersion=2022-11-28
-  params <- params %||% params()
-
-  provider <- ProviderGitHub(
-    name = "gitHub",
-    base_url = base_url,
-    model = model,
-    params = params,
-    extra_args = api_args,
-    extra_headers = api_headers,
-    credentials = credentials
-  )
-  Chat$new(provider = provider, system_prompt = system_prompt, echo = echo)
-}
-
-github_key <- function() {
-  withCallingHandlers(
-    gitcreds::gitcreds_get()$password,
-    error = function(cnd) {
-      cli::cli_abort(
-        "Failed to find git credentials or GITHUB_PAT env var",
-        parent = cnd
-      )
-    }
+  lifecycle::deprecate_stop(
+    "0.5.0",
+    "chat_github()",
+    details = c(
+      "GitHub Models was retired on 2026-07-30.",
+      i = "`chat_google_gemini()` offers a free tier and `chat_posit()` offers a free trial."
+    )
   )
 }
 
@@ -83,66 +47,12 @@ models_github <- function(
   api_key = NULL,
   credentials = NULL
 ) {
-  credentials <- as_credentials(
-    "models_github",
-    function() github_key(),
-    credentials = credentials,
-    api_key = api_key
-  )
-
-  provider <- ProviderGitHub(
-    name = "github",
-    model = "",
-    credentials = credentials,
-    base_url = base_url
-  )
-
-  models_list(provider)
-}
-
-ProviderGitHub <- new_class(
-  "ProviderGitHub",
-  parent = ProviderOpenAICompatible
-)
-
-method(models_list, ProviderGitHub) <- function(provider) {
-  req <- base_request(provider)
-  req <- req_url_path_append(req, "/catalog/models")
-  resp <- req_perform(req)
-
-  json <- resp_body_json(resp)
-
-  if (grepl("models.inference.ai.azure.com", provider@base_url, fixed = TRUE)) {
-    id <- map_chr(json, "[[", "name")
-    publisher <- map_chr(json, "[[", "publisher")
-    license <- map_chr(json, "[[", "license")
-    task <- map_chr(json, "[[", "task")
-
-    return(data.frame(
-      id = id,
-      publisher = publisher,
-      license = license,
-      task = task
-    ))
-  }
-
-  id <- map_chr(json, "[[", "id")
-  publisher <- map_chr(json, "[[", "publisher")
-  registry <- map_chr(json, "[[", "registry")
-  rate_limit_tier <- map_chr(json, "[[", "rate_limit_tier")
-  version <- map_chr(json, "[[", "version")
-  capabilities <- map_chr(
-    map(json, "[[", "capabilities"),
-    paste,
-    collapse = ", "
-  )
-
-  data.frame(
-    id = id,
-    publisher = publisher,
-    registry = registry,
-    rate_limit_tier = rate_limit_tier,
-    version = version,
-    capabilities = capabilities
+  lifecycle::deprecate_stop(
+    "0.5.0",
+    "models_github()",
+    details = c(
+      "GitHub Models was retired on 2026-07-30.",
+      i = "`chat_google_gemini()` offers a free tier and `chat_posit()` offers a free trial."
+    )
   )
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,7 +53,6 @@ contributions to improve them are especially welcome.
 * Azure OpenAI: `chat_azure_openai()`.
 * Databricks: `chat_databricks()`.
 * DeepSeek: `chat_deepseek()`.
-* GitHub model marketplace: `chat_github()`.
 * Google Gemini/Vertex AI: `chat_google_gemini()`, `chat_google_vertex()`.
 * Ollama: `chat_ollama()`.
 * OpenAI: `chat_openai()`.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ community; contributions to improve them are especially welcome.
 - Azure OpenAI: `chat_azure_openai()`.
 - Databricks: `chat_databricks()`.
 - DeepSeek: `chat_deepseek()`.
-- GitHub model marketplace: `chat_github()`.
 - Google Gemini/Vertex AI: `chat_google_gemini()`,
   `chat_google_vertex()`.
 - Ollama: `chat_ollama()`.

--- a/man/chat_github.Rd
+++ b/man/chat_github.Rd
@@ -61,17 +61,10 @@ to every chat API call.}
 A \link{Chat} object.
 }
 \description{
-\ifelse{html}{\figure{support-official.svg}{options: alt='[Official supported provider]'}}{\strong{[Official supported provider]}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-GitHub Models hosts a number of open source and OpenAI models. To access the
-GitHub model marketplace, you will need to apply for and be accepted into the
-beta access program. See \url{https://github.com/marketplace/models} for details.
-
-The defaults are tweaked for the GitHub Models marketplace.
-
-GitHub also supports the Azure AI Inference SDK, which you can use by setting
-\code{base_url} to \code{"https://models.inference.ai.azure.com/"}. This endpoint was
-used in \pkg{ellmer} v0.3.0 and earlier.
+\code{chat_github()} and \code{models_github()} are defunct because GitHub Models
+was retired on 2026-07-30.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-provider-github.R
+++ b/tests/testthat/test-provider-github.R
@@ -1,7 +1,0 @@
-test_that("uses to GITHUB_PAT if set", {
-  withr::local_envvar(
-    GITHUB_PAT = "abc",
-    GITHUB_PAT_GITHUB_COM = NA
-  )
-  expect_equal(github_key(), "abc")
-})


### PR DESCRIPTION
Fixes #1069 

GitHub Models was [fully retired on July 30, 2026](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/). Both `chat_github()` and `models_github()` now fail with HTTP 410 Gone errors.

This PR removes deprecates them both and removes extra code and references to either.


