### PR TITLE
Don't populate `grounded_span` for OpenAI web-search citations

### DIFF
--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -415,8 +415,6 @@ openai_citations <- function(content) {
   annotations <- keep(annotations, function(annotation) {
     identical(annotation$type, "url_citation")
   })
-  # No grounded_span: OpenAI's start_index/end_index delimit the inline
-  # citation marker, not the answer text supported by the source.
   lapply(annotations, function(annotation) {
     ContentCitation(
       source = WebSource(

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -249,6 +249,8 @@ method(stream_content, ProviderOpenAI) <- function(
     if (!identical(annotation$type, "url_citation")) {
       return(list())
     }
+    # No grounded_span: OpenAI's offsets delimit the inline citation marker,
+    # not the answer text supported by the source.
     list(
       ContentCitation(
         source = WebSource(
@@ -415,21 +417,14 @@ openai_citations <- function(content) {
   annotations <- keep(annotations, function(annotation) {
     identical(annotation$type, "url_citation")
   })
+  # No grounded_span: OpenAI's start_index/end_index delimit the inline
+  # citation marker, not the answer text supported by the source.
   lapply(annotations, function(annotation) {
-    start <- annotation$start_index
-    end <- annotation$end_index
-    grounded_span <- if (is.null(start) || is.null(end)) {
-      NULL
-    } else {
-      span <- substr(content$text, start + 1L, end)
-      if (nzchar(span)) span else NULL
-    }
     ContentCitation(
       source = WebSource(
         url = annotation$url,
         title = annotation$title
       ),
-      grounded_span = grounded_span,
       extra = annotation
     )
   })

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -249,8 +249,6 @@ method(stream_content, ProviderOpenAI) <- function(
     if (!identical(annotation$type, "url_citation")) {
       return(list())
     }
-    # No grounded_span: OpenAI's offsets delimit the inline citation marker,
-    # not the answer text supported by the source.
     list(
       ContentCitation(
         source = WebSource(

--- a/tests/testthat/test-provider-openai.R
+++ b/tests/testthat/test-provider-openai.R
@@ -168,7 +168,7 @@ test_that("value_turn handles NULL service_tier gracefully", {
   expect_no_error(value_turn(provider, test_model(), result))
 })
 
-test_that("value_turn() resolves OpenAI citation spans", {
+test_that("value_turn() keeps OpenAI citation metadata without grounded_span", {
   provider <- chat_openai_test()$get_provider()
   annotation <- list(
     type = "url_citation",
@@ -199,7 +199,7 @@ test_that("value_turn() resolves OpenAI citation spans", {
   expect_s7_class(contents[[2]], ContentCitation)
   expect_equal(contents[[2]]@source@url, "https://example.com")
   expect_equal(contents[[2]]@source@title, "Example")
-  expect_equal(contents[[2]]@grounded_span, "answer")
+  expect_null(contents[[2]]@grounded_span)
   expect_equal(contents[[2]]@extra, annotation)
 })
 


### PR DESCRIPTION
Fixes #1093, porting a fix over from chatlas