### PR TITLE
Add `conversation_id` active binding to `Chat`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,5 @@
 # ellmer (development version)
 
-* `Chat` gains a settable `$conversation_id` active binding. When set, the identifier is recorded as the `gen_ai.conversation.id` attribute on the OpenTelemetry `chat` and `invoke_agent` spans, allowing backends to group spans belonging to the same conversation (per the OpenTelemetry GenAI semantic conventions). Developer-facing: intended for frameworks that manage conversation history; ellmer never generates an identifier on its own.
-
 * ellmer now preserves provider citations in chat history and streamed content, and displays cited sources in console output. Enable cited web results with `chat$register_tool()`, using tools such as `openai_tool_web_search()`, `claude_tool_web_search()`, or `claude_tool_web_fetch(citations = TRUE)` (#1068).
 * `Chat` gains a `$token_count()` method that estimates the number of tokens in new input using the provider's token counting endpoint (@thisisnic, #814).
 * `chat_anthropic()`, `chat_aws_bedrock()`, and `chat_posit()` now default to `claude-sonnet-5`. `chat_openai()` and `chat_openrouter()` now default to `gpt-5.6-terra` (@thisisnic, #1066).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ellmer (development version)
 
+* `Chat` gains a settable `$conversation_id` active binding. When set, the identifier is recorded as the `gen_ai.conversation.id` attribute on the OpenTelemetry `chat` and `invoke_agent` spans, allowing backends to group spans belonging to the same conversation (per the OpenTelemetry GenAI semantic conventions). Developer-facing: intended for frameworks that manage conversation history; ellmer never generates an identifier on its own.
+
 * ellmer now preserves provider citations in chat history and streamed content, and displays cited sources in console output. Enable cited web results with `chat$register_tool()`, using tools such as `openai_tool_web_search()`, `claude_tool_web_search()`, or `claude_tool_web_fetch(citations = TRUE)` (#1068).
 * `Chat` gains a `$token_count()` method that estimates the number of tokens in new input using the provider's token counting endpoint (@thisisnic, #814).
 * `chat_anthropic()`, `chat_aws_bedrock()`, and `chat_posit()` now default to `claude-sonnet-5`. `chat_openai()` and `chat_openrouter()` now default to `gpt-5.6-terra` (@thisisnic, #1066).

--- a/R/chat.R
+++ b/R/chat.R
@@ -79,7 +79,6 @@ Chat <- R6::R6Class(
       invisible(self)
     },
 
-
     #' @description Retrieve the conversation grouped into [Round]s. Each
     #'   `Round` pairs a user turn with the assistant and tool-result turns it
     #'   produced.

--- a/R/chat.R
+++ b/R/chat.R
@@ -79,6 +79,7 @@ Chat <- R6::R6Class(
       invisible(self)
     },
 
+
     #' @description Retrieve the conversation grouped into [Round]s. Each
     #'   `Round` pairs a user turn with the assistant and tool-result turns it
     #'   produced.
@@ -565,6 +566,7 @@ Chat <- R6::R6Class(
 
     .turns = list(),
     echo = NULL,
+    .conversation_id = NULL,
     tools = list(),
     callback_on_tool_request = NULL,
     callback_on_tool_result = NULL,
@@ -586,7 +588,8 @@ Chat <- R6::R6Class(
       agent_span <- local_agent_otel_span(
         private$provider,
         private$model,
-        activate = FALSE
+        activate = FALSE,
+        conversation_id = private$.conversation_id
       )
 
       while (!is.null(user_turn)) {
@@ -660,7 +663,8 @@ Chat <- R6::R6Class(
       agent_span <- local_agent_otel_span(
         private$provider,
         private$model,
-        activate = FALSE
+        activate = FALSE,
+        conversation_id = private$.conversation_id
       )
 
       while (!is.null(user_turn)) {
@@ -756,7 +760,8 @@ Chat <- R6::R6Class(
         private$model,
         turns = otel_input$turns,
         system_prompt = otel_input$system_prompt,
-        parent = otel_span
+        parent = otel_span,
+        conversation_id = private$.conversation_id
       )
 
       response <- chat_perform(
@@ -916,7 +921,8 @@ Chat <- R6::R6Class(
         private$model,
         turns = otel_input$turns,
         system_prompt = otel_input$system_prompt,
-        parent = otel_span
+        parent = otel_span,
+        conversation_id = private$.conversation_id
       )
 
       response <- chat_perform(
@@ -1077,6 +1083,24 @@ Chat <- R6::R6Class(
           request = req
         )
       })
+    }
+  ),
+  active = list(
+    #' @field conversation_id Identifier for the current conversation. When
+    #'   set, it is recorded as the `gen_ai.conversation.id` attribute on the
+    #'   OpenTelemetry spans emitted for subsequent model calls. Assign `NULL`
+    #'   to clear.
+    #'
+    #'   Developer-facing: intended for frameworks that manage conversation
+    #'   history (e.g., Shiny apps). ellmer never generates an identifier on
+    #'   its own.
+    conversation_id = function(value) {
+      if (missing(value)) {
+        private$.conversation_id
+      } else {
+        check_string(value, allow_null = TRUE)
+        private$.conversation_id <- value
+      }
     }
   )
 )

--- a/R/otel.R
+++ b/R/otel.R
@@ -31,6 +31,7 @@ local({
     turns = NULL,
     system_prompt = NULL,
     parent = NULL,
+    conversation_id = NULL,
     local_envir = parent.frame()
   ) {
     if (!otel_is_tracing) {
@@ -43,11 +44,15 @@ local({
           parent = parent,
           kind = "client"
         ),
-        attributes = list(
+        # Per the GenAI semantic conventions, gen_ai.conversation.id is only
+        # set when the caller has a conversation identifier readily available;
+        # never invent a fallback value.
+        attributes = compact(list(
           "gen_ai.operation.name" = "chat",
           "gen_ai.provider.name" = tolower(provider@name),
-          "gen_ai.request.model" = model@name
-        ),
+          "gen_ai.request.model" = model@name,
+          "gen_ai.conversation.id" = conversation_id
+        )),
         tracer = otel_tracer
       )
 
@@ -125,6 +130,7 @@ local({
     provider,
     model,
     activate = TRUE,
+    conversation_id = NULL,
     local_envir = parent.frame()
   ) {
     if (!otel_is_tracing) {
@@ -142,11 +148,12 @@ local({
       otel::start_span(
         "invoke_agent",
         options = list(kind = "client"),
-        attributes = list(
+        attributes = compact(list(
           "gen_ai.operation.name" = "invoke_agent",
           "gen_ai.provider.name" = tolower(provider@name),
-          "gen_ai.request.model" = model@name
-        ),
+          "gen_ai.request.model" = model@name,
+          "gen_ai.conversation.id" = conversation_id
+        )),
         tracer = otel_tracer
       )
 

--- a/man/Chat.Rd
+++ b/man/Chat.Rd
@@ -23,6 +23,20 @@ chat <- chat_openai()
 chat$chat("Tell me a funny joke")
 \dontshow{ellmer:::vcr_example_end()}
 }
+\section{Active bindings}{
+  \if{html}{\out{<div class="r6-active-bindings">}}
+  \describe{
+    \item{\code{conversation_id}}{Identifier for the current conversation. When
+set, it is recorded as the \code{gen_ai.conversation.id} attribute on the
+OpenTelemetry spans emitted for subsequent model calls. Assign \code{NULL}
+to clear.
+
+Developer-facing: intended for frameworks that manage conversation
+history (e.g., Shiny apps). ellmer never generates an identifier on
+its own.}
+  }
+  \if{html}{\out{</div>}}
+}
 \section{Methods}{
 \subsection{Public methods}{
   \itemize{

--- a/tests/testthat/test-otel.R
+++ b/tests/testthat/test-otel.R
@@ -351,3 +351,70 @@ test_that("tool_call_response part decodes json-class values", {
     list(foo = 1, bar = list(2, 3))
   )
 })
+
+test_that("conversation id is recorded on agent and chat spans when set", {
+  skip_if_not_installed("otelsdk")
+  withr::local_envvar(OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = NA)
+
+  chat <- chat_openai_test()
+  private <- chat$.__enclos_env__$private
+
+  # Binding round-trip, clearing, and input validation
+  expect_null(chat$conversation_id)
+  chat$conversation_id <- "conv_123"
+  expect_equal(chat$conversation_id, "conv_123")
+  chat$conversation_id <- NULL
+  expect_null(chat$conversation_id)
+  expect_error(chat$conversation_id <- 123)
+
+  chat$conversation_id <- "conv_123"
+  spans <- with_otel_record({
+    # Anonymous function so the deferred span ends fire before recording is read
+    (function() {
+      agent_span <- local_agent_otel_span(
+        private$provider,
+        private$model,
+        activate = FALSE,
+        conversation_id = chat$conversation_id
+      )
+      local_chat_otel_span(
+        private$provider,
+        private$model,
+        parent = agent_span,
+        conversation_id = chat$conversation_id
+      )
+    })()
+  })[["traces"]]
+
+  agent_spans <- Filter(function(x) x$name == "invoke_agent", spans)
+  chat_spans <- Filter(function(x) startsWith(x$name, "chat"), spans)
+  expect_length(agent_spans, 1L)
+  expect_length(chat_spans, 1L)
+  expect_equal(
+    agent_spans[[1]]$attributes[["gen_ai.conversation.id"]],
+    "conv_123"
+  )
+  expect_equal(
+    chat_spans[[1]]$attributes[["gen_ai.conversation.id"]],
+    "conv_123"
+  )
+})
+
+test_that("conversation id attribute is absent when unset", {
+  skip_if_not_installed("otelsdk")
+  withr::local_envvar(OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = NA)
+
+  chat <- chat_openai_test()
+  private <- chat$.__enclos_env__$private
+
+  spans <- with_otel_record({
+    (function() {
+      local_chat_otel_span(private$provider, private$model)
+    })()
+  })[["traces"]]
+
+  chat_spans <- Filter(function(x) startsWith(x$name, "chat"), spans)
+  expect_length(chat_spans, 1L)
+  # Per the GenAI semantic conventions, no fallback identifier is invented
+  expect_null(chat_spans[[1]]$attributes[["gen_ai.conversation.id"]])
+})


### PR DESCRIPTION
Part of posit-dev/shinychat#307. Python equivalent: posit-dev/chatlas#398. Downstream consumer: posit-dev/shinychat#343.

## Summary

Adds a `conversation_id` active binding to `Chat`. When set, the identifier is recorded as the `gen_ai.conversation.id` attribute on the `invoke_agent` and `chat` OpenTelemetry spans emitted for subsequent model calls, so backends can group spans belonging to the same conversation (per the [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/)).

This is developer-facing: intended for frameworks that manage conversation history rather than end users. Because ellmer owns the spans, downstream frameworks don't need to define any OpenTelemetry spans of their own — they just hand over the conversation ID. In shinychat's case (posit-dev/shinychat#343), this drops its entire OTel span apparatus (tracer resolution, promise-domain span wrapping, otel/otelsdk dependencies, span tests) in favor of a single assignment before the model call.

Following the conventions, ellmer never generates an identifier on its own — when unset (`NULL`, the default), the attribute is omitted entirely rather than falling back to an invented value. Setting the binding only affects spans created for subsequent model calls; in-flight responses keep the ID captured at their submission.

## Verification

```r
chat <- chat_openai(model = "gpt-4o-mini")
chat$conversation_id <- "conv_123"  # recorded as gen_ai.conversation.id on chat/invoke_agent spans
chat$conversation_id <- NULL        # clear (e.g., starting a new conversation)
```

Tests in `tests/testthat/test-otel.R` cover: attribute present on both span types when set, absent by default, and binding round-trip/validation.
