### PR TITLE
feat: stream structured output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # ellmer (development version)
 
 * ellmer now preserves provider citations in chat history and streamed content, and displays cited sources in console output. Enable cited web results with `chat$register_tool()`, using tools such as `openai_tool_web_search()`, `claude_tool_web_search()`, or `claude_tool_web_fetch(citations = TRUE)` (#1068).
+* `Chat$stream()` and `Chat$stream_async()` now suppress registered tools when given a `type_()` specification and store the completed assistant turn as `ContentJson`; streaming structured output requires native provider support and does not use tool-based fallback.
 * `Chat` gains a `$token_count()` method that estimates the number of tokens in new input using the provider's token counting endpoint (@thisisnic, #814).
 * `chat_anthropic()`, `chat_aws_bedrock()`, and `chat_posit()` now default to `claude-sonnet-5`. `chat_openai()` and `chat_openrouter()` now default to `gpt-5.6-terra` (@thisisnic, #1066).
 * `chat_anthropic()` now correctly handles the `fallback` content block returned when a model's server-side refusal fallback (`server-side-fallback-2026-06-01`) is triggered (@simonpcouch, #1058).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # ellmer (development version)
 
 * ellmer now preserves provider citations in chat history and streamed content, and displays cited sources in console output. Enable cited web results with `chat$register_tool()`, using tools such as `openai_tool_web_search()`, `claude_tool_web_search()`, or `claude_tool_web_fetch(citations = TRUE)` (#1068).
-* `Chat$stream()` and `Chat$stream_async()` now suppress registered tools when given a `type_()` specification and store the completed assistant turn as `ContentJson`; streaming structured output requires native provider support and does not use tool-based fallback.
+* `Chat$stream()` and `Chat$stream_async()` gain a `type` argument for streaming structured output from providers with native support (@cpsievert, #1102)
 * `Chat` gains a `$token_count()` method that estimates the number of tokens in new input using the provider's token counting endpoint (@thisisnic, #814).
 * `chat_anthropic()`, `chat_aws_bedrock()`, and `chat_posit()` now default to `claude-sonnet-5`. `chat_openai()` and `chat_openrouter()` now default to `gpt-5.6-terra` (@thisisnic, #1066).
 * `chat_anthropic()` now correctly handles the `fallback` content block returned when a model's server-side refusal fallback (`server-side-fallback-2026-06-01`) is triggered (@simonpcouch, #1058).

--- a/R/chat-structured.R
+++ b/R/chat-structured.R
@@ -27,7 +27,8 @@ uses_tool_structured_output <- function(provider, model, type) {
   if (S7_inherits(provider, ProviderAWSBedrock)) {
     TRUE
   } else if (S7_inherits(provider, ProviderAnthropic)) {
-    !has_claude_structured_output(model@name)
+    !has_claude_structured_output(model@name) ||
+      type_has_additional_properties(type)
   } else {
     FALSE
   }

--- a/R/chat.R
+++ b/R/chat.R
@@ -617,9 +617,11 @@ Chat <- R6::R6Class(
         !is.null(type) &&
           uses_tool_structured_output(private$provider, private$model, type)
       ) {
-        cli::cli_abort(
-          "Streaming structured output requires native provider support for the supplied model."
-        )
+        cli::cli_abort(c(
+          "Can't stream structured output with {private$provider@name} model {.val {private$model@name}}.",
+          i = "Streaming requires native structured output, but this provider and model fall back to tool calling.",
+          i = "Use `$chat_structured()` instead."
+        ))
       }
 
       tool_errors <- list()
@@ -702,9 +704,11 @@ Chat <- R6::R6Class(
         !is.null(type) &&
           uses_tool_structured_output(private$provider, private$model, type)
       ) {
-        cli::cli_abort(
-          "Streaming structured output requires native provider support for the supplied model."
-        )
+        cli::cli_abort(c(
+          "Can't stream structured output with {private$provider@name} model {.val {private$model@name}}.",
+          i = "Streaming requires native structured output, but this provider and model fall back to tool calling.",
+          i = "Use `$chat_structured()` instead."
+        ))
       }
 
       tool_errors <- list()

--- a/R/chat.R
+++ b/R/chat.R
@@ -433,14 +433,31 @@ Chat <- R6::R6Class(
     #'   that yields strings. While iterating, the generator will block while
     #'   waiting for more content from the chatbot.
     #' @param ... The input to send to the chatbot. Can be strings or images.
+    #' @param type An optional `type_()` structured-data specification. When
+    #'   supplied, registered tools are suppressed and the completed assistant
+    #'   turn stores a `ContentJson`. The provider constrains the response to
+    #'   JSON. With `stream = "text"` (the default), structured stream chunks
+    #'   are raw JSON text; with `stream = "content"`, they are [Content]
+    #'   objects. Streaming structured output requires native provider support;
+    #'   tool-based fallback is not supported.
     #' @param stream Whether the stream should yield only `"text"` or ellmer's
     #'   rich content types. When `stream = "content"`, `stream()` yields
     #'   [Content] objects.
     #' @param controller An optional [stream_controller()] used to cancel the
     #'   stream from outside the iteration loop.
-    stream = function(..., stream = c("text", "content"), controller = NULL) {
+    stream = function(
+      ...,
+      type = NULL,
+      stream = c("text", "content"),
+      controller = NULL
+    ) {
       controller <- as_controller(controller)
       finish_tools <- private$complete_dangling_tool_requests()
+
+      if (!is.null(type)) {
+        needs_wrapper <- type_needs_wrapper(type, private$provider)
+        type <- wrap_type_if_needed(type, needs_wrapper)
+      }
 
       turn <- user_turn(!!!finish_tools, ...)
       stream <- arg_match(stream)
@@ -448,6 +465,7 @@ Chat <- R6::R6Class(
         turn,
         stream = TRUE,
         echo = "none",
+        type = type,
         yield_as_content = stream == "content",
         controller = controller
       )
@@ -458,6 +476,13 @@ Chat <- R6::R6Class(
     #'   generator](https://coro.r-lib.org/reference/async_generator.html) that
     #'   yields string promises.
     #' @param ... The input to send to the chatbot. Can be strings or images.
+    #' @param type An optional `type_()` structured-data specification. When
+    #'   supplied, registered tools are suppressed and the completed assistant
+    #'   turn stores a `ContentJson`. The provider constrains the response to
+    #'   JSON. With `stream = "text"` (the default), structured stream chunks
+    #'   are raw JSON text; with `stream = "content"`, they are [Content]
+    #'   objects. Streaming structured output requires native provider support;
+    #'   tool-based fallback is not supported.
     #' @param tool_mode Whether tools should be invoked one-at-a-time
     #'   (`"sequential"`) or concurrently (`"concurrent"`). Sequential mode is
     #'   best for interactive applications, especially when a tool may involve
@@ -470,12 +495,18 @@ Chat <- R6::R6Class(
     #'   stream from outside the iteration loop.
     stream_async = function(
       ...,
+      type = NULL,
       tool_mode = c("concurrent", "sequential"),
       stream = c("text", "content"),
       controller = NULL
     ) {
       controller <- as_controller(controller)
       finish_tools <- private$complete_dangling_tool_requests()
+
+      if (!is.null(type)) {
+        needs_wrapper <- type_needs_wrapper(type, private$provider)
+        type <- wrap_type_if_needed(type, needs_wrapper)
+      }
 
       turn <- user_turn(!!!finish_tools, ...)
       tool_mode <- arg_match(tool_mode)
@@ -485,6 +516,7 @@ Chat <- R6::R6Class(
         stream = TRUE,
         echo = "none",
         tool_mode = tool_mode,
+        type = type,
         yield_as_content = stream == "content",
         controller = controller
       )
@@ -577,9 +609,19 @@ Chat <- R6::R6Class(
       user_turn,
       stream,
       echo,
+      type = NULL,
       yield_as_content = FALSE,
       controller = NULL
     ) {
+      if (
+        !is.null(type) &&
+          uses_tool_structured_output(private$provider, private$model, type)
+      ) {
+        cli::cli_abort(
+          "Streaming structured output requires native provider support for the supplied model."
+        )
+      }
+
       tool_errors <- list()
       defer(warn_tool_errors(tool_errors))
 
@@ -594,6 +636,7 @@ Chat <- R6::R6Class(
           user_turn,
           stream = stream,
           echo = echo,
+          type = type,
           yield_as_content = yield_as_content,
           controller = controller,
           otel_span = agent_span
@@ -650,10 +693,20 @@ Chat <- R6::R6Class(
       user_turn,
       stream,
       echo,
+      type = NULL,
       tool_mode = "concurrent",
       yield_as_content = FALSE,
       controller = NULL
     ) {
+      if (
+        !is.null(type) &&
+          uses_tool_structured_output(private$provider, private$model, type)
+      ) {
+        cli::cli_abort(
+          "Streaming structured output requires native provider support for the supplied model."
+        )
+      }
+
       tool_errors <- list()
       defer(warn_tool_errors(tool_errors))
 
@@ -668,6 +721,7 @@ Chat <- R6::R6Class(
           user_turn,
           stream = stream,
           echo = echo,
+          type = type,
           yield_as_content = yield_as_content,
           controller = controller,
           otel_span = agent_span
@@ -873,7 +927,7 @@ Chat <- R6::R6Class(
           emit(activity)
           emit("\n")
         }
-        if (!is_partial_turn(turn) && any_text) {
+        if (!is_partial_turn(turn) && any_text && is.null(type)) {
           if (!endsWith(turn@text, "\n")) {
             if (yield_as_content) {
               yield(ContentText("\n"))
@@ -1034,7 +1088,7 @@ Chat <- R6::R6Class(
           emit(activity)
           emit("\n")
         }
-        if (!is_partial_turn(turn) && any_text) {
+        if (!is_partial_turn(turn) && any_text && is.null(type)) {
           if (!endsWith(turn@text, "\n")) {
             if (yield_as_content) {
               yield(ContentText("\n"))

--- a/man/Chat.Rd
+++ b/man/Chat.Rd
@@ -487,13 +487,20 @@ that yields strings. While iterating, the generator will block while
 waiting for more content from the chatbot.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{Chat$stream(..., stream = c("text", "content"), controller = NULL)}
+    \preformatted{Chat$stream(..., type = NULL, stream = c("text", "content"), controller = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{...}}{The input to send to the chatbot. Can be strings or images.}
+      \item{\code{type}}{An optional \code{type_()} structured-data specification. When
+supplied, registered tools are suppressed and the completed assistant
+turn stores a \code{ContentJson}. The provider constrains the response to
+JSON. With \code{stream = "text"} (the default), structured stream chunks
+are raw JSON text; with \code{stream = "content"}, they are \link{Content}
+objects. Streaming structured output requires native provider support;
+tool-based fallback is not supported.}
       \item{\code{stream}}{Whether the stream should yield only \code{"text"} or ellmer's
 rich content types. When \code{stream = "content"}, \code{stream()} yields
 \link{Content} objects.}
@@ -515,6 +522,7 @@ yields string promises.
     \if{html}{\out{<div class="r">}}
     \preformatted{Chat$stream_async(
   ...,
+  type = NULL,
   tool_mode = c("concurrent", "sequential"),
   stream = c("text", "content"),
   controller = NULL
@@ -525,6 +533,13 @@ yields string promises.
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{...}}{The input to send to the chatbot. Can be strings or images.}
+      \item{\code{type}}{An optional \code{type_()} structured-data specification. When
+supplied, registered tools are suppressed and the completed assistant
+turn stores a \code{ContentJson}. The provider constrains the response to
+JSON. With \code{stream = "text"} (the default), structured stream chunks
+are raw JSON text; with \code{stream = "content"}, they are \link{Content}
+objects. Streaming structured output requires native provider support;
+tool-based fallback is not supported.}
       \item{\code{tool_mode}}{Whether tools should be invoked one-at-a-time
 (\code{"sequential"}) or concurrently (\code{"concurrent"}). Sequential mode is
 best for interactive applications, especially when a tool may involve

--- a/tests/testthat/_snaps/chat.md
+++ b/tests/testthat/_snaps/chat.md
@@ -14,6 +14,72 @@
       Error in `chat$chat()`:
       ! `...` can only accept a single prompt.
 
+# streaming structured output rejects unsupported providers and types
+
+    Code
+      chat <- chat_anthropic_test(model = "claude-3-haiku-20240307")
+      collect_stream(chat, "Extract John, age 15", type = person, async = async)
+    Condition
+      Error:
+      ! Can't stream structured output with Anthropic model "claude-3-haiku-20240307".
+      i Streaming requires native structured output, but this provider and model fall back to tool calling.
+      i Use `$chat_structured()` instead.
+
+---
+
+    Code
+      chat <- chat_anthropic_test(model = "claude-sonnet-5")
+      collect_stream(chat, "Extract John", type = additional_props, async = async)
+    Condition
+      Error:
+      ! Can't stream structured output with Anthropic model "claude-sonnet-5".
+      i Streaming requires native structured output, but this provider and model fall back to tool calling.
+      i Use `$chat_structured()` instead.
+
+---
+
+    Code
+      chat <- chat_anthropic_test(model = "claude-sonnet-5")
+      collect_stream(chat, "Extract John", type = nested_additional_props, async = async)
+    Condition
+      Error:
+      ! Can't stream structured output with Anthropic model "claude-sonnet-5".
+      i Streaming requires native structured output, but this provider and model fall back to tool calling.
+      i Use `$chat_structured()` instead.
+
+---
+
+    Code
+      chat <- chat_anthropic_test(model = "claude-3-haiku-20240307")
+      collect_stream(chat, "Extract John, age 15", type = person, async = async)
+    Condition
+      Error:
+      ! Can't stream structured output with Anthropic model "claude-3-haiku-20240307".
+      i Streaming requires native structured output, but this provider and model fall back to tool calling.
+      i Use `$chat_structured()` instead.
+
+---
+
+    Code
+      chat <- chat_anthropic_test(model = "claude-sonnet-5")
+      collect_stream(chat, "Extract John", type = additional_props, async = async)
+    Condition
+      Error:
+      ! Can't stream structured output with Anthropic model "claude-sonnet-5".
+      i Streaming requires native structured output, but this provider and model fall back to tool calling.
+      i Use `$chat_structured()` instead.
+
+---
+
+    Code
+      chat <- chat_anthropic_test(model = "claude-sonnet-5")
+      collect_stream(chat, "Extract John", type = nested_additional_props, async = async)
+    Condition
+      Error:
+      ! Can't stream structured output with Anthropic model "claude-sonnet-5".
+      i Streaming requires native structured output, but this provider and model fall back to tool calling.
+      i Use `$chat_structured()` instead.
+
 # has a basic print method
 
     Code

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -335,6 +335,529 @@ test_that("can perform a simple async batch chat", {
   )
 })
 
+make_structured_stream_response <- function() {
+  list(
+    list(type = "response.output_text.delta", delta = '{"name":"John"'),
+    list(type = "response.output_text.delta", delta = ',"age":15}'),
+    list(
+      type = "response.completed",
+      response = list(
+        status = "completed",
+        output = list(list(
+          type = "message",
+          content = list(list(
+            type = "output_text",
+            text = '{"name":"John","age":15}'
+          ))
+        )),
+        usage = list(
+          input_tokens = 1,
+          output_tokens = 2,
+          input_tokens_details = list(cached_tokens = 0)
+        )
+      )
+    )
+  )
+}
+
+make_scalar_structured_stream_response <- function() {
+  list(
+    list(type = "response.output_text.delta", delta = '{"wrapper":"John"}'),
+    list(
+      type = "response.completed",
+      response = list(
+        status = "completed",
+        output = list(list(
+          type = "message",
+          content = list(list(
+            type = "output_text",
+            text = '{"wrapper":"John"}'
+          ))
+        )),
+        usage = list(
+          input_tokens = 1,
+          output_tokens = 2,
+          input_tokens_details = list(cached_tokens = 0)
+        )
+      )
+    )
+  )
+}
+
+make_text_stream_response <- function() {
+  list(
+    list(type = "response.output_text.delta", delta = "Hello"),
+    list(
+      type = "response.completed",
+      response = list(
+        status = "completed",
+        output = list(list(
+          type = "message",
+          content = list(list(
+            type = "output_text",
+            text = "Hello"
+          ))
+        )),
+        usage = list(
+          input_tokens = 1,
+          output_tokens = 2,
+          input_tokens_details = list(cached_tokens = 0)
+        )
+      )
+    )
+  )
+}
+
+test_that("stream() supports native structured output", {
+  person <- type_object(name = type_string(), age = type_integer())
+  response <- make_structured_stream_response()
+
+  local_mocked_bindings(
+    chat_perform = function(...) {
+      coro::generator(function() {
+        for (chunk in response) {
+          yield(chunk)
+        }
+      })()
+    }
+  )
+
+  chat <- chat_openai_test()
+  chunks <- coro::collect(
+    chat$stream("Extract John, age 15", type = person)
+  )
+
+  expect_identical(chunks, list('{"name":"John"', ',"age":15}'))
+  expect_s7_class(chat$last_turn()@contents[[1]], ContentJson)
+  expect_equal(
+    chat$last_turn()@contents[[1]]@parsed,
+    list(
+      name = "John",
+      age = 15
+    )
+  )
+})
+
+test_that("stream_async() supports native structured output", {
+  person <- type_object(name = type_string(), age = type_integer())
+  response <- make_structured_stream_response()
+
+  local_mocked_bindings(
+    chat_perform = function(...) {
+      coro::async_generator(function() {
+        for (chunk in response) {
+          yield(chunk)
+        }
+      })()
+    }
+  )
+
+  chat <- chat_openai_test()
+  chunks <- sync(coro::async_collect(
+    chat$stream_async("Extract John, age 15", type = person)
+  ))
+
+  expect_identical(chunks, list('{"name":"John"', ',"age":15}'))
+  expect_s7_class(chat$last_turn()@contents[[1]], ContentJson)
+  expect_equal(
+    chat$last_turn()@contents[[1]]@parsed,
+    list(
+      name = "John",
+      age = 15
+    )
+  )
+})
+
+test_that("stream() wraps scalar structured output types", {
+  type <- type_string()
+  requested_type <- NULL
+  response <- make_scalar_structured_stream_response()
+
+  local_mocked_bindings(
+    chat_perform = function(...) {
+      requested_type <<- list(...)$type
+      coro::generator(function() {
+        for (chunk in response) {
+          yield(chunk)
+        }
+      })()
+    }
+  )
+
+  chat <- chat_openai_test()
+  chunks <- coro::collect(chat$stream("Extract John", type = type))
+
+  expect_s7_class(requested_type, TypeObject)
+  expect_identical(requested_type@properties, list(wrapper = type))
+  expect_identical(chunks, list('{"wrapper":"John"}'))
+  expect_s7_class(chat$last_turn()@contents[[1]], ContentJson)
+  expect_equal(chat$last_turn()@contents[[1]]@parsed, list(wrapper = "John"))
+})
+
+test_that("stream_async() wraps scalar structured output types", {
+  type <- type_string()
+  requested_type <- NULL
+  response <- make_scalar_structured_stream_response()
+
+  local_mocked_bindings(
+    chat_perform = function(...) {
+      requested_type <<- list(...)$type
+      coro::async_generator(function() {
+        for (chunk in response) {
+          yield(chunk)
+        }
+      })()
+    }
+  )
+
+  chat <- chat_openai_test()
+  chunks <- sync(coro::async_collect(
+    chat$stream_async("Extract John", type = type)
+  ))
+
+  expect_s7_class(requested_type, TypeObject)
+  expect_identical(requested_type@properties, list(wrapper = type))
+  expect_identical(chunks, list('{"wrapper":"John"}'))
+  expect_s7_class(chat$last_turn()@contents[[1]], ContentJson)
+  expect_equal(chat$last_turn()@contents[[1]]@parsed, list(wrapper = "John"))
+})
+
+test_that("stream() rejects additional properties on native Anthropic models before request", {
+  type <- suppressWarnings(
+    type_object(
+      value = type_string(),
+      .additional_properties = TRUE
+    )
+  )
+  request_started <- FALSE
+
+  local_mocked_bindings(
+    chat_perform = function(...) {
+      request_started <<- TRUE
+      stop("request should not have started")
+    }
+  )
+
+  chat <- chat_anthropic_test(model = "claude-sonnet-5")
+  error <- tryCatch(
+    coro::collect(chat$stream("Extract John", type = type)),
+    error = identity
+  )
+
+  expect_identical(
+    conditionMessage(error),
+    "Streaming structured output requires native provider support for the supplied model."
+  )
+  expect_false(request_started)
+})
+
+test_that("stream_async() rejects additional properties on native Anthropic models before request", {
+  type <- suppressWarnings(
+    type_object(
+      value = type_string(),
+      .additional_properties = TRUE
+    )
+  )
+  request_started <- FALSE
+
+  local_mocked_bindings(
+    chat_perform = function(...) {
+      request_started <<- TRUE
+      stop("request should not have started")
+    }
+  )
+
+  chat <- chat_anthropic_test(model = "claude-sonnet-5")
+  error <- tryCatch(
+    sync(coro::async_collect(
+      chat$stream_async("Extract John", type = type)
+    )),
+    error = identity
+  )
+
+  expect_identical(
+    conditionMessage(error),
+    "Streaming structured output requires native provider support for the supplied model."
+  )
+  expect_false(request_started)
+})
+
+test_that("streaming rejects nested additional properties before request", {
+  withr::local_options(cli.width = 120)
+
+  type <- suppressWarnings(
+    type_object(
+      value = type_object(
+        name = type_string(),
+        .additional_properties = TRUE
+      )
+    )
+  )
+
+  run_case <- function(async) {
+    request_started <- FALSE
+
+    local_mocked_bindings(
+      chat_perform = function(...) {
+        request_started <<- TRUE
+        stop("request should not have started")
+      }
+    )
+
+    chat <- chat_anthropic_test(model = "claude-sonnet-5")
+    error <- if (async) {
+      tryCatch(
+        sync(coro::async_collect(
+          chat$stream_async("Extract John", type = type)
+        )),
+        error = identity
+      )
+    } else {
+      tryCatch(
+        coro::collect(chat$stream("Extract John", type = type)),
+        error = identity
+      )
+    }
+
+    expect_identical(
+      conditionMessage(error),
+      "Streaming structured output requires native provider support for the supplied model."
+    )
+    expect_identical(request_started, FALSE)
+  }
+
+  run_case(FALSE)
+  run_case(TRUE)
+})
+
+test_that("Bedrock streaming structured output rejects types before requests", {
+  type <- type_object(value = type_string())
+
+  run_case <- function(async) {
+    request_started <- FALSE
+
+    local_mocked_bindings(
+      chat_perform = function(...) {
+        request_started <<- TRUE
+        stop("request should not have started")
+      }
+    )
+
+    chat <- chat_aws_bedrock_test()
+    error <- if (async) {
+      tryCatch(
+        sync(coro::async_collect(
+          chat$stream_async("Extract John", type = type)
+        )),
+        error = identity
+      )
+    } else {
+      tryCatch(
+        coro::collect(chat$stream("Extract John", type = type)),
+        error = identity
+      )
+    }
+
+    expect_identical(
+      conditionMessage(error),
+      "Streaming structured output requires native provider support for the supplied model."
+    )
+    expect_false(request_started)
+  }
+
+  run_case(FALSE)
+  run_case(TRUE)
+})
+
+test_that("structured text streams omit registered tools from requests", {
+  run_case <- function(async) {
+    request_started <- FALSE
+    requested_tools <- NULL
+    response <- make_structured_stream_response()
+
+    local_mocked_bindings(
+      chat_perform = function(...) {
+        request_started <<- TRUE
+        requested_tools <<- list(...)$tools
+        if (async) {
+          coro::async_generator(function() {
+            for (chunk in response) {
+              yield(chunk)
+            }
+          })()
+        } else {
+          coro::generator(function() {
+            for (chunk in response) {
+              yield(chunk)
+            }
+          })()
+        }
+      }
+    )
+
+    chat <- chat_openai_test()
+    chat$register_tool(tool(function() "unused", "unused"))
+    if (async) {
+      sync(coro::async_collect(chat$stream_async(
+        "Extract John",
+        type = type_object(value = type_string())
+      )))
+    } else {
+      coro::collect(chat$stream(
+        "Extract John",
+        type = type_object(value = type_string())
+      ))
+    }
+
+    expect_true(request_started)
+    expect_length(requested_tools %||% list(), 0)
+  }
+
+  run_case(FALSE)
+  run_case(TRUE)
+})
+
+test_that("untyped streams retain registered tools in requests", {
+  run_case <- function(async) {
+    request_started <- FALSE
+    requested_tools <- NULL
+    response <- make_text_stream_response()
+
+    local_mocked_bindings(
+      chat_perform = function(...) {
+        request_started <<- TRUE
+        requested_tools <<- list(...)$tools
+        if (async) {
+          coro::async_generator(function() {
+            for (chunk in response) {
+              yield(chunk)
+            }
+          })()
+        } else {
+          coro::generator(function() {
+            for (chunk in response) {
+              yield(chunk)
+            }
+          })()
+        }
+      }
+    )
+
+    chat <- chat_openai_test()
+    chat$register_tool(tool(function() "unused", "unused"))
+    if (async) {
+      sync(coro::async_collect(chat$stream_async("Hello")))
+    } else {
+      coro::collect(chat$stream("Hello"))
+    }
+
+    expect_true(request_started)
+    expect_length(requested_tools, 1)
+  }
+
+  run_case(FALSE)
+  run_case(TRUE)
+})
+
+test_that("structured content streams yield Content objects", {
+  run_case <- function(async) {
+    response <- make_structured_stream_response()
+
+    local_mocked_bindings(
+      chat_perform = function(...) {
+        if (async) {
+          coro::async_generator(function() {
+            for (chunk in response) {
+              yield(chunk)
+            }
+          })()
+        } else {
+          coro::generator(function() {
+            for (chunk in response) {
+              yield(chunk)
+            }
+          })()
+        }
+      }
+    )
+
+    chat <- chat_openai_test()
+    chunks <- if (async) {
+      sync(coro::async_collect(chat$stream_async(
+        "Extract John",
+        type = type_object(value = type_string()),
+        stream = "content"
+      )))
+    } else {
+      coro::collect(chat$stream(
+        "Extract John",
+        type = type_object(value = type_string()),
+        stream = "content"
+      ))
+    }
+
+    expect_length(chunks, 2)
+    expect_s7_class(chunks[[1]], ContentText)
+    expect_s7_class(chunks[[2]], ContentText)
+    expect_identical(
+      lapply(chunks, function(chunk) chunk@text),
+      list('{"name":"John"', ',"age":15}')
+    )
+    expect_s7_class(chat$last_turn()@contents[[1]], ContentJson)
+  }
+
+  run_case(FALSE)
+  run_case(TRUE)
+})
+
+test_that("streaming structured output rejects non-native providers before request", {
+  person <- type_object(name = type_string(), age = type_integer())
+  request_started <- FALSE
+
+  local_mocked_bindings(
+    chat_perform = function(...) {
+      request_started <<- TRUE
+      stop("request should not have started")
+    }
+  )
+
+  chat <- chat_anthropic_test(model = "claude-3-haiku-20240307")
+  error <- tryCatch(
+    coro::collect(chat$stream("Extract John, age 15", type = person)),
+    error = identity
+  )
+  expect_identical(
+    conditionMessage(error),
+    "Streaming structured output requires native provider support for the supplied model."
+  )
+  expect_false(request_started)
+})
+
+test_that("async streaming structured output rejects non-native providers before request", {
+  person <- type_object(name = type_string(), age = type_integer())
+  request_started <- FALSE
+
+  local_mocked_bindings(
+    chat_perform = function(...) {
+      request_started <<- TRUE
+      stop("request should not have started")
+    }
+  )
+
+  chat <- chat_anthropic_test(model = "claude-3-haiku-20240307")
+  error <- tryCatch(
+    sync(coro::async_collect(
+      chat$stream_async("Extract John, age 15", type = person)
+    )),
+    error = identity
+  )
+  expect_identical(
+    conditionMessage(error),
+    "Streaming structured output requires native provider support for the supplied model."
+  )
+  expect_false(request_started)
+})
+
 test_that("can extract structured data", {
   person <- type_object(name = type_string(), age = type_integer())
 

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -335,7 +335,9 @@ test_that("can perform a simple async batch chat", {
   )
 })
 
-make_structured_stream_response <- function(deltas = c('{"name":"John"', ',"age":15}')) {
+make_structured_stream_response <- function(
+  deltas = c('{"name":"John"', ',"age":15}')
+) {
   text <- paste(deltas, collapse = "")
   c(
     lapply(deltas, function(delta) {
@@ -488,7 +490,12 @@ test_that("streaming structured output rejects unsupported providers and types",
     })
     expect_snapshot(error = TRUE, {
       chat <- chat_anthropic_test(model = "claude-sonnet-5")
-      collect_stream(chat, "Extract John", type = additional_props, async = async)
+      collect_stream(
+        chat,
+        "Extract John",
+        type = additional_props,
+        async = async
+      )
     })
     expect_snapshot(error = TRUE, {
       chat <- chat_anthropic_test(model = "claude-sonnet-5")
@@ -507,7 +514,12 @@ test_that("streaming structured output rejects unsupported providers and types",
     )
     if (!is.null(bedrock_chat)) {
       expect_snapshot(error = TRUE, {
-        collect_stream(bedrock_chat, "Extract John", type = person, async = async)
+        collect_stream(
+          bedrock_chat,
+          "Extract John",
+          type = person,
+          async = async
+        )
       })
     }
   }

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -335,11 +335,13 @@ test_that("can perform a simple async batch chat", {
   )
 })
 
-make_structured_stream_response <- function() {
-  list(
-    list(type = "response.output_text.delta", delta = '{"name":"John"'),
-    list(type = "response.output_text.delta", delta = ',"age":15}'),
-    list(
+make_structured_stream_response <- function(deltas = c('{"name":"John"', ',"age":15}')) {
+  text <- paste(deltas, collapse = "")
+  c(
+    lapply(deltas, function(delta) {
+      list(type = "response.output_text.delta", delta = delta)
+    }),
+    list(list(
       type = "response.completed",
       response = list(
         status = "completed",
@@ -347,7 +349,7 @@ make_structured_stream_response <- function() {
           type = "message",
           content = list(list(
             type = "output_text",
-            text = '{"name":"John","age":15}'
+            text = text
           ))
         )),
         usage = list(
@@ -356,32 +358,36 @@ make_structured_stream_response <- function() {
           input_tokens_details = list(cached_tokens = 0)
         )
       )
-    )
+    ))
   )
 }
 
-make_scalar_structured_stream_response <- function() {
-  list(
-    list(type = "response.output_text.delta", delta = '{"wrapper":"John"}'),
-    list(
-      type = "response.completed",
-      response = list(
-        status = "completed",
-        output = list(list(
-          type = "message",
-          content = list(list(
-            type = "output_text",
-            text = '{"wrapper":"John"}'
-          ))
-        )),
-        usage = list(
-          input_tokens = 1,
-          output_tokens = 2,
-          input_tokens_details = list(cached_tokens = 0)
-        )
-      )
-    )
+# Mock chat_perform to stream the given deltas; returns a function that
+# reports the arguments chat_perform was called with
+mock_chat_stream <- function(deltas, async, env = rlang::caller_env()) {
+  response <- make_structured_stream_response(deltas)
+  called_with <- NULL
+  local_mocked_bindings(
+    chat_perform = function(...) {
+      called_with <<- list(...)
+      gen <- if (async) coro::async_generator else coro::generator
+      gen(function() {
+        for (chunk in response) {
+          yield(chunk)
+        }
+      })()
+    },
+    .env = env
   )
+  function() called_with
+}
+
+collect_stream <- function(chat, ..., async) {
+  if (async) {
+    sync(coro::async_collect(chat$stream_async(...)))
+  } else {
+    coro::collect(chat$stream(...))
+  }
 }
 
 make_text_stream_response <- function() {
@@ -410,259 +416,100 @@ make_text_stream_response <- function() {
 
 test_that("stream() supports native structured output", {
   person <- type_object(name = type_string(), age = type_integer())
-  response <- make_structured_stream_response()
-
-  local_mocked_bindings(
-    chat_perform = function(...) {
-      coro::generator(function() {
-        for (chunk in response) {
-          yield(chunk)
-        }
-      })()
-    }
-  )
-
-  chat <- chat_openai_test()
-  chunks <- coro::collect(
-    chat$stream("Extract John, age 15", type = person)
-  )
-
-  expect_identical(chunks, list('{"name":"John"', ',"age":15}'))
-  expect_s7_class(chat$last_turn()@contents[[1]], ContentJson)
-  expect_equal(
-    chat$last_turn()@contents[[1]]@parsed,
-    list(
-      name = "John",
-      age = 15
-    )
-  )
-})
-
-test_that("stream_async() supports native structured output", {
-  person <- type_object(name = type_string(), age = type_integer())
-  response <- make_structured_stream_response()
-
-  local_mocked_bindings(
-    chat_perform = function(...) {
-      coro::async_generator(function() {
-        for (chunk in response) {
-          yield(chunk)
-        }
-      })()
-    }
-  )
-
-  chat <- chat_openai_test()
-  chunks <- sync(coro::async_collect(
-    chat$stream_async("Extract John, age 15", type = person)
-  ))
-
-  expect_identical(chunks, list('{"name":"John"', ',"age":15}'))
-  expect_s7_class(chat$last_turn()@contents[[1]], ContentJson)
-  expect_equal(
-    chat$last_turn()@contents[[1]]@parsed,
-    list(
-      name = "John",
-      age = 15
-    )
-  )
-})
-
-test_that("stream() wraps scalar structured output types", {
-  type <- type_string()
-  requested_type <- NULL
-  response <- make_scalar_structured_stream_response()
-
-  local_mocked_bindings(
-    chat_perform = function(...) {
-      requested_type <<- list(...)$type
-      coro::generator(function() {
-        for (chunk in response) {
-          yield(chunk)
-        }
-      })()
-    }
-  )
-
-  chat <- chat_openai_test()
-  chunks <- coro::collect(chat$stream("Extract John", type = type))
-
-  expect_s7_class(requested_type, TypeObject)
-  expect_identical(requested_type@properties, list(wrapper = type))
-  expect_identical(chunks, list('{"wrapper":"John"}'))
-  expect_s7_class(chat$last_turn()@contents[[1]], ContentJson)
-  expect_equal(chat$last_turn()@contents[[1]]@parsed, list(wrapper = "John"))
-})
-
-test_that("stream_async() wraps scalar structured output types", {
-  type <- type_string()
-  requested_type <- NULL
-  response <- make_scalar_structured_stream_response()
-
-  local_mocked_bindings(
-    chat_perform = function(...) {
-      requested_type <<- list(...)$type
-      coro::async_generator(function() {
-        for (chunk in response) {
-          yield(chunk)
-        }
-      })()
-    }
-  )
-
-  chat <- chat_openai_test()
-  chunks <- sync(coro::async_collect(
-    chat$stream_async("Extract John", type = type)
-  ))
-
-  expect_s7_class(requested_type, TypeObject)
-  expect_identical(requested_type@properties, list(wrapper = type))
-  expect_identical(chunks, list('{"wrapper":"John"}'))
-  expect_s7_class(chat$last_turn()@contents[[1]], ContentJson)
-  expect_equal(chat$last_turn()@contents[[1]]@parsed, list(wrapper = "John"))
-})
-
-test_that("stream() rejects additional properties on native Anthropic models before request", {
-  type <- suppressWarnings(
-    type_object(
-      value = type_string(),
-      .additional_properties = TRUE
-    )
-  )
-  request_started <- FALSE
-
-  local_mocked_bindings(
-    chat_perform = function(...) {
-      request_started <<- TRUE
-      stop("request should not have started")
-    }
-  )
-
-  chat <- chat_anthropic_test(model = "claude-sonnet-5")
-  error <- tryCatch(
-    coro::collect(chat$stream("Extract John", type = type)),
-    error = identity
-  )
-
-  expect_identical(
-    conditionMessage(error),
-    "Streaming structured output requires native provider support for the supplied model."
-  )
-  expect_false(request_started)
-})
-
-test_that("stream_async() rejects additional properties on native Anthropic models before request", {
-  type <- suppressWarnings(
-    type_object(
-      value = type_string(),
-      .additional_properties = TRUE
-    )
-  )
-  request_started <- FALSE
-
-  local_mocked_bindings(
-    chat_perform = function(...) {
-      request_started <<- TRUE
-      stop("request should not have started")
-    }
-  )
-
-  chat <- chat_anthropic_test(model = "claude-sonnet-5")
-  error <- tryCatch(
-    sync(coro::async_collect(
-      chat$stream_async("Extract John", type = type)
-    )),
-    error = identity
-  )
-
-  expect_identical(
-    conditionMessage(error),
-    "Streaming structured output requires native provider support for the supplied model."
-  )
-  expect_false(request_started)
-})
-
-test_that("streaming rejects nested additional properties before request", {
-  withr::local_options(cli.width = 120)
-
-  type <- suppressWarnings(
-    type_object(
-      value = type_object(
-        name = type_string(),
-        .additional_properties = TRUE
-      )
-    )
-  )
 
   run_case <- function(async) {
-    request_started <- FALSE
+    mock_chat_stream(c('{"name":"John"', ',"age":15}'), async)
 
-    local_mocked_bindings(
-      chat_perform = function(...) {
-        request_started <<- TRUE
-        stop("request should not have started")
-      }
+    chat <- chat_openai_test()
+    chunks <- collect_stream(
+      chat,
+      "Extract John, age 15",
+      type = person,
+      async = async
     )
 
-    chat <- chat_anthropic_test(model = "claude-sonnet-5")
-    error <- if (async) {
-      tryCatch(
-        sync(coro::async_collect(
-          chat$stream_async("Extract John", type = type)
-        )),
-        error = identity
-      )
-    } else {
-      tryCatch(
-        coro::collect(chat$stream("Extract John", type = type)),
-        error = identity
-      )
-    }
-
-    expect_identical(
-      conditionMessage(error),
-      "Streaming structured output requires native provider support for the supplied model."
+    expect_identical(chunks, list('{"name":"John"', ',"age":15}'))
+    expect_s7_class(chat$last_turn()@contents[[1]], ContentJson)
+    expect_equal(
+      chat$last_turn()@contents[[1]]@parsed,
+      list(name = "John", age = 15)
     )
-    expect_identical(request_started, FALSE)
   }
 
   run_case(FALSE)
   run_case(TRUE)
 })
 
-test_that("Bedrock streaming structured output rejects types before requests", {
-  type <- type_object(value = type_string())
+test_that("stream() wraps scalar structured output types", {
+  type <- type_string()
 
   run_case <- function(async) {
-    request_started <- FALSE
+    called_with <- mock_chat_stream('{"wrapper":"John"}', async)
 
+    chat <- chat_openai_test()
+    chunks <- collect_stream(chat, "Extract John", type = type, async = async)
+
+    requested_type <- called_with()$type
+    expect_s7_class(requested_type, TypeObject)
+    expect_identical(requested_type@properties, list(wrapper = type))
+    expect_identical(chunks, list('{"wrapper":"John"}'))
+    expect_s7_class(chat$last_turn()@contents[[1]], ContentJson)
+    expect_equal(chat$last_turn()@contents[[1]]@parsed, list(wrapper = "John"))
+  }
+
+  run_case(FALSE)
+  run_case(TRUE)
+})
+
+test_that("streaming structured output rejects unsupported providers and types", {
+  withr::local_options(cli.width = 120)
+
+  person <- type_object(name = type_string(), age = type_integer())
+  additional_props <- suppressWarnings(
+    type_object(value = type_string(), .additional_properties = TRUE)
+  )
+  nested_additional_props <- suppressWarnings(
+    type_object(
+      value = type_object(name = type_string(), .additional_properties = TRUE)
+    )
+  )
+
+  run_case <- function(async) {
+    # Errors should be raised before any request is made
     local_mocked_bindings(
       chat_perform = function(...) {
-        request_started <<- TRUE
         stop("request should not have started")
       }
     )
 
-    chat <- chat_aws_bedrock_test()
-    error <- if (async) {
-      tryCatch(
-        sync(coro::async_collect(
-          chat$stream_async("Extract John", type = type)
-        )),
-        error = identity
+    expect_snapshot(error = TRUE, {
+      chat <- chat_anthropic_test(model = "claude-3-haiku-20240307")
+      collect_stream(chat, "Extract John, age 15", type = person, async = async)
+    })
+    expect_snapshot(error = TRUE, {
+      chat <- chat_anthropic_test(model = "claude-sonnet-5")
+      collect_stream(chat, "Extract John", type = additional_props, async = async)
+    })
+    expect_snapshot(error = TRUE, {
+      chat <- chat_anthropic_test(model = "claude-sonnet-5")
+      collect_stream(
+        chat,
+        "Extract John",
+        type = nested_additional_props,
+        async = async
       )
-    } else {
-      tryCatch(
-        coro::collect(chat$stream("Extract John", type = type)),
-        error = identity
-      )
-    }
-
-    expect_identical(
-      conditionMessage(error),
-      "Streaming structured output requires native provider support for the supplied model."
+    })
+    # chat_aws_bedrock_test() skips when AWS credentials aren't available;
+    # catch that here so the rest of the test still runs
+    bedrock_chat <- tryCatch(
+      chat_aws_bedrock_test(),
+      skip = function(cnd) NULL
     )
-    expect_false(request_started)
+    if (!is.null(bedrock_chat)) {
+      expect_snapshot(error = TRUE, {
+        collect_stream(bedrock_chat, "Extract John", type = person, async = async)
+      })
+    }
   }
 
   run_case(FALSE)
@@ -808,54 +655,6 @@ test_that("structured content streams yield Content objects", {
 
   run_case(FALSE)
   run_case(TRUE)
-})
-
-test_that("streaming structured output rejects non-native providers before request", {
-  person <- type_object(name = type_string(), age = type_integer())
-  request_started <- FALSE
-
-  local_mocked_bindings(
-    chat_perform = function(...) {
-      request_started <<- TRUE
-      stop("request should not have started")
-    }
-  )
-
-  chat <- chat_anthropic_test(model = "claude-3-haiku-20240307")
-  error <- tryCatch(
-    coro::collect(chat$stream("Extract John, age 15", type = person)),
-    error = identity
-  )
-  expect_identical(
-    conditionMessage(error),
-    "Streaming structured output requires native provider support for the supplied model."
-  )
-  expect_false(request_started)
-})
-
-test_that("async streaming structured output rejects non-native providers before request", {
-  person <- type_object(name = type_string(), age = type_integer())
-  request_started <- FALSE
-
-  local_mocked_bindings(
-    chat_perform = function(...) {
-      request_started <<- TRUE
-      stop("request should not have started")
-    }
-  )
-
-  chat <- chat_anthropic_test(model = "claude-3-haiku-20240307")
-  error <- tryCatch(
-    sync(coro::async_collect(
-      chat$stream_async("Extract John, age 15", type = person)
-    )),
-    error = identity
-  )
-  expect_identical(
-    conditionMessage(error),
-    "Streaming structured output requires native provider support for the supplied model."
-  )
-  expect_false(request_started)
 })
 
 test_that("can extract structured data", {


### PR DESCRIPTION
## Why this matters
`Chat$stream()` and `Chat$stream_async()` can now stream provider-native structured output as it is generated, enabling callers to render JSON-backed artifacts and other structured responses incrementally. This follows the public API and orchestration precedent from [Chatlas PR #262](https://github.com/posit-dev/chatlas/pull/262).

## What changes
- Add `type` support to synchronous and asynchronous streaming.
- Preserve raw JSON fragments in text mode and `Content` chunks in content mode, while saving the completed response as `ContentJson`.
- Suppress registered tools for structured requests and reject provider/model/type combinations that require tool-based structured output.
- Cover OpenAI root-schema wrapping, Anthropic and Bedrock fallback rejection, tool behavior, and streaming modes.

## Verification
- `Rscript -e 'devtools::test(".", filter = "chat")'` (`614` passing)\n- `air format R/chat.R R/chat-structured.R tests/testthat/test-chat.R`\n- `devtools::document()`