### PR TITLE
Handle empty thinking for AWS provider

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 * `chat_anthropic()` and `chat_aws_bedrock()` no longer error after the model returns an empty response (@thisisnic, #1070).
 * `chat_anthropic()` now defaults `base_url` to the `ANTHROPIC_BASE_URL` environment variable, and `chat_aws_bedrock()` to `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` or `AWS_ENDPOINT_URL_BEDROCK_MANTLE` depending on `api`, matching the official SDKs (@karawoo, #1103).
 * `chat_anthropic()` now correctly handles the `fallback` content block returned when a model's server-side refusal fallback (`server-side-fallback-2026-06-01`) is triggered (@simonpcouch, #1058).
-* `chat_aws_bedrock()` no longer errors when the model returns a thinking block with no text (@thisisnic, #1085).
+* `chat_aws_bedrock()` no longer errors when the model returns a thinking block with no text (@thisisnic, #1100).
 * `chat_aws_bedrock()` now supports bearer token authentication for enterprise API gateways (@thisisnic, #1002).
 * `chat_databricks()` no longer errors with models that return content as an array of typed objects (e.g. `databricks-gpt-oss-120b`); reasoning parts are now captured as thinking content (@thisisnic, #1078).
 * `chat_databricks()` no longer errors when a registered tool has no arguments (@thisisnic, #1084).

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * `chat_anthropic()` and `chat_aws_bedrock()` no longer error after the model returns an empty response (@thisisnic, #1070).
 * `chat_anthropic()` now defaults `base_url` to the `ANTHROPIC_BASE_URL` environment variable, and `chat_aws_bedrock()` to `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` or `AWS_ENDPOINT_URL_BEDROCK_MANTLE` depending on `api`, matching the official SDKs (@karawoo, #1103).
 * `chat_anthropic()` now correctly handles the `fallback` content block returned when a model's server-side refusal fallback (`server-side-fallback-2026-06-01`) is triggered (@simonpcouch, #1058).
+* `chat_aws_bedrock()` no longer errors when the model returns a thinking block with no text (@thisisnic, #1085).
 * `chat_aws_bedrock()` now supports bearer token authentication for enterprise API gateways (@thisisnic, #1002).
 * `chat_databricks()` no longer errors with models that return content as an array of typed objects (e.g. `databricks-gpt-oss-120b`); reasoning parts are now captured as thinking content (@thisisnic, #1078).
 * `chat_databricks()` no longer errors when a registered tool has no arguments (@thisisnic, #1084).

--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -612,7 +612,7 @@ method(value_turn, ProviderAWSBedrock) <- function(
       }
     } else if (has_name(content, "reasoningContent")) {
       ContentThinking(
-        content$reasoningContent$reasoningText$text,
+        content$reasoningContent$reasoningText$text %||% "",
         extra = list(
           signature = content$reasoningContent$reasoningText$signature
         )

--- a/tests/testthat/test-provider-aws.R
+++ b/tests/testthat/test-provider-aws.R
@@ -490,3 +490,29 @@ test_that("drops empty user turns (#1070)", {
 
   expect_length(turns_json, 2)
 })
+
+test_that("value_turn() handles thinking blocks with no text (#1085)", {
+  provider <- test_aws_bedrock_provider()
+  result <- list(
+    output = list(
+      message = list(
+        content = list(
+          list(
+            reasoningContent = list(reasoningText = list(signature = "abc"))
+          ),
+          list(text = "Knock knock")
+        )
+      )
+    ),
+    stopReason = "end_turn",
+    usage = list(inputTokens = 10, outputTokens = 5)
+  )
+
+  turn <- value_turn(
+    provider,
+    test_model("us.anthropic.claude-sonnet-5"),
+    result
+  )
+  expect_equal(turn@contents[[1]]@thinking, "")
+  expect_equal(turn@contents[[1]]@extra$signature, "abc")
+})


### PR DESCRIPTION
Fixes #1085 

When AWS Bedrock returns empty thinking, ensure it's an empty string `""` rather than `NULL`, to prevent errors