### PR TITLE
Handle empty responses in AWS and Claude

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * ellmer now preserves provider citations in chat history and streamed content, and displays cited sources in console output. Enable cited web results with `chat$register_tool()`, using tools such as `openai_tool_web_search()`, `claude_tool_web_search()`, or `claude_tool_web_fetch(citations = TRUE)` (#1068).
 * `Chat` gains a `$token_count()` method that estimates the number of tokens in new input using the provider's token counting endpoint (@thisisnic, #814).
 * `chat_anthropic()`, `chat_aws_bedrock()`, and `chat_posit()` now default to `claude-sonnet-5`. `chat_openai()` and `chat_openrouter()` now default to `gpt-5.6-terra` (@thisisnic, #1066).
+* `chat_anthropic()` and `chat_aws_bedrock()` no longer error after the model returns an empty response (@thisisnic, #1070).
 * `chat_anthropic()` now defaults `base_url` to the `ANTHROPIC_BASE_URL` environment variable, and `chat_aws_bedrock()` to `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` or `AWS_ENDPOINT_URL_BEDROCK_MANTLE` depending on `api`, matching the official SDKs (@karawoo, #1103).
 * `chat_anthropic()` now correctly handles the `fallback` content block returned when a model's server-side refusal fallback (`server-side-fallback-2026-06-01`) is triggered (@simonpcouch, #1058).
 * `chat_aws_bedrock()` now supports bearer token authentication for enterprise API gateways (@thisisnic, #1002).

--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -651,9 +651,12 @@ method(as_json, list(ProviderAWSBedrock, Turn)) <- function(
   } else if (is_user_turn(x) || is_assistant_turn(x)) {
     x <- turn_contents_expand(x)
     content <- as_json(provider, x@contents, ...)
-    if (is_assistant_turn(x) && length(content) == 0) {
-      # Bedrock rejects empty content arrays, and dropping the turn
-      # confuses the model, so send a placeholder instead
+    if (length(content) == 0) {
+      if (!is_assistant_turn(x)) {
+        return()
+      }
+      # Dropping empty assistant turns confuses the model, so send a
+      # placeholder instead (#711, #1070)
       content <- list(list(text = "[empty string]"))
     }
 

--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -651,6 +651,11 @@ method(as_json, list(ProviderAWSBedrock, Turn)) <- function(
   } else if (is_user_turn(x) || is_assistant_turn(x)) {
     x <- turn_contents_expand(x)
     content <- as_json(provider, x@contents, ...)
+    if (is_assistant_turn(x) && length(content) == 0) {
+      # Bedrock rejects empty content arrays, and dropping the turn
+      # confuses the model, so send a placeholder instead
+      content <- list(list(text = "[empty string]"))
+    }
 
     if (is_last) {
       content <- c(content, bedrock_cache_point(provider))

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -777,7 +777,10 @@ method(as_json, list(ProviderAnthropic, Turn)) <- function(
   } else if (is_user_turn(x) || is_assistant_turn(x)) {
     x <- turn_contents_expand(x)
     content <- as_json(provider, x@contents, ...)
-    if (is_assistant_turn(x) && length(content) == 0) {
+    if (length(content) == 0) {
+      if (!is_assistant_turn(x)) {
+        return()
+      }
       # Dropping empty assistant turns confuses the model, so send a
       # placeholder instead (#711, #1070)
       content <- list(list(type = "text", text = "[empty string]"))

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -530,6 +530,7 @@ method(value_turn_with_turns, ProviderAnthropic) <- function(
       )
     }
   }))
+  contents <- contents %||% list()
 
   tokens <- value_tokens(provider, result)
   cache_write <- result$usage$cache_creation_input_tokens %||% 0
@@ -774,15 +775,12 @@ method(as_json, list(ProviderAnthropic, Turn)) <- function(
     # claude passes system prompt as separate arg
     NULL
   } else if (is_user_turn(x) || is_assistant_turn(x)) {
-    if (is_assistant_turn(x) && identical(x@contents, list())) {
-      # Drop empty assistant turns to avoid an API error
-      # (all messages must have non-empty content)
-      return(NULL)
-    }
     x <- turn_contents_expand(x)
     content <- as_json(provider, x@contents, ...)
-    if (length(content) == 0) {
-      return(NULL)
+    if (is_assistant_turn(x) && length(content) == 0) {
+      # Dropping empty assistant turns confuses the model, so send a
+      # placeholder instead (#711, #1070)
+      content <- list(list(type = "text", text = "[empty string]"))
     }
 
     # Add caching to the last content block in the last turn

--- a/tests/testthat/test-provider-aws.R
+++ b/tests/testthat/test-provider-aws.R
@@ -472,3 +472,11 @@ test_that("aws_bedrock_models_url() resolves the model-listing endpoint", {
     "https://bedrock.example.com"
   )
 })
+
+test_that("sends placeholder for empty assistant turns (#1070)", {
+  provider <- test_aws_bedrock_provider()
+  turns_json <- as_json(provider, list(UserTurn("Hi"), AssistantTurn()))
+
+  expect_length(turns_json, 2)
+  expect_equal(turns_json[[2]]$content, list(list(text = "[empty string]")))
+})

--- a/tests/testthat/test-provider-aws.R
+++ b/tests/testthat/test-provider-aws.R
@@ -480,3 +480,13 @@ test_that("sends placeholder for empty assistant turns (#1070)", {
   expect_length(turns_json, 2)
   expect_equal(turns_json[[2]]$content, list(list(text = "[empty string]")))
 })
+
+test_that("drops empty user turns (#1070)", {
+  provider <- test_aws_bedrock_provider()
+  turns_json <- as_json(
+    provider,
+    list(UserTurn("Hi"), AssistantTurn("Hello"), UserTurn())
+  )
+
+  expect_length(turns_json, 2)
+})

--- a/tests/testthat/test-provider-claude.R
+++ b/tests/testthat/test-provider-claude.R
@@ -146,7 +146,7 @@ test_that("can match prices for some common models", {
   expect_true(has_cost(chat$get_provider()@name, chat$get_model_object()@name))
 })
 
-test_that("removes empty final chat messages", {
+test_that("sends placeholder for empty assistant turns (#711, #1070)", {
   chat <- chat_anthropic_test()
   chat$set_turns(
     list(
@@ -157,11 +157,10 @@ test_that("removes empty final chat messages", {
 
   turns_json <- as_json(chat$get_provider(), chat$get_turns())
 
-  expect_length(turns_json, 1)
-  expect_equal(turns_json[[1]]$role, "user")
+  expect_length(turns_json, 2)
   expect_equal(
-    turns_json[[1]]$content,
-    list(list(type = "text", text = "Don't say anything"))
+    turns_json[[2]]$content,
+    list(list(type = "text", text = "[empty string]"))
   )
 })
 
@@ -739,4 +738,16 @@ test_that("stream_content() resolves Anthropic citations across request turns", 
 test_that("can count tokens", {
   vcr::local_cassette("anthropic-count-tokens")
   test_token_count(chat_anthropic_test)
+})
+
+test_that("value_turn() handles empty content (#1070)", {
+  provider <- chat_anthropic_test()$get_provider()
+  result <- list(
+    content = list(),
+    stop_reason = "end_turn",
+    usage = list(input_tokens = 10, output_tokens = 2)
+  )
+
+  turn <- value_turn(provider, test_model("claude-sonnet-5"), result)
+  expect_equal(turn@contents, list())
 })


### PR DESCRIPTION
Fixes #1070

`claude-sonnet-5` sometimes returns a completely empty response (no content blocks). This broke things in two ways:

- `chat_anthropic()` errored when constructing the turn from the empty response.
- `chat_aws_bedrock()` sent the empty turn back as part of the conversation history on the next request, and Bedrock rejects empty messages with HTTP 400.

I checked whether the existing #376 workaround (replacing whitespace-only text with `[empty string]`) could be removed but it can't: both APIs still reject whitespace-only text and this is a different case, where there's no text at all.

The fix that :robot: came up with is that when an assistant turn has no content, both providers now send a single `[empty string]` text block in its place. I had :robot: try dropping the turn entirely (which is what `chat_anthropic()` did before, from #711), but that leaves two user messages in a row and the model tends to treat them as one, so the earlier instruction carries over into the later question. With the placeholder, the model answers the follow-up question correctly most of the time. I verified the #711 tool-calling scenario still works on both providers.
