### PR TITLE
Always include `parameters` in Databricks tool definitions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * `chat_anthropic()` now correctly handles the `fallback` content block returned when a model's server-side refusal fallback (`server-side-fallback-2026-06-01`) is triggered (@simonpcouch, #1058).
 * `chat_aws_bedrock()` now supports bearer token authentication for enterprise API gateways (@thisisnic, #1002).
 * `chat_databricks()` no longer errors with models that return content as an array of typed objects (e.g. `databricks-gpt-oss-120b`); reasoning parts are now captured as thinking content (@thisisnic, #1078).
+* `chat_databricks()` no longer errors when a registered tool has no arguments (@thisisnic, #1084).
 * `chat_github()` and `models_github()` are now defunct because GitHub Models has been retired (@thisisnic, #1069).
 * `chat_google_gemini()` no longer errors when mixing regular tools and built-in tools like `google_tool_web_search()` (@thisisnic, #1054).
 * `chat_openrouter()` now correctly preserves provider error messages (@xmarquez, #1059).

--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -235,27 +235,6 @@ method(base_request_error, ProviderDatabricks) <- function(provider, req) {
   })
 }
 
-# See: https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/api-reference#functionobject
-method(as_json, list(ProviderDatabricks, ToolDef)) <- function(
-  provider,
-  x,
-  ...
-) {
-  # Note: It seems that Databricks doesn't support the "strict" field, despite
-  # what their documentation says. It *is* supported for structured outputs,
-  # though. I suspect a copy & paste error in their docs.
-  compact(list(
-    type = "function",
-    "function" = compact(list(
-      name = x@name,
-      description = x@description,
-      # Use the same parameter encoding as the OpenAI provider. Databricks
-      # requires `parameters` even when the tool has no arguments (#1084).
-      parameters = as_json(provider, x@arguments, ...)
-    ))
-  ))
-}
-
 # https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/api-reference#toolcall
 method(as_json, list(ProviderDatabricks, ContentToolRequest)) <- function(
   provider,

--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -249,11 +249,9 @@ method(as_json, list(ProviderDatabricks, ToolDef)) <- function(
     "function" = compact(list(
       name = x@name,
       description = x@description,
-      # Use the same parameter encoding as the OpenAI provider, but only if
-      # there actually are parameters.
-      parameters = if (length(x@arguments@properties) != 0) {
-        as_json(provider, x@arguments, ...)
-      }
+      # Use the same parameter encoding as the OpenAI provider. Databricks
+      # requires `parameters` even when the tool has no arguments (#1084).
+      parameters = as_json(provider, x@arguments, ...)
     ))
   ))
 }

--- a/tests/testthat/_snaps/provider-databricks.md
+++ b/tests/testthat/_snaps/provider-databricks.md
@@ -3,7 +3,7 @@
     Code
       . <- chat_databricks()
     Message
-      Using model = "databricks-claude-3-7-sonnet".
+      Using model = "databricks-claude-sonnet-4-6".
 
 # M2M authentication requests look correct
 

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -204,7 +204,14 @@ test_that("chat_databricks() serializes tools correctly", {
       type = "function",
       "function" = list(
         name = "current_date",
-        description = "Returns the current date in ISO 8601 format."
+        description = "Returns the current date in ISO 8601 format.",
+        parameters = list(
+          type = "object",
+          description = "",
+          properties = set_names(list()),
+          required = list(),
+          additionalProperties = FALSE
+        )
       )
     )
   )

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -205,6 +205,7 @@ test_that("chat_databricks() serializes tools correctly", {
       "function" = list(
         name = "current_date",
         description = "Returns the current date in ISO 8601 format.",
+        strict = TRUE,
         parameters = list(
           type = "object",
           description = "",
@@ -232,6 +233,7 @@ test_that("chat_databricks() serializes tools correctly", {
       "function" = list(
         name = "favourite_colour",
         description = "Returns a person's favourite colour.",
+        strict = TRUE,
         parameters = list(
           type = "object",
           description = "",


### PR DESCRIPTION
Fixes #1084 

Registering a tool with no arguments caused `chat_databricks()` to error as we omitted the `parameters` field entirely from the request when tools have no arguments, as a precaution in #549, which doesn't appear to be needed any more.  

I compared against other models with tools registered with/without parameters and all ran find after this fix. It also brings us in line with chatlas.