### PR TITLE
Deprecate the model property instead of removing it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@
 * `chat_google_gemini()` no longer errors when mixing regular tools and built-in tools like `google_tool_web_search()` (@thisisnic, #1054).
 * `chat_openrouter()` now correctly preserves provider error messages (@xmarquez, #1059).
 * New `models_update_prices()` downloads the latest model pricing data from GitHub and saves it to a local cache. Subsequent calls to `token_usage()` and related functions will use the updated prices (#968).
-* New `Model` class separates model configuration (name, parameters, extra arguments) from the `Provider` class, which now only captures API endpoint details. `Chat` gains a new `$get_model_object()` method to retrieve the `Model` object. `provider@model`, `provider@params`, and `provider@extra_args` are deprecated and will be removed in a future release; use the `Model` object instead (@thisisnic, #499, #1098).
+* New `Model` class separates model configuration (name, parameters, extra arguments) from the `Provider` class, which now only captures API endpoint details. `Chat` gains a new `$get_model_object()` method to retrieve the `Model` object. `provider@model`, `provider@params`, and `provider@extra_args` are deprecated and will be removed in a future release; use the `Model` object instead (@thisisnic, #1098).
 * `tool()` functions that return complex objects like data frames or lists now produce a deprecation warning. Tool functions should return a character vector, an atomic vector, a JSON string (from `jsonlite::toJSON()`), or a `Content` object. Use `jsonlite::toJSON()` to convert complex objects before returning (@thisisnic, #858).
 
 # ellmer 0.4.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@
 * `chat_google_gemini()` no longer errors when mixing regular tools and built-in tools like `google_tool_web_search()` (@thisisnic, #1054).
 * `chat_openrouter()` now correctly preserves provider error messages (@xmarquez, #1059).
 * New `models_update_prices()` downloads the latest model pricing data from GitHub and saves it to a local cache. Subsequent calls to `token_usage()` and related functions will use the updated prices (#968).
-* New `Model` class separates model configuration (name, parameters, extra arguments) from the `Provider` class, which now only captures API endpoint details. `Chat` gains a new `$get_model_object()` method to retrieve the `Model` object. This is a breaking change for anyone who directly accesses `provider@model`, `provider@params`, or `provider@extra_args`; use the `Model` object instead (@thisisnic, #499).
+* New `Model` class separates model configuration (name, parameters, extra arguments) from the `Provider` class, which now only captures API endpoint details. `Chat` gains a new `$get_model_object()` method to retrieve the `Model` object. `provider@model`, `provider@params`, and `provider@extra_args` are deprecated and will be removed in a future release; use the `Model` object instead (@thisisnic, #499, #1098).
 * `tool()` functions that return complex objects like data frames or lists now produce a deprecation warning. Tool functions should return a character vector, an atomic vector, a JSON string (from `jsonlite::toJSON()`), or a `Content` object. Use `jsonlite::toJSON()` to convert complex objects before returning (@thisisnic, #858).
 
 # ellmer 0.4.2

--- a/R/chat.R
+++ b/R/chat.R
@@ -40,10 +40,16 @@ Chat <- R6::R6Class(
     #'  by setting the `ellmer_echo` option.
     initialize = function(
       provider,
-      model,
+      model = NULL,
       system_prompt = NULL,
       echo = "none"
     ) {
+      # Fall back to the model set via deprecated Provider properties.
+      # Remove along with the deprecated properties (#1098).
+      model <- model %||% provider_model(provider)
+      if (is.null(model)) {
+        cli::cli_abort("{.arg model} is required.")
+      }
       private$provider <- provider
       private$model <- model
       provider_model(private$provider) <- model

--- a/R/chat.R
+++ b/R/chat.R
@@ -46,6 +46,7 @@ Chat <- R6::R6Class(
     ) {
       private$provider <- provider
       private$model <- model
+      provider_model(private$provider) <- model
       private$echo <- echo
       private$callback_on_tool_request <- CallbackManager$new(args = "request")
       private$callback_on_tool_result <- CallbackManager$new(args = "result")
@@ -147,6 +148,7 @@ Chat <- R6::R6Class(
     set_model = function(model) {
       check_string(model)
       private$model@name <- model
+      provider_model(private$provider) <- private$model
       invisible(self)
     },
 

--- a/R/provider.R
+++ b/R/provider.R
@@ -41,13 +41,12 @@ Provider <- new_class(
   )
 )
 
-# Default S7 print calls every getter, which would trigger the deprecation
+# Default S7 print/str call every getter, which would trigger the deprecation
 # warnings. Remove along with the deprecated properties (#1098).
-method(print, Provider) <- function(x, ...) {
-  # props() would call the deprecated getters, so pick properties by name
-  names <- setdiff(prop_names(x), c("model", "params", "extra_args"))
-  props <- set_names(lapply(names, \(name) prop(x, name)), names)
-  cat("<", class(x)[[1]], ">\n", sep = "")
+method(utils::str, Provider) <- function(object, ...) {
+  names <- setdiff(prop_names(object), c("model", "params", "extra_args"))
+  props <- set_names(lapply(names, \(name) prop(object, name)), names)
+  cat("<", class(object)[[1]], ">\n", sep = "")
   str(
     props,
     no.list = TRUE,
@@ -55,6 +54,11 @@ method(print, Provider) <- function(x, ...) {
     comp.str = "@ ",
     indent.str = " "
   )
+  invisible()
+}
+
+method(print, Provider) <- function(x, ...) {
+  utils::str(x, ...)
   invisible(x)
 }
 

--- a/R/provider.R
+++ b/R/provider.R
@@ -19,6 +19,8 @@ NULL
 #'   to use for authentication. Can either return a string, representing an
 #'   API key, or a named list of headers.
 #' @param extra_headers Arbitrary extra headers to be added to the request.
+#' @param model,params,extra_args `r lifecycle::badge("deprecated")` These now
+#'   live on the [Model] object; use `chat$get_model_object()` instead.
 #' @return An S7 Provider object.
 #' @examples
 #' Provider(
@@ -31,9 +33,30 @@ Provider <- new_class(
     name = prop_string(),
     base_url = prop_string(),
     extra_headers = class_character,
-    credentials = class_function | NULL
+    credentials = class_function | NULL,
+    # Deprecated: model details now live on Model. Remove after 0.5.0 (#1098).
+    model = prop_deprecated("model", "name"),
+    params = prop_deprecated("params", "params"),
+    extra_args = prop_deprecated("extra_args", "extra_args")
   )
 )
+
+# Default S7 print calls every getter, which would trigger the deprecation
+# warnings. Remove along with the deprecated properties (#1098).
+method(print, Provider) <- function(x, ...) {
+  # props() would call the deprecated getters, so pick properties by name
+  names <- setdiff(prop_names(x), c("model", "params", "extra_args"))
+  props <- set_names(lapply(names, \(name) prop(x, name)), names)
+  cat("<", class(x)[[1]], ">\n", sep = "")
+  str(
+    props,
+    no.list = TRUE,
+    give.attr = FALSE,
+    comp.str = "@ ",
+    indent.str = " "
+  )
+  invisible(x)
+}
 
 test_provider <- function(name = "", base_url = "", ...) {
   Provider(name = name, base_url = base_url, ...)

--- a/R/provider.R
+++ b/R/provider.R
@@ -41,12 +41,12 @@ Provider <- new_class(
   )
 )
 
-# Default S7 print/str call every getter, which would trigger the deprecation
+# Default S7 print calls every getter, which would trigger the deprecation
 # warnings. Remove along with the deprecated properties (#1098).
-method(utils::str, Provider) <- function(object, ...) {
-  names <- setdiff(prop_names(object), c("model", "params", "extra_args"))
-  props <- set_names(lapply(names, \(name) prop(object, name)), names)
-  cat("<", class(object)[[1]], ">\n", sep = "")
+method(print, Provider) <- function(x, ...) {
+  names <- setdiff(prop_names(x), c("model", "params", "extra_args"))
+  props <- set_names(lapply(names, \(name) prop(x, name)), names)
+  cat("<", class(x)[[1]], ">\n", sep = "")
   str(
     props,
     no.list = TRUE,
@@ -54,11 +54,6 @@ method(utils::str, Provider) <- function(object, ...) {
     comp.str = "@ ",
     indent.str = " "
   )
-  invisible()
-}
-
-method(print, Provider) <- function(x, ...) {
-  utils::str(x, ...)
   invisible(x)
 }
 

--- a/R/provider.R
+++ b/R/provider.R
@@ -34,7 +34,7 @@ Provider <- new_class(
     base_url = prop_string(),
     extra_headers = class_character,
     credentials = class_function | NULL,
-    # Deprecated: model details now live on Model. Remove after 0.5.0 (#1098).
+    # Deprecated in 0.5.0: model details now live on Model. Remove in 0.6.0 (#1098).
     model = prop_deprecated("model", "name"),
     params = prop_deprecated("params", "params"),
     extra_args = prop_deprecated("extra_args", "extra_args")

--- a/R/utils-S7.R
+++ b/R/utils-S7.R
@@ -25,12 +25,14 @@ prop_string <- function(default = NULL, allow_null = FALSE, allow_na = FALSE) {
 
 # Deprecated Provider properties, backed by a hidden ".model" attribute that
 # Chat sets. Remove once the deprecation cycle is complete (#1098).
+# user_env is fixed to global_env() because the getter/setter are called from
+# S7's `@` dispatch, so lifecycle would otherwise blame S7.
 prop_deprecated <- function(name, model_prop) {
   force(name)
   force(model_prop)
 
   new_property(
-    class = NULL | class_any,
+    class = class_any,
     getter = function(self) {
       lifecycle::deprecate_warn(
         "0.5.0",

--- a/R/utils-S7.R
+++ b/R/utils-S7.R
@@ -25,8 +25,6 @@ prop_string <- function(default = NULL, allow_null = FALSE, allow_na = FALSE) {
 
 # Deprecated Provider properties, backed by a hidden ".model" attribute that
 # Chat sets. Remove once the deprecation cycle is complete (#1098).
-# user_env is fixed to global_env() because the getter/setter are called from
-# S7's `@` dispatch, so lifecycle would otherwise blame S7.
 prop_deprecated <- function(name, model_prop) {
   force(name)
   force(model_prop)
@@ -34,11 +32,12 @@ prop_deprecated <- function(name, model_prop) {
   new_property(
     class = class_any,
     getter = function(self) {
+      user_env <- deprecated_prop_user_env()
       lifecycle::deprecate_warn(
         "0.5.0",
         I(paste0("`Provider@", name, "`")),
-        details = "Use the `Model` object instead, e.g. `chat$get_model_object()`.",
-        user_env = global_env()
+        details = "Model details now live on the `Model` object; see `chat$get_model_object()`.",
+        user_env = user_env
       )
       model <- provider_model(self)
       if (is.null(model)) NULL else prop(model, model_prop)
@@ -47,11 +46,12 @@ prop_deprecated <- function(name, model_prop) {
       if (is.null(value)) {
         return(self)
       }
+      user_env <- deprecated_prop_user_env()
       lifecycle::deprecate_warn(
         "0.5.0",
         I(paste0("`Provider(", name, ")`")),
-        details = "Use the `Model` object instead.",
-        user_env = global_env()
+        details = "Model details now live on the `Model` object.",
+        user_env = user_env
       )
       model <- provider_model(self) %||% Model(name = "")
       prop(model, model_prop) <- value
@@ -59,6 +59,19 @@ prop_deprecated <- function(name, model_prop) {
       self
     }
   )
+}
+
+# The getter/setter are called from S7's `@` dispatch, so lifecycle's default
+# would blame S7. Walk up the stack to the first frame outside S7 and ellmer.
+deprecated_prop_user_env <- function() {
+  skip <- list(ns_env("ellmer"), ns_env("S7"))
+  for (i in rev(seq_len(sys.nframe() - 1))) {
+    env <- sys.frame(i)
+    if (!any(vapply(skip, identical, logical(1), topenv(env)))) {
+      return(env)
+    }
+  }
+  global_env()
 }
 
 provider_model <- function(provider) {

--- a/R/utils-S7.R
+++ b/R/utils-S7.R
@@ -23,6 +23,51 @@ prop_string <- function(default = NULL, allow_null = FALSE, allow_na = FALSE) {
   )
 }
 
+# Deprecated Provider properties, backed by a hidden ".model" attribute that
+# Chat sets. Remove once the deprecation cycle is complete (#1098).
+prop_deprecated <- function(name, model_prop) {
+  force(name)
+  force(model_prop)
+
+  new_property(
+    class = NULL | class_any,
+    getter = function(self) {
+      lifecycle::deprecate_warn(
+        "0.5.0",
+        I(paste0("`Provider@", name, "`")),
+        details = "Use the `Model` object instead, e.g. `chat$get_model_object()`.",
+        user_env = global_env()
+      )
+      model <- provider_model(self)
+      if (is.null(model)) NULL else prop(model, model_prop)
+    },
+    setter = function(self, value) {
+      if (is.null(value)) {
+        return(self)
+      }
+      lifecycle::deprecate_warn(
+        "0.5.0",
+        I(paste0("`Provider(", name, ")`")),
+        details = "Use the `Model` object instead.",
+        user_env = global_env()
+      )
+      model <- provider_model(self) %||% Model(name = "")
+      prop(model, model_prop) <- value
+      provider_model(self) <- model
+      self
+    }
+  )
+}
+
+provider_model <- function(provider) {
+  attr(provider, ".model", exact = TRUE)
+}
+
+`provider_model<-` <- function(provider, value) {
+  attr(provider, ".model") <- value
+  provider
+}
+
 prop_bool <- function(default, allow_null = FALSE, allow_na = FALSE) {
   force(allow_null)
   force(allow_na)

--- a/man/Chat.Rd
+++ b/man/Chat.Rd
@@ -77,7 +77,7 @@ its own.}
 \subsection{\code{Chat$new()}}{
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{Chat$new(provider, model, system_prompt = NULL, echo = "none")}
+    \preformatted{Chat$new(provider, model = NULL, system_prompt = NULL, echo = "none")}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{

--- a/man/Provider.Rd
+++ b/man/Provider.Rd
@@ -8,7 +8,10 @@ Provider(
   name = stop("Required"),
   base_url = stop("Required"),
   extra_headers = character(0),
-  credentials = function() NULL
+  credentials = function() NULL,
+  model = NULL,
+  params = NULL,
+  extra_args = NULL
 )
 }
 \arguments{
@@ -21,6 +24,9 @@ Provider(
 \item{credentials}{A zero-argument function that returns the credentials
 to use for authentication. Can either return a string, representing an
 API key, or a named list of headers.}
+
+\item{model, params, extra_args}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} These now
+live on the \link{Model} object; use \code{chat$get_model_object()} instead.}
 }
 \value{
 An S7 Provider object.

--- a/tests/testthat/_snaps/provider.md
+++ b/tests/testthat/_snaps/provider.md
@@ -39,10 +39,18 @@
     Output
       [1] "x"
 
-# Provider print omits deprecated properties
+# Provider print and str omit deprecated properties
 
     Code
       print(test_provider())
+    Output
+      <ellmer::Provider>
+       @ name         : chr ""
+       @ base_url     : chr ""
+       @ extra_headers: chr(0) 
+       @ credentials  :function ()  
+    Code
+      str(test_provider())
     Output
       <ellmer::Provider>
        @ name         : chr ""

--- a/tests/testthat/_snaps/provider.md
+++ b/tests/testthat/_snaps/provider.md
@@ -39,18 +39,10 @@
     Output
       [1] "x"
 
-# Provider print and str omit deprecated properties
+# Provider print omits deprecated properties
 
     Code
       print(test_provider())
-    Output
-      <ellmer::Provider>
-       @ name         : chr ""
-       @ base_url     : chr ""
-       @ extra_headers: chr(0) 
-       @ credentials  :function ()  
-    Code
-      str(test_provider())
     Output
       <ellmer::Provider>
        @ name         : chr ""

--- a/tests/testthat/_snaps/provider.md
+++ b/tests/testthat/_snaps/provider.md
@@ -5,7 +5,7 @@
     Condition
       Warning:
       `Provider@model` was deprecated in ellmer 0.5.0.
-      i Use the `Model` object instead, e.g. `chat$get_model_object()`.
+      i Model details now live on the `Model` object; see `chat$get_model_object()`.
     Output
       [1] "m"
     Code
@@ -13,7 +13,7 @@
     Condition
       Warning:
       `Provider@params` was deprecated in ellmer 0.5.0.
-      i Use the `Model` object instead, e.g. `chat$get_model_object()`.
+      i Model details now live on the `Model` object; see `chat$get_model_object()`.
     Output
       list()
     Code
@@ -21,7 +21,7 @@
     Condition
       Warning:
       `Provider@extra_args` was deprecated in ellmer 0.5.0.
-      i Use the `Model` object instead, e.g. `chat$get_model_object()`.
+      i Model details now live on the `Model` object; see `chat$get_model_object()`.
     Output
       list()
     Code
@@ -29,13 +29,13 @@
     Condition
       Warning:
       `Provider(model)` was deprecated in ellmer 0.5.0.
-      i Use the `Model` object instead.
+      i Model details now live on the `Model` object.
     Code
       provider@model
     Condition
       Warning:
       `Provider@model` was deprecated in ellmer 0.5.0.
-      i Use the `Model` object instead, e.g. `chat$get_model_object()`.
+      i Model details now live on the `Model` object; see `chat$get_model_object()`.
     Output
       [1] "x"
 

--- a/tests/testthat/_snaps/provider.md
+++ b/tests/testthat/_snaps/provider.md
@@ -1,0 +1,52 @@
+# deprecated Provider properties warn but still work
+
+    Code
+      provider@model
+    Condition
+      Warning:
+      `Provider@model` was deprecated in ellmer 0.5.0.
+      i Use the `Model` object instead, e.g. `chat$get_model_object()`.
+    Output
+      [1] "m"
+    Code
+      provider@params
+    Condition
+      Warning:
+      `Provider@params` was deprecated in ellmer 0.5.0.
+      i Use the `Model` object instead, e.g. `chat$get_model_object()`.
+    Output
+      list()
+    Code
+      provider@extra_args
+    Condition
+      Warning:
+      `Provider@extra_args` was deprecated in ellmer 0.5.0.
+      i Use the `Model` object instead, e.g. `chat$get_model_object()`.
+    Output
+      list()
+    Code
+      provider <- Provider(name = "test", base_url = "https://example.com", model = "x")
+    Condition
+      Warning:
+      `Provider(model)` was deprecated in ellmer 0.5.0.
+      i Use the `Model` object instead.
+    Code
+      provider@model
+    Condition
+      Warning:
+      `Provider@model` was deprecated in ellmer 0.5.0.
+      i Use the `Model` object instead, e.g. `chat$get_model_object()`.
+    Output
+      [1] "x"
+
+# Provider print omits deprecated properties
+
+    Code
+      print(test_provider())
+    Output
+      <ellmer::Provider>
+       @ name         : chr ""
+       @ base_url     : chr ""
+       @ extra_headers: chr(0) 
+       @ credentials  :function ()  
+

--- a/tests/testthat/test-provider.R
+++ b/tests/testthat/test-provider.R
@@ -22,3 +22,23 @@ test_that("models_list() dispatches through Chat to provider", {
   chat <- Chat$new(provider = provider, model = test_model())
   expect_error(models_list(chat), class = "not_implemented")
 })
+
+test_that("deprecated Provider properties warn but still work", {
+  chat <- Chat$new(provider = test_provider(), model = test_model("m"))
+  provider <- chat$get_provider()
+  expect_snapshot({
+    provider@model
+    provider@params
+    provider@extra_args
+    provider <- Provider(
+      name = "test",
+      base_url = "https://example.com",
+      model = "x"
+    )
+    provider@model
+  })
+})
+
+test_that("Provider print omits deprecated properties", {
+  expect_snapshot(print(test_provider()))
+})

--- a/tests/testthat/test-provider.R
+++ b/tests/testthat/test-provider.R
@@ -39,6 +39,9 @@ test_that("deprecated Provider properties warn but still work", {
   })
 })
 
-test_that("Provider print omits deprecated properties", {
-  expect_snapshot(print(test_provider()))
+test_that("Provider print and str omit deprecated properties", {
+  expect_snapshot({
+    print(test_provider())
+    str(test_provider())
+  })
 })

--- a/tests/testthat/test-provider.R
+++ b/tests/testthat/test-provider.R
@@ -39,9 +39,6 @@ test_that("deprecated Provider properties warn but still work", {
   })
 })
 
-test_that("Provider print and str omit deprecated properties", {
-  expect_snapshot({
-    print(test_provider())
-    str(test_provider())
-  })
+test_that("Provider print omits deprecated properties", {
+  expect_snapshot(print(test_provider()))
 })


### PR DESCRIPTION
Fixes #1098 

We removed `Provider@model` in #1053 but we need to use a proper deprecation cycle for it so this PR introduces a warning instead of completely removing it immediately.

This feels super ugly, but I'm not sure there's currently a better way to do this?