### PR TITLE
Normalise Databricks responses when deviate from OpenAICompatible format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * `chat_anthropic()`, `chat_aws_bedrock()`, and `chat_posit()` now default to `claude-sonnet-5`. `chat_openai()` and `chat_openrouter()` now default to `gpt-5.6-terra` (@thisisnic, #1066).
 * `chat_anthropic()` now correctly handles the `fallback` content block returned when a model's server-side refusal fallback (`server-side-fallback-2026-06-01`) is triggered (@simonpcouch, #1058).
 * `chat_aws_bedrock()` now supports bearer token authentication for enterprise API gateways (@thisisnic, #1002).
+* `chat_databricks()` no longer errors with models that return content as an array of typed objects (e.g. `databricks-gpt-oss-120b`); reasoning parts are now captured as thinking content (@thisisnic, #1078).
 * `chat_github()` and `models_github()` are now defunct because GitHub Models has been retired (@thisisnic, #1069).
 * `chat_google_gemini()` no longer errors when mixing regular tools and built-in tools like `google_tool_web_search()` (@thisisnic, #1054).
 * `chat_openrouter()` now correctly preserves provider error messages (@xmarquez, #1059).

--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -148,16 +148,20 @@ databricks_normalise_message <- function(message) {
   }
 
   parts <- message$content
-  types <- vapply(parts, function(p) p$type %||% "", character(1))
+  types <- map_chr(parts, function(p) p$type %||% "")
   message$content <- paste0(
-    vapply(parts[types == "text"], function(p) p$text, character(1)),
+    map_chr(parts[types == "text"], function(p) p$text),
     collapse = ""
   )
-  reasoning <- unlist(lapply(parts[types == "reasoning"], function(p) {
-    vapply(p$summary, function(s) s$text, character(1))
-  }))
-  if (length(reasoning)) {
-    message$reasoning <- paste0(reasoning, collapse = "")
+  summaries <- unlist(
+    lapply(parts[types == "reasoning"], function(p) p$summary),
+    recursive = FALSE
+  )
+  if (length(summaries)) {
+    message$reasoning <- paste0(
+      map_chr(summaries, function(s) s$text),
+      collapse = ""
+    )
   }
   message
 }

--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -138,6 +138,74 @@ method(chat_params, ProviderDatabricks) <- function(provider, params) {
   )
 }
 
+# Some Databricks models (e.g. GPT-OSS) return message content as an array of
+# typed objects rather than a plain string (#1078). Normalise to the standard
+# OpenAI-compatible shape: text parts pasted into a string `content`, reasoning
+# summaries moved to `reasoning`.
+databricks_normalise_message <- function(message) {
+  if (!is.list(message$content)) {
+    return(message)
+  }
+
+  parts <- message$content
+  types <- vapply(parts, function(p) p$type %||% "", character(1))
+  message$content <- paste0(
+    vapply(parts[types == "text"], function(p) p$text, character(1)),
+    collapse = ""
+  )
+  reasoning <- unlist(lapply(parts[types == "reasoning"], function(p) {
+    vapply(p$summary, function(s) s$text, character(1))
+  }))
+  if (length(reasoning)) {
+    message$reasoning <- paste0(reasoning, collapse = "")
+  }
+  message
+}
+
+method(stream_content, ProviderDatabricks) <- function(provider, event) {
+  if (length(event$choices) > 0) {
+    event$choices[[1]]$delta <- databricks_normalise_message(
+      event$choices[[1]]$delta
+    )
+  }
+  stream_content(super(provider, ProviderOpenAICompatible), event)
+}
+
+method(stream_merge_chunks, ProviderDatabricks) <- function(
+  provider,
+  result,
+  chunk
+) {
+  # Normalise before merging so merge_dicts() only ever concatenates strings;
+  # merging a string `content` with an array `content` mangles the result
+  if (length(chunk$choices) > 0) {
+    chunk$choices[[1]]$delta <- databricks_normalise_message(
+      chunk$choices[[1]]$delta
+    )
+  }
+  stream_merge_chunks(super(provider, ProviderOpenAICompatible), result, chunk)
+}
+
+method(value_turn, ProviderDatabricks) <- function(
+  provider,
+  model,
+  result,
+  has_type = FALSE
+) {
+  choice <- result$choices[[1]]
+  if (has_name(choice, "delta")) {
+    result$choices[[1]]$delta <- databricks_normalise_message(choice$delta)
+  } else {
+    result$choices[[1]]$message <- databricks_normalise_message(choice$message)
+  }
+  value_turn(
+    super(provider, ProviderOpenAICompatible),
+    model,
+    result,
+    has_type = has_type
+  )
+}
+
 method(chat_path, ProviderDatabricks) <- function(provider) {
   # Note: this API endpoint is undocumented and seems to exist primarily for
   # compatibility with the OpenAI Python SDK. The documented endpoint is

--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -139,10 +139,10 @@ method(chat_params, ProviderDatabricks) <- function(provider, params) {
 }
 
 # Some Databricks models (e.g. GPT-OSS) return message content as an array of
-# typed objects rather than a plain string (#1078). Normalise to the standard
+# typed objects rather than a plain string (#1078). Normalize to the standard
 # OpenAI-compatible shape: text parts pasted into a string `content`, reasoning
 # summaries moved to `reasoning`.
-databricks_normalise_message <- function(message) {
+databricks_normalize_message <- function(message) {
   if (!is.list(message$content)) {
     return(message)
   }
@@ -168,7 +168,7 @@ databricks_normalise_message <- function(message) {
 
 method(stream_content, ProviderDatabricks) <- function(provider, event) {
   if (length(event$choices) > 0) {
-    event$choices[[1]]$delta <- databricks_normalise_message(
+    event$choices[[1]]$delta <- databricks_normalize_message(
       event$choices[[1]]$delta
     )
   }
@@ -180,10 +180,10 @@ method(stream_merge_chunks, ProviderDatabricks) <- function(
   result,
   chunk
 ) {
-  # Normalise before merging so merge_dicts() only ever concatenates strings;
+  # Normalize before merging so merge_dicts() only ever concatenates strings;
   # merging a string `content` with an array `content` mangles the result
   if (length(chunk$choices) > 0) {
-    chunk$choices[[1]]$delta <- databricks_normalise_message(
+    chunk$choices[[1]]$delta <- databricks_normalize_message(
       chunk$choices[[1]]$delta
     )
   }
@@ -198,9 +198,9 @@ method(value_turn, ProviderDatabricks) <- function(
 ) {
   choice <- result$choices[[1]]
   if (has_name(choice, "delta")) {
-    result$choices[[1]]$delta <- databricks_normalise_message(choice$delta)
+    result$choices[[1]]$delta <- databricks_normalize_message(choice$delta)
   } else {
-    result$choices[[1]]$message <- databricks_normalise_message(choice$message)
+    result$choices[[1]]$message <- databricks_normalize_message(choice$message)
   }
   value_turn(
     super(provider, ProviderOpenAICompatible),

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -268,3 +268,44 @@ test_that("stream_content() handles array content from reasoning models (#1078)"
   content <- stream_content(provider, event)
   expect_s7_class(content, ContentThinking)
 })
+
+test_that("value_turn() handles array content from reasoning models (#1078)", {
+  provider <- ProviderDatabricks(
+    name = "Databricks",
+    base_url = "https://example.cloud.databricks.com",
+    credentials = NULL,
+    extra_headers = character()
+  )
+
+  result <- list(
+    choices = list(list(
+      message = list(
+        role = "assistant",
+        content = list(
+          list(
+            type = "reasoning",
+            summary = list(
+              list(
+                type = "summary_text",
+                text = "We just need to answer 1+1=2."
+              )
+            )
+          ),
+          list(type = "text", text = "2")
+        )
+      ),
+      finish_reason = "stop"
+    )),
+    usage = list(
+      prompt_tokens = 108,
+      completion_tokens = 36,
+      total_tokens = 144
+    )
+  )
+
+  turn <- value_turn(provider, test_model("databricks-gpt-oss-20b"), result)
+  expect_length(turn@contents, 2)
+  expect_s7_class(turn@contents[[1]], ContentThinking)
+  expect_s7_class(turn@contents[[2]], ContentText)
+  expect_equal(turn@contents[[2]]@text, "2")
+})

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -267,6 +267,7 @@ test_that("stream_content() handles array content from reasoning models (#1078)"
 
   content <- stream_content(provider, event)
   expect_s7_class(content, ContentThinking)
+  expect_equal(content@thinking, "We need to respond")
 })
 
 test_that("value_turn() handles array content from reasoning models (#1078)", {
@@ -306,6 +307,7 @@ test_that("value_turn() handles array content from reasoning models (#1078)", {
   turn <- value_turn(provider, test_model("databricks-gpt-oss-20b"), result)
   expect_length(turn@contents, 2)
   expect_s7_class(turn@contents[[1]], ContentThinking)
+  expect_equal(turn@contents[[1]]@thinking, "We just need to answer 1+1=2.")
   expect_s7_class(turn@contents[[2]], ContentText)
   expect_equal(turn@contents[[2]]@text, "2")
 })

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -241,3 +241,30 @@ test_that("chat_databricks() serializes tools correctly", {
     )
   )
 })
+
+test_that("stream_content() handles array content from reasoning models (#1078)", {
+  provider <- ProviderDatabricks(
+    name = "Databricks",
+    base_url = "https://example.cloud.databricks.com",
+    credentials = NULL,
+    extra_headers = character()
+  )
+
+  event <- list(
+    choices = list(list(
+      delta = list(
+        content = list(
+          list(
+            type = "reasoning",
+            summary = list(
+              list(type = "summary_text", text = "We need to respond")
+            )
+          )
+        )
+      )
+    ))
+  )
+
+  content <- stream_content(provider, event)
+  expect_s7_class(content, ContentThinking)
+})


### PR DESCRIPTION
Fixes #1078 

Databricks' endpoint deviates a bit from the typical OpenAICompatible format for some models, putting the reasoning content in the wrong field; this PR implements a custom function which detects this and then normalizes it.