### PR TITLE
Support output schemas in tool definitions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * `chat_openrouter()` now correctly preserves provider error messages (@xmarquez, #1059).
 * New `models_update_prices()` downloads the latest model pricing data from GitHub and saves it to a local cache. Subsequent calls to `token_usage()` and related functions will use the updated prices (#968).
 * New `Model` class separates model configuration (name, parameters, extra arguments) from the `Provider` class, which now only captures API endpoint details. `Chat` gains a new `$get_model_object()` method to retrieve the `Model` object. This is a breaking change for anyone who directly accesses `provider@model`, `provider@params`, or `provider@extra_args`; use the `Model` object instead (@thisisnic, #499).
+* `tool()` gains an `output_schema` argument for describing structured tool outputs (@alesangreat, #1082).
 * `tool()` functions that return complex objects like data frames or lists now produce a deprecation warning. Tool functions should return a character vector, an atomic vector, a JSON string (from `jsonlite::toJSON()`), or a `Content` object. Use `jsonlite::toJSON()` to convert complex objects before returning (@thisisnic, #858).
 
 

--- a/R/tools-def.R
+++ b/R/tools-def.R
@@ -76,6 +76,8 @@ NULL
 #'   function. Each element should be created by a [`type_*()`][type_boolean]
 #'   function. Use [type_ignore()] if you don't want the LLM to provide that
 #'   argument (e.g., because the R function has a suitable default value).
+#' @param output_schema An optional [TypeObject] describing the structured
+#'   output returned by the tool.
 #' @param annotations Additional properties that describe the tool and its
 #'   behavior. Usually created by [tool_annotations()], where you can find a
 #'   description of the annotation properties recommended by the [Model Context
@@ -124,6 +126,7 @@ tool <- function(
   ...,
   arguments = list(),
   name = NULL,
+  output_schema = NULL,
   convert = TRUE,
   annotations = list(),
   .name = deprecated(),
@@ -187,6 +190,7 @@ tool <- function(
     name = name,
     description = description,
     arguments = TypeObject(properties = llm_arguments),
+    output_schema = output_schema,
     convert = convert,
     annotations = annotations
   )
@@ -203,6 +207,8 @@ tool <- function(
 #' @param name The name of the tool.
 #' @param description A description of what the tool does.
 #' @param arguments A [TypeObject] describing the tool's arguments.
+#' @param output_schema An optional [TypeObject] describing the structured
+#'   output returned by the tool.
 #' @param convert Whether to automatically convert JSON inputs to R
 #'   equivalents.
 #' @param annotations A list of additional tool annotations.
@@ -222,7 +228,8 @@ ToolDef <- new_class(
     description = prop_string(),
     arguments = TypeObject,
     convert = prop_bool(TRUE),
-    annotations = class_list
+    annotations = class_list,
+    output_schema = NULL | TypeObject
   )
 )
 

--- a/man/ToolDef.Rd
+++ b/man/ToolDef.Rd
@@ -10,7 +10,8 @@ ToolDef(
   description = stop("Required"),
   arguments = TypeObject(),
   convert = TRUE,
-  annotations = list()
+  annotations = list(),
+  output_schema = NULL
 )
 }
 \arguments{
@@ -21,6 +22,9 @@ ToolDef(
 \item{description}{A description of what the tool does.}
 
 \item{arguments}{A \link{TypeObject} describing the tool's arguments.}
+
+\item{output_schema}{An optional \link{TypeObject} describing the structured
+output returned by the tool.}
 
 \item{convert}{Whether to automatically convert JSON inputs to R
 equivalents.}

--- a/man/tool.Rd
+++ b/man/tool.Rd
@@ -10,6 +10,7 @@ tool(
   ...,
   arguments = list(),
   name = NULL,
+  output_schema = NULL,
   convert = TRUE,
   annotations = list(),
   .name = deprecated(),
@@ -48,6 +49,9 @@ argument (e.g., because the R function has a suitable default value).}
 
 \item{name}{The name of the function. This can be omitted if \code{fun} is an
 existing function (i.e. not defined inline).}
+
+\item{output_schema}{An optional \link{TypeObject} describing the structured
+output returned by the tool.}
 
 \item{convert}{Should JSON inputs be automatically convert to their
 R data type equivalents? Defaults to \code{TRUE}.}

--- a/tests/testthat/_snaps/tools-def.md
+++ b/tests/testthat/_snaps/tools-def.md
@@ -100,6 +100,16 @@
       Error:
       ! `x[[1]]` must be a <ToolDef>, not the number 1.
 
+# tool() checks output schema type
+
+    Code
+      tool(function() list(auc = 0.92), description = "Evaluate model performance",
+      output_schema = list(type = "object"))
+    Condition
+      Error:
+      ! <ellmer::ToolDef> object properties are invalid:
+      - @output_schema must be <NULL> or <ellmer::TypeObject>, not <list>
+
 # tool_annotations(): checks its inputs
 
     Code

--- a/tests/testthat/test-tools-def.R
+++ b/tests/testthat/test-tools-def.R
@@ -123,6 +123,30 @@ test_that("can check tool/tools", {
   })
 })
 
+test_that("tool() stores an optional output schema", {
+  output_schema <- type_object(
+    auc = type_number(),
+    tss = type_number()
+  )
+  tool_def <- tool(
+    function() list(auc = 0.92, tss = 0.81),
+    description = "Evaluate model performance",
+    output_schema = output_schema
+  )
+
+  expect_identical(tool_def@output_schema, output_schema)
+})
+
+test_that("tool() checks output schema type", {
+  expect_snapshot(error = TRUE, {
+    tool(
+      function() list(auc = 0.92),
+      description = "Evaluate model performance",
+      output_schema = list(type = "object")
+    )
+  })
+})
+
 # tool_annotations() -------------------------------------------------------
 
 test_that("tool_annotations(): NULL values are stripped", {


### PR DESCRIPTION
## Summary

Adds an optional `output_schema` argument to `tool()` and stores it on `ToolDef` as a `TypeObject`.

This enables downstream MCP servers such as `posit-dev/mcptools` to advertise the MCP 2025-06-18 `outputSchema` field without changing tool execution behavior. It also preserves positional `ToolDef()` compatibility by appending the new property after the existing properties.

Related downstream issue: https://github.com/posit-dev/mcptools/issues/103

## Validation

- `tests/testthat/test-tools-def.R` passes with the new storage/type-check tests.
- Verified existing positional `ToolDef(..., convert, annotations)` construction still maps arguments correctly and leaves `output_schema = NULL`.
- `git diff --check` passes.
- A broader local suite run reached the affected `tools-def` tests successfully; unrelated provider tests in the isolated container require optional packages and credentials that are not configured there.