### PR TITLE
Update Gemini functions which are missing the model/provider split

### DIFF
--- a/R/provider-google.R
+++ b/R/provider-google.R
@@ -259,7 +259,7 @@ method(chat_body, ProviderGoogleGemini) <- function(
     if (
       any(is_builtin) &&
         !all(is_builtin) &&
-        has_google_mixed_tool_support(provider)
+        has_google_mixed_tool_support(provider@name, model@name)
     ) {
       tool_config <- list(includeServerSideToolInvocations = TRUE)
     }
@@ -1266,7 +1266,7 @@ gemini_normalize_result <- function(x, index_default) {
   list(index = index, result = list(status_code = 500L, body = NULL))
 }
 
-has_google_mixed_tool_support <- function(provider) {
-  identical(provider@name, "Google/Gemini") &&
-    grepl("^gemini-([3-9]|[0-9]{2,})", provider@model)
+has_google_mixed_tool_support <- function(provider_name, model_name) {
+  identical(provider_name, "Google/Gemini") &&
+    grepl("^gemini-([3-9]|[0-9]{2,})", model_name)
 }

--- a/tests/testthat/test-provider-google.R
+++ b/tests/testthat/test-provider-google.R
@@ -60,7 +60,9 @@ test_that("can search web pages", {
 })
 
 test_that("can combine built-in and user tools", {
-  provider <- chat_google_gemini_test()$get_provider()
+  chat <- chat_google_gemini_test()
+  provider <- chat$get_provider()
+  model <- chat$get_model_object()
 
   regular_tool <- tool(
     function(x) x,
@@ -70,6 +72,7 @@ test_that("can combine built-in and user tools", {
 
   body <- chat_body(
     provider,
+    model,
     stream = TRUE,
     turns = list(Turn("user", "hi")),
     tools = list(regular_tool, google_tool_web_search())


### PR DESCRIPTION
In #1053 we split out the model/provider, but missed updating a few functions/calls that only became apparent after the live API tests ran on main. This PR fixes those failures.