### PR TITLE
Update check to use native structured output for Claude models >= 5

### DIFF
--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -1082,7 +1082,9 @@ cache_control <- function(provider) {
 }
 
 has_claude_structured_output <- function(model) {
-  # Matches Claude 4.5+ models
+  # Matches Claude 4.5+ models, including major versions 5 and later.
+  # The name segment is restricted to [a-z] so that version-first names
+  # (claude-3-5-sonnet-*, claude-4-sonnet-*) don't match.
   # https://platform.claude.com/docs/en/build-with-claude/structured-outputs
-  grepl("^claude-\\w+-4-[5-9](-|$)", model)
+  grepl("^claude-[a-z]+-(4-[5-9]|[5-9]|[1-9]\\d)(-|$)", model)
 }

--- a/tests/testthat/_vcr/anthropic-count-tokens.yml
+++ b/tests/testthat/_vcr/anthropic-count-tokens.yml
@@ -8,21 +8,22 @@ http_interactions:
   response:
     status: 200
     headers:
-      date: Sun, 02 Aug 2026 17:45:05 GMT
+      date: Fri, 14 Aug 2026 13:23:34 GMT
       content-type: application/json
-      request-id: req_011CdeLZvUMYd1CXj9nzwwbU
+      request-id: req_011Ce2iLFzMyoaWTUiZujGpz
       anthropic-organization-id: 67bb8feb-7bca-4369-9e04-339d73646b40
-      content-encoding: gzip
+      anthropic-workspace-id: wrkspc_01HCeyEoRM38KjSttghsJ3cP
       vary: Accept-Encoding
+      content-encoding: br
       server: cloudflare
-      server-timing: x-originResponse;dur=35
+      server-timing: x-originResponse;dur=69
       x-robots-tag: none
       content-security-policy: default-src 'none'; frame-ancestors 'none'
       cf-cache-status: DYNAMIC
-      cf-ray: a24ee4f05e9facc5-EWR
+      cf-ray: a2b0465b4a08ed0a-LHR
     body:
       string: '{"input_tokens":12}'
-  recorded_at: 2026-08-02 17:45:05
+  recorded_at: 2026-08-14 13:23:34
 - request:
     method: POST
     uri: https://api.anthropic.com/v1/messages/count_tokens
@@ -33,21 +34,22 @@ http_interactions:
   response:
     status: 200
     headers:
-      date: Sun, 02 Aug 2026 17:45:05 GMT
+      date: Fri, 14 Aug 2026 13:23:34 GMT
       content-type: application/json
-      request-id: req_011CdeLZvv9PnbEqFAJH4fMF
+      request-id: req_011Ce2iLHSRxfwaMDiurV1sN
       anthropic-organization-id: 67bb8feb-7bca-4369-9e04-339d73646b40
-      content-encoding: gzip
+      anthropic-workspace-id: wrkspc_01HCeyEoRM38KjSttghsJ3cP
       vary: Accept-Encoding
+      content-encoding: br
       server: cloudflare
-      server-timing: x-originResponse;dur=36
+      server-timing: x-originResponse;dur=49
       x-robots-tag: none
       content-security-policy: default-src 'none'; frame-ancestors 'none'
       cf-cache-status: DYNAMIC
-      cf-ray: a24ee4f0f87facc5-EWR
+      cf-ray: a2b0465d6f55ed0a-LHR
     body:
       string: '{"input_tokens":20}'
-  recorded_at: 2026-08-02 17:45:05
+  recorded_at: 2026-08-14 13:23:34
 - request:
     method: POST
     uri: https://api.anthropic.com/v1/messages
@@ -58,39 +60,39 @@ http_interactions:
   response:
     status: 200
     headers:
-      date: Sun, 02 Aug 2026 17:45:07 GMT
+      date: Fri, 14 Aug 2026 13:23:37 GMT
       content-type: application/json
       anthropic-ratelimit-input-tokens-limit: '10000000'
       anthropic-ratelimit-input-tokens-remaining: '10000000'
-      anthropic-ratelimit-input-tokens-reset: '2026-08-02T17:45:06Z'
+      anthropic-ratelimit-input-tokens-reset: '2026-08-14T13:23:35Z'
       anthropic-ratelimit-output-tokens-limit: '2000000'
       anthropic-ratelimit-output-tokens-remaining: '2000000'
-      anthropic-ratelimit-output-tokens-reset: '2026-08-02T17:45:07Z'
+      anthropic-ratelimit-output-tokens-reset: '2026-08-14T13:23:37Z'
       anthropic-ratelimit-requests-limit: '10000'
       anthropic-ratelimit-requests-remaining: '9999'
-      anthropic-ratelimit-requests-reset: '2026-08-02T17:45:05Z'
+      anthropic-ratelimit-requests-reset: '2026-08-14T13:23:35Z'
       anthropic-ratelimit-tokens-limit: '12000000'
       anthropic-ratelimit-tokens-remaining: '12000000'
-      anthropic-ratelimit-tokens-reset: '2026-08-02T17:45:06Z'
-      request-id: req_011CdeLZwSe3fnPdKUAVj7Ub
+      anthropic-ratelimit-tokens-reset: '2026-08-14T13:23:35Z'
+      request-id: req_011Ce2iLJrVzTooPKhDzvk6p
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       anthropic-organization-id: 67bb8feb-7bca-4369-9e04-339d73646b40
-      traceresponse: 00-7d1427e1992cfb2284e798c85b7fbd84-160b1da168ac267a-01
+      anthropic-workspace-id: wrkspc_01HCeyEoRM38KjSttghsJ3cP
+      traceresponse: 00-e81690a1a0c35d8ecd669b59bed3f78e-8bcf0104db1203a4-01
       server: cloudflare
-      content-encoding: gzip
       vary: Accept-Encoding
+      content-encoding: br
       cf-cache-status: DYNAMIC
       x-robots-tag: none
       content-security-policy: default-src 'none'; frame-ancestors 'none'
-      cf-ray: a24ee4f189f0acc5-EWR
+      cf-ray: a2b0465f0b7bed0a-LHR
     body:
-      string: '{"model":"claude-sonnet-5","id":"msg_011CdeLZxWsoa8Jd7cdczjDn","type":"message","role":"assistant","content":[{"type":"text","text":"I
+      string: '{"model":"claude-sonnet-5","id":"msg_011Ce2iLKhMFzyjR9MxgRzGP","type":"message","role":"assistant","content":[{"type":"text","text":"I
         don''t have access to real-time information, so I can''t tell you the current
         date. My knowledge has a training cutoff, but I don''t have a live clock or
-        calendar to reference.\n\nIf you let me know the date, I can help with anything
-        time-related from there! Or check your device''s clock or calendar app for
-        the current date."}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":20,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":93,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
-  recorded_at: 2026-08-02 17:45:07
+        calendar to check what today''s actual date is.\n\nIf you let me know the
+        date, I''m happy to help with anything related to it!"}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":20,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":83,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
+  recorded_at: 2026-08-14 13:23:37
 - request:
     method: POST
     uri: https://api.anthropic.com/v1/messages/count_tokens
@@ -100,21 +102,22 @@ http_interactions:
   response:
     status: 200
     headers:
-      date: Sun, 02 Aug 2026 17:45:08 GMT
+      date: Fri, 14 Aug 2026 13:23:37 GMT
       content-type: application/json
-      request-id: req_011CdeLa8H1R3DhE32egd7dE
+      request-id: req_011Ce2iLWgANz3TcwPiJ1pKX
       anthropic-organization-id: 67bb8feb-7bca-4369-9e04-339d73646b40
-      content-encoding: gzip
+      anthropic-workspace-id: wrkspc_01HCeyEoRM38KjSttghsJ3cP
       vary: Accept-Encoding
+      content-encoding: br
       server: cloudflare
-      server-timing: x-originResponse;dur=57
+      server-timing: x-originResponse;dur=50
       x-robots-tag: none
       content-security-policy: default-src 'none'; frame-ancestors 'none'
       cf-cache-status: DYNAMIC
-      cf-ray: a24ee5018a27acc5-EWR
+      cf-ray: a2b04670cac0ed0a-LHR
     body:
       string: '{"input_tokens":13}'
-  recorded_at: 2026-08-02 17:45:08
+  recorded_at: 2026-08-14 13:23:37
 - request:
     method: POST
     uri: https://api.anthropic.com/v1/messages/count_tokens
@@ -124,45 +127,46 @@ http_interactions:
   response:
     status: 200
     headers:
-      date: Sun, 02 Aug 2026 17:45:08 GMT
+      date: Fri, 14 Aug 2026 13:23:38 GMT
       content-type: application/json
-      request-id: req_011CdeLa8pzohDjJ5XFMQ1dx
+      request-id: req_011Ce2iLXTnJBnf2TE4c2Ji1
       anthropic-organization-id: 67bb8feb-7bca-4369-9e04-339d73646b40
-      content-encoding: gzip
+      anthropic-workspace-id: wrkspc_01HCeyEoRM38KjSttghsJ3cP
       vary: Accept-Encoding
+      content-encoding: br
       server: cloudflare
-      server-timing: x-originResponse;dur=27
+      server-timing: x-originResponse;dur=55
       x-robots-tag: none
       content-security-policy: default-src 'none'; frame-ancestors 'none'
       cf-cache-status: DYNAMIC
-      cf-ray: a24ee5026d4cacc5-EWR
+      cf-ray: a2b04671ed9ced0a-LHR
     body:
       string: '{"input_tokens":13}'
-  recorded_at: 2026-08-02 17:45:08
+  recorded_at: 2026-08-14 13:23:38
 - request:
     method: POST
     uri: https://api.anthropic.com/v1/messages/count_tokens
     body:
       string: '{"model":"claude-sonnet-5","messages":[{"role":"user","content":[{"type":"text","text":"Apples
-        are tasty. By Hadley Wickham.","cache_control":{"type":"ephemeral","ttl":"5m"}}]}],"tools":[{"name":"_structured_tool_call","description":"Extract
-        structured data","input_schema":{"type":"object","description":"","properties":{"data":{"type":"object","description":"","properties":{"title":{"type":"string","description":"Content
-        title"},"author":{"type":"string","description":"Name of the author"}},"required":["title","author"],"additionalProperties":false}},"required":["data"],"additionalProperties":false}}],"tool_choice":{"type":"tool","name":"_structured_tool_call"}}'
+        are tasty. By Hadley Wickham.","cache_control":{"type":"ephemeral","ttl":"5m"}}]}],"output_config":{"format":{"type":"json_schema","schema":{"type":"object","description":"","properties":{"title":{"type":"string","description":"Content
+        title"},"author":{"type":"string","description":"Name of the author"}},"required":["title","author"],"additionalProperties":false}}}}'
   response:
     status: 200
     headers:
-      date: Sun, 02 Aug 2026 17:45:08 GMT
+      date: Fri, 14 Aug 2026 13:23:38 GMT
       content-type: application/json
-      request-id: req_011CdeLa9D4aitCGJAbAKWC7
+      request-id: req_011Ce2iLYX2sDpzPfED6HYh6
       anthropic-organization-id: 67bb8feb-7bca-4369-9e04-339d73646b40
-      content-encoding: gzip
+      anthropic-workspace-id: wrkspc_01HCeyEoRM38KjSttghsJ3cP
       vary: Accept-Encoding
+      content-encoding: br
       server: cloudflare
-      server-timing: x-originResponse;dur=40
+      server-timing: x-originResponse;dur=48
       x-robots-tag: none
       content-security-policy: default-src 'none'; frame-ancestors 'none'
       cf-cache-status: DYNAMIC
-      cf-ray: a24ee502fec2acc5-EWR
+      cf-ray: a2b0467379d0ed0a-LHR
     body:
-      string: '{"input_tokens":669}'
-  recorded_at: 2026-08-02 17:45:08
+      string: '{"input_tokens":259}'
+  recorded_at: 2026-08-14 13:23:38
 recorded_with: VCR-vcr/2.1.0

--- a/tests/testthat/_vcr/anthropic-structured-data.yml
+++ b/tests/testthat/_vcr/anthropic-structured-data.yml
@@ -6,42 +6,42 @@ http_interactions:
       string: '{"model":"claude-sonnet-5","messages":[{"role":"user","content":[{"type":"text","text":"\n    #
         Apples are tasty\n    By Hadley Wickham\n\n    Apples are delicious and tasty
         and I like to eat them.\n    Except for red delicious, that is. They are NOT
-        delicious.\n  ","cache_control":{"type":"ephemeral","ttl":"5m"}}]}],"stream":false,"tools":[{"name":"_structured_tool_call","description":"Extract
-        structured data","input_schema":{"type":"object","description":"","properties":{"data":{"type":"object","description":"Summary
+        delicious.\n  ","cache_control":{"type":"ephemeral","ttl":"5m"}}]}],"stream":false,"output_config":{"format":{"type":"json_schema","schema":{"type":"object","description":"Summary
         of the article. Preserve existing case.","properties":{"title":{"type":"string","description":"Content
-        title"},"author":{"type":"string","description":"Name of the author"}},"required":["title","author"],"additionalProperties":false}},"required":["data"],"additionalProperties":false}}],"tool_choice":{"type":"tool","name":"_structured_tool_call"},"max_tokens":4096}'
+        title"},"author":{"type":"string","description":"Name of the author"}},"required":["title","author"],"additionalProperties":false}}},"max_tokens":4096}'
   response:
     status: 200
     headers:
-      date: Sun, 02 Aug 2026 17:44:44 GMT
+      date: Fri, 14 Aug 2026 13:23:26 GMT
       content-type: application/json
       anthropic-ratelimit-input-tokens-limit: '10000000'
       anthropic-ratelimit-input-tokens-remaining: '10000000'
-      anthropic-ratelimit-input-tokens-reset: '2026-08-02T17:44:43Z'
+      anthropic-ratelimit-input-tokens-reset: '2026-08-14T13:23:25Z'
       anthropic-ratelimit-output-tokens-limit: '2000000'
       anthropic-ratelimit-output-tokens-remaining: '2000000'
-      anthropic-ratelimit-output-tokens-reset: '2026-08-02T17:44:44Z'
+      anthropic-ratelimit-output-tokens-reset: '2026-08-14T13:23:26Z'
       anthropic-ratelimit-requests-limit: '10000'
       anthropic-ratelimit-requests-remaining: '9999'
-      anthropic-ratelimit-requests-reset: '2026-08-02T17:44:43Z'
+      anthropic-ratelimit-requests-reset: '2026-08-14T13:23:18Z'
       anthropic-ratelimit-tokens-limit: '12000000'
       anthropic-ratelimit-tokens-remaining: '12000000'
-      anthropic-ratelimit-tokens-reset: '2026-08-02T17:44:43Z'
-      request-id: req_011CdeLYGamcGJvMB4DRR5Nf
+      anthropic-ratelimit-tokens-reset: '2026-08-14T13:23:25Z'
+      request-id: req_011Ce2iK41kZkx6DhAVASMnQ
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       anthropic-organization-id: 67bb8feb-7bca-4369-9e04-339d73646b40
-      traceresponse: 00-07b0a3e6a5b7f0787a09437c5464a09d-de351a891a30832e-01
+      anthropic-workspace-id: wrkspc_01HCeyEoRM38KjSttghsJ3cP
+      traceresponse: 00-14e8ce9670f6bb530a7aa288b91071aa-5751c9426c231317-01
       server: cloudflare
-      content-encoding: gzip
       vary: Accept-Encoding
+      content-encoding: br
       cf-cache-status: DYNAMIC
       x-robots-tag: none
       content-security-policy: default-src 'none'; frame-ancestors 'none'
-      cf-ray: a24ee463fe51acc5-EWR
+      cf-ray: a2b045f49a9ded0a-LHR
     body:
-      string: '{"model":"claude-sonnet-5","id":"msg_011CdeLYH531V2YmiJbzDrUo","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_01Cu5FQYhi93jrPv8zBmJcPh","name":"_structured_tool_call","input":{"data":{"title":"Apples
-        are tasty","author":"Hadley Wickham"}},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":732,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":58,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
-  recorded_at: 2026-08-02 17:44:44
+      string: '{"model":"claude-sonnet-5","id":"msg_011Ce2iKXgtydjLUVkRJjzHs","type":"message","role":"assistant","content":[{"type":"text","text":"{\"title\":\"Apples
+        are tasty\",\"author\":\"Hadley Wickham\"}"}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":322,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":28,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
+  recorded_at: 2026-08-14 13:23:26
 - request:
     method: POST
     uri: https://api.anthropic.com/v1/messages
@@ -53,40 +53,40 @@ http_interactions:
         are tasty\",\"author\":\"Hadley Wickham\"}"}]},{"role":"user","content":[{"type":"text","text":"\n    #
         Apples are tasty\n    By Hadley Wickham\n\n    Apples are delicious and tasty
         and I like to eat them.\n    Except for red delicious, that is. They are NOT
-        delicious.\n  ","cache_control":{"type":"ephemeral","ttl":"5m"}}]}],"stream":false,"tools":[{"name":"_structured_tool_call","description":"Extract
-        structured data","input_schema":{"type":"object","description":"","properties":{"data":{"type":"object","description":"Summary
+        delicious.\n  ","cache_control":{"type":"ephemeral","ttl":"5m"}}]}],"stream":false,"output_config":{"format":{"type":"json_schema","schema":{"type":"object","description":"Summary
         of the article. Preserve existing case.","properties":{"title":{"type":"string","description":"Content
-        title"},"author":{"type":"string","description":"Name of the author"}},"required":["title","author"],"additionalProperties":false}},"required":["data"],"additionalProperties":false}}],"tool_choice":{"type":"tool","name":"_structured_tool_call"},"max_tokens":4096}'
+        title"},"author":{"type":"string","description":"Name of the author"}},"required":["title","author"],"additionalProperties":false}}},"max_tokens":4096}'
   response:
     status: 200
     headers:
-      date: Sun, 02 Aug 2026 17:44:46 GMT
+      date: Fri, 14 Aug 2026 13:23:29 GMT
       content-type: application/json
       anthropic-ratelimit-input-tokens-limit: '10000000'
       anthropic-ratelimit-input-tokens-remaining: '10000000'
-      anthropic-ratelimit-input-tokens-reset: '2026-08-02T17:44:45Z'
+      anthropic-ratelimit-input-tokens-reset: '2026-08-14T13:23:29Z'
       anthropic-ratelimit-output-tokens-limit: '2000000'
       anthropic-ratelimit-output-tokens-remaining: '2000000'
-      anthropic-ratelimit-output-tokens-reset: '2026-08-02T17:44:46Z'
+      anthropic-ratelimit-output-tokens-reset: '2026-08-14T13:23:29Z'
       anthropic-ratelimit-requests-limit: '10000'
       anthropic-ratelimit-requests-remaining: '9999'
-      anthropic-ratelimit-requests-reset: '2026-08-02T17:44:44Z'
+      anthropic-ratelimit-requests-reset: '2026-08-14T13:23:27Z'
       anthropic-ratelimit-tokens-limit: '12000000'
       anthropic-ratelimit-tokens-remaining: '12000000'
-      anthropic-ratelimit-tokens-reset: '2026-08-02T17:44:45Z'
-      request-id: req_011CdeLYQYFFx3nsrsZ8pcrB
+      anthropic-ratelimit-tokens-reset: '2026-08-14T13:23:29Z'
+      request-id: req_011Ce2iKiX1hbCisgMyfyzCr
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       anthropic-organization-id: 67bb8feb-7bca-4369-9e04-339d73646b40
-      traceresponse: 00-d0191774d4f42c60dd6cdbe2ff732ba6-50859aa78ee58dc5-01
+      anthropic-workspace-id: wrkspc_01HCeyEoRM38KjSttghsJ3cP
+      traceresponse: 00-a554de775b6abb7f299f8bd55a968f64-8e900f02edd20001-01
       server: cloudflare
-      content-encoding: gzip
       vary: Accept-Encoding
+      content-encoding: br
       cf-cache-status: DYNAMIC
       x-robots-tag: none
       content-security-policy: default-src 'none'; frame-ancestors 'none'
-      cf-ray: a24ee46f9f8eacc5-EWR
+      cf-ray: a2b0462d0d95ed0a-LHR
     body:
-      string: '{"model":"claude-sonnet-5","id":"msg_011CdeLYR1Gt5sECzNCcy2Ex","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_01GJ8dSPXwyBW4z7oSYniMWe","name":"_structured_tool_call","input":{"data":{"title":"Apples
-        are tasty","author":"Hadley Wickham"}},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":828,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":58,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
-  recorded_at: 2026-08-02 17:44:46
+      string: '{"model":"claude-sonnet-5","id":"msg_011Ce2iKkLQcGiHxfCS1vi1b","type":"message","role":"assistant","content":[{"type":"text","text":"{\"title\":\"Apples
+        are tasty\",\"author\":\"Hadley Wickham\"}"}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":418,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":28,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
+  recorded_at: 2026-08-14 13:23:30
 recorded_with: VCR-vcr/2.1.0

--- a/tests/testthat/test-provider-claude.R
+++ b/tests/testthat/test-provider-claude.R
@@ -66,6 +66,27 @@ test_that("can extract data", {
   test_data_extraction(chat_fun)
 })
 
+test_that("has_claude_structured_output() matches Claude 4.5+ and 5+ models", {
+  expect_all_true(has_claude_structured_output(c(
+    "claude-sonnet-4-5",
+    "claude-opus-4-6",
+    "claude-sonnet-5",
+    "claude-sonnet-5-20260201",
+    "claude-sonnet-6",
+    "claude-opus-7-1",
+    "claude-haiku-10"
+  )))
+  expect_all_equal(
+    has_claude_structured_output(c(
+      "claude-sonnet-4-0",
+      "claude-3-5-sonnet-20241022",
+      "claude-3-7-sonnet-20250219",
+      "claude-4-sonnet-20250514"
+    )),
+    FALSE
+  )
+})
+
 test_that("can use images", {
   vcr::local_cassette("anthropic-images")
   chat_fun <- chat_anthropic_test

--- a/vignettes/_vcr/structured-data-examples-unknown-keys.yml
+++ b/vignettes/_vcr/structured-data-examples-unknown-keys.yml
@@ -6,41 +6,41 @@ http_interactions:
       string: '{"model":"claude-sonnet-5","system":[{"type":"text","text":"Extract
         all characteristics of supplied character","cache_control":{"type":"ephemeral","ttl":"5m"}}],"messages":[{"role":"user","content":[{"type":"text","text":"\n  The
         man is tall, with a beard and a scar on his left cheek. He has a deep voice
-        and wears a black leather jacket.\n","cache_control":{"type":"ephemeral","ttl":"5m"}}]}],"stream":false,"tools":[{"name":"_structured_tool_call","description":"Extract
-        structured data","input_schema":{"type":"object","description":"","properties":{"data":{"type":"array","description":"All
-        characteristics","items":{"type":"object","description":"","properties":{"name":{"type":"string","description":""},"value":{"type":"string","description":""}},"required":["name","value"],"additionalProperties":false}}},"required":["data"],"additionalProperties":false}}],"tool_choice":{"type":"tool","name":"_structured_tool_call"},"max_tokens":4096}'
+        and wears a black leather jacket.\n","cache_control":{"type":"ephemeral","ttl":"5m"}}]}],"stream":false,"output_config":{"format":{"type":"json_schema","schema":{"type":"array","description":"All
+        characteristics","items":{"type":"object","description":"","properties":{"name":{"type":"string","description":""},"value":{"type":"string","description":""}},"required":["name","value"],"additionalProperties":false}}}},"max_tokens":4096}'
   response:
     status: 200
     headers:
-      date: Sun, 02 Aug 2026 22:34:01 GMT
+      date: Fri, 14 Aug 2026 13:32:09 GMT
       content-type: application/json
       anthropic-ratelimit-input-tokens-limit: '10000000'
       anthropic-ratelimit-input-tokens-remaining: '10000000'
-      anthropic-ratelimit-input-tokens-reset: '2026-08-02T22:34:00Z'
+      anthropic-ratelimit-input-tokens-reset: '2026-08-14T13:32:08Z'
       anthropic-ratelimit-output-tokens-limit: '2000000'
       anthropic-ratelimit-output-tokens-remaining: '2000000'
-      anthropic-ratelimit-output-tokens-reset: '2026-08-02T22:34:01Z'
+      anthropic-ratelimit-output-tokens-reset: '2026-08-14T13:32:09Z'
       anthropic-ratelimit-requests-limit: '10000'
       anthropic-ratelimit-requests-remaining: '9999'
-      anthropic-ratelimit-requests-reset: '2026-08-02T22:33:59Z'
+      anthropic-ratelimit-requests-reset: '2026-08-14T13:32:05Z'
       anthropic-ratelimit-tokens-limit: '12000000'
       anthropic-ratelimit-tokens-remaining: '12000000'
-      anthropic-ratelimit-tokens-reset: '2026-08-02T22:34:00Z'
-      request-id: req_011CdeibixvGNTgsPHPgWbhY
+      anthropic-ratelimit-tokens-reset: '2026-08-14T13:32:08Z'
+      request-id: req_011Ce2iyvfpUkFrxBN2ACN4N
       strict-transport-security: max-age=31536000; includeSubDomains; preload
       anthropic-organization-id: 67bb8feb-7bca-4369-9e04-339d73646b40
-      traceresponse: 00-4cdfe6023fe21b1a660163824a40f90c-f403a2f7cdaf1e10-01
+      anthropic-workspace-id: wrkspc_01HCeyEoRM38KjSttghsJ3cP
+      traceresponse: 00-a27476c8c95b87905fc83c57b4f8a342-4450d4df661a011f-01
       server: cloudflare
-      content-encoding: gzip
       vary: Accept-Encoding
+      content-encoding: br
       cf-cache-status: DYNAMIC
       x-robots-tag: none
       content-security-policy: default-src 'none'; frame-ancestors 'none'
-      cf-ray: a2508c24cad84350-EWR
+      cf-ray: a2b052d4ac8cef44-LHR
     body:
-      string: '{"model":"claude-sonnet-5","id":"msg_011CdeibjRhM3puXwZqmS63d","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_01Y855hwBiiejEvLd3SGSMmM","name":"_structured_tool_call","input":{"data":[{"name":"height","value":"tall"},{"name":"facial
-        hair","value":"beard"},{"name":"distinguishing mark","value":"scar on left
-        cheek"},{"name":"voice","value":"deep"},{"name":"clothing","value":"black
-        leather jacket"}]},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":720,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":133,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
-  recorded_at: 2026-08-02 22:34:01
+      string: '{"model":"claude-sonnet-5","id":"msg_011Ce2iz3z7BsnxDH7PrxzBS","type":"message","role":"assistant","content":[{"type":"text","text":"[{\"name\":\"height\",\"value\":\"tall\"},{\"name\":\"facial
+        hair\",\"value\":\"beard\"},{\"name\":\"distinguishing mark\",\"value\":\"scar
+        on left cheek\"},{\"name\":\"voice\",\"value\":\"deep\"},{\"name\":\"clothing\",\"value\":\"black
+        leather jacket\"}]"}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":317,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":95,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
+  recorded_at: 2026-08-14 13:32:09
 recorded_with: VCR-vcr/2.1.0


### PR DESCRIPTION
The check for whether Anthropic models support native structured output (as opposed to the tool hack) incorrectly returns `FALSE` for models such as sonnet 5, the default. The regex used to check the model name needs updating - which is done in this PR.  It also checks for different possible formulations of model names that have been used.