### PR TITLE
Report the model's context window in `models_*()` and on `Chat`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # ellmer (development version)
 
 * ellmer now preserves provider citations in chat history and streamed content, and displays cited sources in console output. Enable cited web results with `chat$register_tool()`, using tools such as `openai_tool_web_search()`, `claude_tool_web_search()`, or `claude_tool_web_fetch(citations = TRUE)` (#1068).
+* `Chat` gains a `$get_context_window()` method that reports how many tokens the current model's context window holds, so you can tell how much of it `$get_tokens()` has used (@nbenn, #1083).
 * `Chat` gains a `$token_count()` method that estimates the number of tokens in new input using the provider's token counting endpoint (@thisisnic, #814).
 * `chat_anthropic()`, `chat_aws_bedrock()`, and `chat_posit()` now default to `claude-sonnet-5`. `chat_openai()` and `chat_openrouter()` now default to `gpt-5.6-terra` (@thisisnic, #1066).
 * `chat_anthropic()` now correctly handles the `fallback` content block returned when a model's server-side refusal fallback (`server-side-fallback-2026-06-01`) is triggered (@simonpcouch, #1058).
@@ -9,6 +10,8 @@
 * `chat_github()` and `models_github()` are now defunct because GitHub Models has been retired (@thisisnic, #1069).
 * `chat_google_gemini()` no longer errors when mixing regular tools and built-in tools like `google_tool_web_search()` (@thisisnic, #1054).
 * `chat_openrouter()` now correctly preserves provider error messages (@xmarquez, #1059).
+* `models_mistral()` no longer errors on R 4.2 and earlier, where `as.POSIXct()` on a numeric requires an explicit `origin` (@nbenn, #1083).
+* `models_anthropic()`, `models_google_gemini()`, `models_groq()`, `models_lmstudio()`, `models_mistral()`, `models_ollama()`, `models_posit()`, and `models_vllm()` gain a `context_window` column reporting how many tokens the model accepts, as does any other OpenAI-compatible endpoint that reports `context_window`. Every other `models_*()` function gains the column too, filled with `NA` where the provider doesn't report one (@nbenn, #1083).
 * New `models_update_prices()` downloads the latest model pricing data from GitHub and saves it to a local cache. Subsequent calls to `token_usage()` and related functions will use the updated prices (#968).
 * New `Model` class separates model configuration (name, parameters, extra arguments) from the `Provider` class, which now only captures API endpoint details. `Chat` gains a new `$get_model_object()` method to retrieve the `Model` object. This is a breaking change for anyone who directly accesses `provider@model`, `provider@params`, or `provider@extra_args`; use the `Model` object instead (@thisisnic, #499).
 * `tool()` functions that return complex objects like data frames or lists now produce a deprecation warning. Tool functions should return a character vector, an atomic vector, a JSON string (from `jsonlite::toJSON()`), or a `Content` object. Use `jsonlite::toJSON()` to convert complex objects before returning (@thisisnic, #858).

--- a/R/chat.R
+++ b/R/chat.R
@@ -263,6 +263,18 @@ Chat <- R6::R6Class(
       new_tokens + last$input + last$output + last$cached_input
     },
 
+    #' @description The size of the current model's context window, in tokens,
+    #'   as reported by the provider. Compare it to the input tokens in
+    #'   `$get_tokens()` to see how much of the window a conversation has used.
+    #'
+    #'   This requires a request to the provider's model listing endpoint, so
+    #'   the result is cached for the rest of the session.
+    #' @return A single integer, or `NA` if the provider doesn't list models
+    #'   or doesn't report a window for this one.
+    get_context_window = function() {
+      model_context_window(private$provider, private$model@name)
+    },
+
     #' @description The last turn returned by the assistant.
     #' @param role Optionally, specify a role to find the last turn with
     #'   for the role.

--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -209,7 +209,8 @@ method(models_list, ProviderAWSBedrock) <- function(provider) {
   df <- data.frame(
     id = map_chr(models, "[[", "modelId"),
     name = map_chr(models, "[[", "modelName"),
-    provider = map_chr(models, "[[", "providerName")
+    provider = map_chr(models, "[[", "providerName"),
+    context_window = rep(NA_integer_, length(models))
   )
   cbind(df, match_prices("AWS/Bedrock", df$id))
 }

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -1057,7 +1057,8 @@ method(models_list, ProviderAnthropic) <- function(provider) {
   df <- data.frame(
     id = id,
     name = display_name,
-    created_at = created_at
+    created_at = created_at,
+    context_window = map_token_limit(json$data, "max_input_tokens")
   )
   df <- cbind(df, match_prices("Anthropic", df$id))
   df[order(-xtfrm(df$created_at)), ]

--- a/R/provider-deepseek.R
+++ b/R/provider-deepseek.R
@@ -167,6 +167,10 @@ method(models_list, ProviderDeepSeek) <- function(provider) {
   id <- map_chr(json$data, "[[", "id")
   owned_by <- map_chr(json$data, "[[", "owned_by")
 
-  df <- data.frame(id = id, owned_by = owned_by)
+  df <- data.frame(
+    id = id,
+    owned_by = owned_by,
+    context_window = rep(NA_integer_, length(id))
+  )
   cbind(df, match_prices(provider@name, df$id))
 }

--- a/R/provider-google.R
+++ b/R/provider-google.R
@@ -1140,21 +1140,26 @@ method(models_list, ProviderGoogleGemini) <- function(provider) {
   json <- resp_body_json(resp)
 
   if (is_vertex) {
-    name <- map_chr(json$publisherModels, "[[", "name")
+    models <- json$publisherModels
+    name <- map_chr(models, "[[", "name")
     name <- gsub("^publishers/google/models/", "", name)
     # this is the closest to "generateContent" in "supportedGenerationMethods" for Gemini
     # https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/publishers.models
-    can_generate <- json$publisherModels |>
+    can_generate <- models |>
       map_lgl(\(x) "openGenerationAiStudio" %in% names(x$supportedActions))
   } else {
-    name <- map_chr(json$models, "[[", "name")
+    models <- json$models
+    name <- map_chr(models, "[[", "name")
     name <- gsub("^models/", "", name)
 
-    methods <- map(json$models, \(x) unlist(x$supportedGenerationMethods))
+    methods <- map(models, \(x) unlist(x$supportedGenerationMethods))
     can_generate <- map_lgl(methods, \(x) "generateContent" %in% x)
   }
 
-  df <- data.frame(id = name)
+  df <- data.frame(
+    id = name,
+    context_window = map_token_limit(models, "inputTokenLimit")
+  )
   df <- cbind(df, match_prices(provider@name, df$id))
   df <- df[can_generate, ]
   unrowname(df[order(df$id), ])

--- a/R/provider-lmstudio.R
+++ b/R/provider-lmstudio.R
@@ -172,9 +172,32 @@ method(models_list, ProviderLMStudio) <- function(provider) {
   resp <- req_perform(req)
   json <- resp_body_json(resp)
 
+  id <- map_chr(json$data, "[[", "id")
+
   data.frame(
-    id = map_chr(json$data, "[[", "id")
+    id = id,
+    context_window = lmstudio_context_windows(
+      base_url,
+      id,
+      provider@credentials
+    )
   )
+}
+
+lmstudio_context_windows <- function(
+  base_url,
+  ids,
+  credentials = lmstudio_credentials()
+) {
+  req <- request(base_url)
+  req <- ellmer_req_credentials(req, credentials(), "Authorization")
+  req <- req_url_path_append(req, "/api/v1/models")
+
+  json <- tryCatch(resp_body_json(req_perform(req)), error = function(cnd) NULL)
+
+  keys <- map_chr(json$models, \(model) model[["key"]] %||% NA_character_)
+  windows <- map_token_limit(json$models, "max_context_length")
+  windows[match(ids, keys)]
 }
 
 has_lmstudio <- function(

--- a/R/provider-mistral.R
+++ b/R/provider-mistral.R
@@ -165,12 +165,13 @@ method(models_list, ProviderMistral) <- function(provider) {
 
   id <- map_chr(json$data, `[[`, "id")
   display_name <- map_chr(json$data, `[[`, "name")
-  created_at <- as.POSIXct(map_int(json$data, `[[`, "created"))
+  created_at <- .POSIXct(map_int(json$data, `[[`, "created"))
 
   df <- data.frame(
     id = id,
     name = display_name,
-    created_at = created_at
+    created_at = created_at,
+    context_window = map_token_limit(json$data, "max_context_length")
   )
   df <- cbind(df, match_prices("Mistral", df$id))
   df

--- a/R/provider-ollama.R
+++ b/R/provider-ollama.R
@@ -216,15 +216,19 @@ method(models_list, ProviderOllama) <- function(provider) {
   modified_at <- as.POSIXct(map_chr(json$models, "[[", "modified_at"))
   size <- map_dbl(json$models, "[[", "size")
 
+  details <- map(names, function(model) {
+    tryCatch(
+      ollama_model_details(base_url, model, provider@credentials),
+      error = function(cnd) NULL
+    )
+  })
+
   df <- data.frame(
     id = names,
     created_at = modified_at,
     size = size,
-    capabilities = ollama_model_capabilities(
-      base_url,
-      names,
-      provider@credentials
-    )
+    capabilities = map_chr(details, \(x) paste(x$capabilities, collapse = ",")),
+    context_window = map_int(details, ollama_context_length)
   )
   df[order(-xtfrm(df$created_at)), ]
 }
@@ -255,18 +259,10 @@ ollama_model_details <- function(
   details
 }
 
-ollama_model_capabilities <- function(
-  base_url,
-  models,
-  credentials = ollama_credentials()
-) {
-  res <- map(models, function(m) {
-    tryCatch(
-      ollama_model_details(base_url, m, credentials),
-      error = function(e) NULL
-    )
-  })
-  map_chr(res, \(x) paste(x$capabilities, collapse = ","))
+ollama_context_length <- function(details) {
+  info <- details$model_info
+  arch <- info[["general.architecture"]]
+  as.integer(info[[paste0(arch, ".context_length")]] %||% NA)
 }
 
 is_local_ollama <- function(base_url) {

--- a/R/provider-openai-compatible.R
+++ b/R/provider-openai-compatible.R
@@ -585,7 +585,8 @@ method(models_list, ProviderOpenAICompatible) <- function(provider) {
   df <- data.frame(
     id = id,
     created_at = created,
-    owned_by = owned_by
+    owned_by = owned_by,
+    context_window = map_token_limit(json$data, "context_window")
   )
   df <- cbind(df, match_prices(provider@name, df$id))
   df[order(-xtfrm(df$created_at)), ]

--- a/R/provider-portkey.R
+++ b/R/provider-portkey.R
@@ -149,6 +149,7 @@ method(models_list, ProviderPortkeyAI) <- function(provider) {
 
   data.frame(
     id = id,
-    slug = slug
+    slug = slug,
+    context_window = rep(NA_integer_, length(id))
   )
 }

--- a/R/provider-posit.R
+++ b/R/provider-posit.R
@@ -111,7 +111,8 @@ models_posit <- function(
 
   data.frame(
     id = map_chr(json$chat, "[[", "id"),
-    name = map_chr(json$chat, "[[", "display_name")
+    name = map_chr(json$chat, "[[", "display_name"),
+    context_window = map_token_limit(json$chat, "max_context_length")
   )
 }
 

--- a/R/provider-vllm.R
+++ b/R/provider-vllm.R
@@ -130,6 +130,7 @@ method(models_list, ProviderVllm) <- function(provider) {
   json <- resp_body_json(resp)
 
   data.frame(
-    id = map_chr(json$data, "[[", "id")
+    id = map_chr(json$data, "[[", "id"),
+    context_window = map_token_limit(json$data, "max_model_len")
   )
 }

--- a/R/provider.R
+++ b/R/provider.R
@@ -328,6 +328,24 @@ method(models_list, new_S3_class("Chat")) <- function(provider) {
   models_list(provider$get_provider())
 }
 
+the$context_windows <- new_environment()
+
+model_context_window <- function(provider, model) {
+  key <- paste(provider@name, provider@base_url, model, sep = "|")
+  if (env_has(the$context_windows, key)) {
+    return(the$context_windows[[key]])
+  }
+
+  models <- try_fetch(
+    models_list(provider),
+    not_implemented = function(cnd) NULL
+  )
+  limit <- models$context_window[match(model, models$id)] %||% NA_integer_
+
+  the$context_windows[[key]] <- limit
+  limit
+}
+
 # Batch AI ---------------------------------------------------------------
 
 # Does the provider support batch uploads?

--- a/R/utils.R
+++ b/R/utils.R
@@ -267,6 +267,10 @@ match_prices <- function(provider, id) {
   p
 }
 
+map_token_limit <- function(models, field) {
+  map_int(models, \(model) as.integer(model[[field]] %||% NA))
+}
+
 base64_enc <- function(path, raw) {
   check_exclusive(path, raw)
   if (!missing(path)) {

--- a/man/Chat.Rd
+++ b/man/Chat.Rd
@@ -40,6 +40,7 @@ chat$chat("Tell me a funny joke")
     \item \href{#method-Chat-get_tokens}{\code{Chat$get_tokens()}}
     \item \href{#method-Chat-get_cost}{\code{Chat$get_cost()}}
     \item \href{#method-Chat-token_count}{\code{Chat$token_count()}}
+    \item \href{#method-Chat-get_context_window}{\code{Chat$get_context_window()}}
     \item \href{#method-Chat-last_turn}{\code{Chat$last_turn()}}
     \item \href{#method-Chat-chat}{\code{Chat$chat()}}
     \item \href{#method-Chat-chat_structured}{\code{Chat$chat_structured()}}
@@ -339,6 +340,27 @@ extraction, created with a \code{\link[=type_boolean]{type_()}} function.}
   }
   \subsection{Returns}{
     The estimated number of input tokens.
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Chat-get_context_window"></a>}}
+\if{latex}{\out{\hypertarget{method-Chat-get_context_window}{}}}
+\subsection{\code{Chat$get_context_window()}}{
+  The size of the current model's context window, in tokens,
+as reported by the provider. Compare it to the input tokens in
+\verb{$get_tokens()} to see how much of the window a conversation has used.
+
+This requires a request to the provider's model listing endpoint, so
+the result is cached for the rest of the session.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Chat$get_context_window()}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A single integer, or \code{NA} if the provider doesn't list models
+or doesn't report a window for this one.
   }
 }
 

--- a/tests/testthat/_snaps/provider-mistral.md
+++ b/tests/testthat/_snaps/provider-mistral.md
@@ -1,12 +1,3 @@
-# can handle errors
-
-    Code
-      chat$chat("Hi")
-    Condition
-      Error in `req_perform()`:
-      ! HTTP 400 Bad Request.
-      i Invalid model: doesnt-exist
-
 # defaults are reported
 
     Code

--- a/tests/testthat/helper-provider.R
+++ b/tests/testthat/helper-provider.R
@@ -182,11 +182,30 @@ test_pdf_local <- function(chat_fun) {
 
 # Models ------------------------------------------------------------------
 
-test_models <- function(models_fun) {
+test_models <- function(models_fun, has_context_window = FALSE) {
   models <- models_fun()
   expect_gt(nrow(models), 0)
   expect_s3_class(models, "data.frame")
-  expect_contains(names(models), "id")
+  expect_contains(names(models), c("id", "context_window"))
+  expect_type(models$context_window, "integer")
+
+  if (has_context_window) {
+    expect_gt(sum(!is.na(models$context_window)), 0)
+  }
+
+  invisible(models)
+}
+
+local_context_windows <- function(frame = parent.frame()) {
+  old <- the$context_windows
+  the$context_windows <- new_environment()
+  defer(the$context_windows <- old, envir = frame)
+}
+
+local_ollama_cache <- function(frame = parent.frame()) {
+  old <- the$ollama_cache
+  the$ollama_cache <- new_environment()
+  defer(the$ollama_cache <- old, envir = frame)
 }
 
 # Token counting -----------------------------------------------------------

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -117,6 +117,25 @@ test_that("can set model", {
   expect_equal(chat$get_model(), "def")
 })
 
+test_that("can get the model's context window", {
+  local_context_windows()
+  local_mocked_responses(function(req) {
+    response_json(
+      body = list(data = list(list(id = "qwen3", max_model_len = 40960)))
+    )
+  })
+  chat <- Chat$new(
+    provider = ProviderVllm(
+      name = "VLLM",
+      base_url = "https://example.com",
+      credentials = \() ""
+    ),
+    model = test_model("qwen3")
+  )
+
+  expect_equal(chat$get_context_window(), 40960L)
+})
+
 test_that("setting turns usually preserves, but can set system prompt", {
   chat <- chat_openai_test(system_prompt = "You're a funny guy")
   chat$set_turns(list())

--- a/tests/testthat/test-provider-claude.R
+++ b/tests/testthat/test-provider-claude.R
@@ -18,7 +18,8 @@ test_that("can make simple streaming request", {
 test_that("can list models", {
   vcr::local_cassette("anthropic-list-models")
 
-  test_models(models_anthropic)
+  models <- test_models(models_anthropic, has_context_window = TRUE)
+  expect_equal(models$context_window[models$id == "claude-opus-5"], 1000000L)
 })
 
 # Common provider interface -----------------------------------------------

--- a/tests/testthat/test-provider-google.R
+++ b/tests/testthat/test-provider-google.R
@@ -19,7 +19,63 @@ test_that("can handle errors", {
 })
 
 test_that("can list models", {
-  test_models(models_google_gemini)
+  test_models(models_google_gemini, has_context_window = TRUE)
+})
+
+test_that("vertex model listing keeps generative models but reports no window", {
+  local_mocked_responses(function(req) {
+    response_json(
+      body = list(
+        publisherModels = list(
+          list(
+            name = "publishers/google/models/gemini-2.5-flash",
+            versionId = "gemini-2.5-flash",
+            launchStage = "GA",
+            supportedActions = list(openGenerationAiStudio = list())
+          ),
+          list(
+            name = "publishers/google/models/codegemma",
+            openSourceCategory = "GOOGLE_OWNED_OSS_WITH_GOOGLE_CHECKPOINT",
+            supportedActions = list(
+              openNotebook = list(),
+              openNotebooks = list()
+            )
+          )
+        )
+      )
+    )
+  })
+
+  models <- models_google_vertex(
+    location = "us-central1",
+    project_id = "test-project",
+    credentials = \() ""
+  )
+  expect_equal(models$id, "gemini-2.5-flash")
+  expect_equal(models$context_window, NA_integer_)
+})
+
+test_that("model listing reports the context window", {
+  local_mocked_responses(function(req) {
+    response_json(
+      body = list(
+        models = list(
+          list(
+            name = "models/gemini-3.5-flash",
+            inputTokenLimit = 1048576,
+            supportedGenerationMethods = list("generateContent")
+          ),
+          list(
+            name = "models/unknown",
+            supportedGenerationMethods = list("generateContent")
+          )
+        )
+      )
+    )
+  })
+
+  models <- models_google_gemini(credentials = \() "")
+  expect_equal(models$context_window, c(1048576L, NA_integer_))
 })
 
 # Common provider interface -----------------------------------------------

--- a/tests/testthat/test-provider-groq.R
+++ b/tests/testthat/test-provider-groq.R
@@ -1,5 +1,26 @@
 test_that("can list models", {
-  test_models(models_groq)
+  test_models(models_groq, has_context_window = TRUE)
+})
+
+test_that("model listing reports the context window when present", {
+  local_mocked_responses(function(req) {
+    response_json(
+      body = list(
+        data = list(
+          list(
+            id = "llama3-8b-8192",
+            created = 1693721698,
+            owned_by = "Meta",
+            context_window = 8192
+          ),
+          list(id = "unknown", created = 1693721698, owned_by = "Groq")
+        )
+      )
+    )
+  })
+
+  models <- models_groq(credentials = \() "")
+  expect_equal(models$context_window, c(8192L, NA_integer_))
 })
 
 # Common provider interface -----------------------------------------------

--- a/tests/testthat/test-provider-lmstudio.R
+++ b/tests/testthat/test-provider-lmstudio.R
@@ -18,6 +18,64 @@ test_that("can list models", {
   test_models(models_lmstudio)
 })
 
+test_that("model listing joins the context window from the native endpoint", {
+  local_mocked_responses(function(req) {
+    if (grepl("api/v1/models", req$url)) {
+      response_json(
+        body = list(
+          models = list(
+            list(key = "qwen/qwen3-0.6b", max_context_length = 32768),
+            list(key = "nomic-embed-text-v1.5", max_context_length = 2048)
+          )
+        )
+      )
+    } else {
+      response_json(
+        body = list(
+          data = list(
+            list(id = "qwen/qwen3-0.6b"),
+            list(id = "nomic-embed-text-v1.5")
+          )
+        )
+      )
+    }
+  })
+
+  models <- models_lmstudio(credentials = \() "")
+  expect_equal(models$context_window, c(32768L, 2048L))
+})
+
+test_that("model listing survives the native endpoint changing shape", {
+  local_mocked_responses(function(req) {
+    if (grepl("api/v1/models", req$url)) {
+      response_json(body = list(models = list(list(max_context_length = 4096))))
+    } else {
+      response_json(body = list(data = list(list(id = "qwen/qwen3-0.6b"))))
+    }
+  })
+
+  expect_equal(
+    models_lmstudio(credentials = \() "")$context_window,
+    NA_integer_
+  )
+})
+
+test_that("model listing survives a server without the native endpoint", {
+  local_mocked_responses(function(req) {
+    if (grepl("api/v1/models", req$url)) {
+      # LM Studio answers an unknown route with 200 and an error body
+      response_json(body = list(error = "Unexpected endpoint or method."))
+    } else {
+      response_json(body = list(data = list(list(id = "qwen/qwen3-0.6b"))))
+    }
+  })
+
+  expect_equal(
+    models_lmstudio(credentials = \() "")$context_window,
+    NA_integer_
+  )
+})
+
 test_that("includes list of models in error message if `model` is missing", {
   skip_if_no_lmstudio()
 

--- a/tests/testthat/test-provider-mistral.R
+++ b/tests/testthat/test-provider-mistral.R
@@ -19,7 +19,28 @@ test_that("can handle errors", {
 })
 
 test_that("can list models", {
-  test_models(models_mistral)
+  test_models(models_mistral, has_context_window = TRUE)
+})
+
+test_that("model listing reports the context window", {
+  local_mocked_responses(function(req) {
+    response_json(
+      body = list(
+        data = list(
+          list(
+            id = "mistral-large-latest",
+            name = "Mistral Large",
+            created = 0L,
+            max_context_length = 131072
+          ),
+          list(id = "unknown", name = "Unknown", created = 0L)
+        )
+      )
+    )
+  })
+
+  models <- models_mistral(api_key = "")
+  expect_equal(models$context_window, c(131072L, NA_integer_))
 })
 
 # Common provider interface -----------------------------------------------

--- a/tests/testthat/test-provider-ollama.R
+++ b/tests/testthat/test-provider-ollama.R
@@ -15,7 +15,53 @@ test_that("can make simple streaming request", {
 
 test_that("can list models", {
   skip_if_no_ollama()
-  test_models(models_ollama)
+  test_models(models_ollama, has_context_window = TRUE)
+})
+
+test_that("model listing reports capabilities and the context window", {
+  local_ollama_cache()
+  local_mocked_responses(function(req) {
+    if (grepl("api/tags", req$url)) {
+      response_json(
+        body = list(
+          models = list(
+            list(
+              name = "gpt-oss:20b",
+              modified_at = "2026-01-01T00:00:00Z",
+              size = 1
+            )
+          )
+        )
+      )
+    } else {
+      response_json(
+        body = list(
+          capabilities = list("completion", "tools"),
+          model_info = list(
+            "general.architecture" = "gptoss",
+            "gptoss.context_length" = 131072
+          )
+        )
+      )
+    }
+  })
+
+  models <- models_ollama(credentials = \() "")
+  expect_equal(models$id, "gpt-oss:20b")
+  expect_equal(models$capabilities, "completion,tools")
+  expect_equal(models$context_window, 131072L)
+})
+
+test_that("context length is read from the architecture-specific field", {
+  details <- list(
+    model_info = list(
+      "general.architecture" = "gemma3",
+      "gemma3.context_length" = 8192
+    )
+  )
+  expect_equal(ollama_context_length(details), 8192L)
+  expect_equal(ollama_context_length(list(model_info = list())), NA_integer_)
+  expect_equal(ollama_context_length(NULL), NA_integer_)
 })
 
 test_that("includes list of models in error message if `model` is missing", {

--- a/tests/testthat/test-provider-portkey.R
+++ b/tests/testthat/test-provider-portkey.R
@@ -52,3 +52,13 @@ test_that("model without @ prefix works without virtual_key (#872)", {
     "arn:aws:bedrock:us-east-1:123456:model/my-model"
   )
 })
+
+test_that("model listing survives an empty catalogue", {
+  local_mocked_responses(function(req) {
+    response_json(body = list(object = "list", total = 0, data = list()))
+  })
+
+  models <- models_portkey(api_key = "key")
+  expect_equal(nrow(models), 0)
+  expect_type(models$context_window, "integer")
+})

--- a/tests/testthat/test-provider-posit.R
+++ b/tests/testthat/test-provider-posit.R
@@ -46,6 +46,26 @@ test_that("gateway-specific errors get useful messages", {
   expect_equal(posit_error_body(string_error), "bad request")
 })
 
+test_that("model listing reports the context window", {
+  local_mocked_responses(function(req) {
+    response_json(
+      body = list(
+        chat = list(
+          list(
+            id = "claude-sonnet-5",
+            display_name = "Claude Sonnet 5",
+            max_context_length = 1000000
+          ),
+          list(id = "unknown", display_name = "Unknown")
+        )
+      )
+    )
+  })
+
+  models <- models_posit(credentials = \() "")
+  expect_equal(models$context_window, c(1000000L, NA_integer_))
+})
+
 # Checking the cache before calling models_posit() keeps an unauthenticated
 # machine from triggering (and hanging on) the interactive device flow.
 available_posit_models <- function() {

--- a/tests/testthat/test-provider-vllm.R
+++ b/tests/testthat/test-provider-vllm.R
@@ -14,5 +14,24 @@ test_that("can make simple streaming request", {
 })
 
 test_that("can list models", {
-  test_models(\(...) models_vllm("https://llm.nrp-nautilus.io/"))
+  test_models(
+    \(...) models_vllm("https://llm.nrp-nautilus.io/"),
+    has_context_window = TRUE
+  )
+})
+
+test_that("model listing reports the context window", {
+  local_mocked_responses(function(req) {
+    response_json(
+      body = list(
+        data = list(
+          list(id = "qwen3", max_model_len = 40960),
+          list(id = "unknown")
+        )
+      )
+    )
+  })
+
+  models <- models_vllm("https://example.com", credentials = \() "")
+  expect_equal(models$context_window, c(40960L, NA_integer_))
 })

--- a/tests/testthat/test-provider.R
+++ b/tests/testthat/test-provider.R
@@ -22,3 +22,46 @@ test_that("models_list() dispatches through Chat to provider", {
   chat <- Chat$new(provider = provider, model = test_model())
   expect_error(models_list(chat), class = "not_implemented")
 })
+
+test_that("model_context_window() is NA when the provider can't list models", {
+  local_context_windows()
+  provider <- Provider(
+    name = "test",
+    base_url = "https://example.com"
+  )
+  expect_equal(model_context_window(provider, "model"), NA_integer_)
+})
+
+test_that("model_context_window() is NA when the listing reports no window", {
+  local_context_windows()
+  local_mocked_responses(function(req) {
+    response_json(body = list(data = list(list(id = "qwen3"))))
+  })
+  provider <- ProviderVllm(
+    name = "VLLM",
+    base_url = "https://example.com",
+    credentials = \() ""
+  )
+  expect_equal(model_context_window(provider, "qwen3"), NA_integer_)
+  expect_equal(model_context_window(provider, "not-a-model"), NA_integer_)
+})
+
+test_that("model_context_window() only requests the model listing once", {
+  local_context_windows()
+  requests <- 0
+  local_mocked_responses(function(req) {
+    requests <<- requests + 1
+    response_json(
+      body = list(data = list(list(id = "qwen3", max_model_len = 40960)))
+    )
+  })
+  provider <- ProviderVllm(
+    name = "VLLM",
+    base_url = "https://example.com",
+    credentials = \() ""
+  )
+
+  expect_equal(model_context_window(provider, "qwen3"), 40960L)
+  expect_equal(model_context_window(provider, "qwen3"), 40960L)
+  expect_equal(requests, 1)
+})


### PR DESCRIPTION
Most providers publish a model's context window in a response `models_list()` already parses and then discards. This adds a `context_window` column to the `models_*()` data frames, and `Chat$get_context_window()` to pair with `$get_tokens()`.

| Provider | Field read |
| --- | --- |
| Anthropic | `max_input_tokens` |
| Gemini | `inputTokenLimit` |
| Groq | `context_window` |
| LM Studio | `max_context_length`, from the native `/api/v1/models` |
| Mistral | `max_context_length` |
| Posit | `max_context_length` |
| vLLM | `max_model_len` |
| Ollama | `<arch>.context_length`, from the `api/show` response already fetched for `capabilities` |

Everyone else gets `NA`, so the column is there whichever provider you ask. The OpenAI-compatible parser reads `context_window` generically, which is what covers Groq.

The `Chat$get_context_window()` method resolves the current model through `models_list()`, caching per provider, base URL and model, so it costs one request per session.

Verified live: Gemini 36/36 models, Mistral 55/55, Groq 15/15, Ollama Cloud 18/18, Posit 10/10, LM Studio against a local server. Anthropic comes from the existing `anthropic-list-models` cassette and vLLM from vLLM's source. Vertex publishes no token limit anywhere in `publisherModels`, in either projection, so it falls through to `NA`. For LM Studio, its OpenAI-compatible `/v1/models` carries only `id`, `object` and `owned_by`, so the window is joined from the native `/api/v1/models` by model key, and a server without that route degrades to `NA`. The `test_models()` helper now checks the column, and checks it is populated for the providers that report one.

Fixes #1083
