### PR TITLE
Don't send the unsupported `strict` field in Databricks tool definitions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,5 @@
 # ellmer (development version)
 
-* `chat_databricks()` no longer sends the unsupported `strict` field in tool definitions. This fixes a regression introduced in #1086, where inheriting the OpenAI-compatible encoding made Databricks compile every tool schema into a sampling grammar; once enough tools were registered, all requests failed with `HTTP 400 Compiled grammar size (...MB) exceeds maximum allowed size (300MB)` (#548).
 * `chat_aws_bedrock()` gains an `api` argument to select between the Converse API on the `bedrock-runtime` endpoint and the Anthropic Messages or OpenAI Responses APIs on the `bedrock-mantle` endpoint. This makes models that Converse can't serve, like Claude Mythos and the GPT-5 family, available on Bedrock. The API is picked from `model` by default, so you only need to set `api` for models ellmer doesn't recognize (#1064).
 * ellmer now preserves provider citations in chat history and streamed content, and displays cited sources in console output. Enable cited web results with `chat$register_tool()`, using tools such as `openai_tool_web_search()`, `claude_tool_web_search()`, or `claude_tool_web_fetch(citations = TRUE)` (#1068).
 * `Chat` gains a `$token_count()` method that estimates the number of tokens in new input using the provider's token counting endpoint (@thisisnic, #814).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ellmer (development version)
 
+* `chat_databricks()` no longer sends the unsupported `strict` field in tool definitions. This fixes a regression introduced in #1086, where inheriting the OpenAI-compatible encoding made Databricks compile every tool schema into a sampling grammar; once enough tools were registered, all requests failed with `HTTP 400 Compiled grammar size (...MB) exceeds maximum allowed size (300MB)` (#548).
 * `chat_aws_bedrock()` gains an `api` argument to select between the Converse API on the `bedrock-runtime` endpoint and the Anthropic Messages or OpenAI Responses APIs on the `bedrock-mantle` endpoint. This makes models that Converse can't serve, like Claude Mythos and the GPT-5 family, available on Bedrock. The API is picked from `model` by default, so you only need to set `api` for models ellmer doesn't recognize (#1064).
 * ellmer now preserves provider citations in chat history and streamed content, and displays cited sources in console output. Enable cited web results with `chat$register_tool()`, using tools such as `openai_tool_web_search()`, `claude_tool_web_search()`, or `claude_tool_web_fetch(citations = TRUE)` (#1068).
 * `Chat` gains a `$token_count()` method that estimates the number of tokens in new input using the provider's token counting endpoint (@thisisnic, #814).

--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -235,6 +235,38 @@ method(base_request_error, ProviderDatabricks) <- function(provider, req) {
   })
 }
 
+# See: https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/api-reference#functionobject
+method(as_json, list(ProviderDatabricks, ToolDef)) <- function(
+  provider,
+  x,
+  ...
+) {
+  # Databricks does not support the "strict" field for tools, despite what their
+  # documentation says. It *is* supported for structured outputs, though. This
+  # method exists only to omit it; everything else matches the OpenAI encoding.
+  #
+  # Do not remove this method to inherit ProviderOpenAICompatible's: that sends
+  # `strict = TRUE` and reintroduces #548. The failure has changed shape since
+  # #548 was filed, which makes it easy to miss. Databricks used to reject the
+  # field outright ("tools.0.custom.strict: Extra inputs are not permitted"), but
+  # now accepts it and compiles the schema into a sampling grammar. Small tool
+  # sets therefore appear to work, while a set large enough to exceed the grammar
+  # budget fails with HTTP 400 "Compiled grammar size (...MB) exceeds maximum
+  # allowed size (300MB)" -- and because compilation happens before generation,
+  # *every* request fails, not only the ones using the offending tool.
+  #
+  # `parameters` is always included, even when the tool takes no arguments,
+  # because omitting it errors on Databricks (#1084).
+  compact(list(
+    type = "function",
+    "function" = compact(list(
+      name = x@name,
+      description = x@description,
+      parameters = as_json(provider, x@arguments, ...)
+    ))
+  ))
+}
+
 # https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/api-reference#toolcall
 method(as_json, list(ProviderDatabricks, ContentToolRequest)) <- function(
   provider,

--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -241,22 +241,9 @@ method(as_json, list(ProviderDatabricks, ToolDef)) <- function(
   x,
   ...
 ) {
-  # Databricks does not support the "strict" field for tools, despite what their
-  # documentation says. It *is* supported for structured outputs, though. This
-  # method exists only to omit it; everything else matches the OpenAI encoding.
-  #
-  # Do not remove this method to inherit ProviderOpenAICompatible's: that sends
-  # `strict = TRUE` and reintroduces #548. The failure has changed shape since
-  # #548 was filed, which makes it easy to miss. Databricks used to reject the
-  # field outright ("tools.0.custom.strict: Extra inputs are not permitted"), but
-  # now accepts it and compiles the schema into a sampling grammar. Small tool
-  # sets therefore appear to work, while a set large enough to exceed the grammar
-  # budget fails with HTTP 400 "Compiled grammar size (...MB) exceeds maximum
-  # allowed size (300MB)" -- and because compilation happens before generation,
-  # *every* request fails, not only the ones using the offending tool.
-  #
-  # `parameters` is always included, even when the tool takes no arguments,
-  # because omitting it errors on Databricks (#1084).
+  # Same as ProviderOpenAICompatible but without `strict`: Databricks accepts
+  # it, but large tool sets then fail with "Compiled grammar size exceeds
+  # maximum allowed size" (#548). `parameters` must always be sent (#1084).
   compact(list(
     type = "function",
     "function" = compact(list(

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -184,36 +184,6 @@ test_that("tokens can be requested from a Connect server", {
   expect_equal(credentials(), list(Authorization = "Bearer token"))
 })
 
-test_that("chat_databricks() never sends the unsupported `strict` tool field", {
-  # Regression test for #548: Databricks rejected `strict` outright, and now
-  # accepts it but compiles a sampling grammar that a large tool set cannot
-  # afford. Inheriting ProviderOpenAICompatible's method reintroduces both.
-  withr::local_envvar(
-    DATABRICKS_HOST = "https://example.cloud.databricks.com",
-    DATABRICKS_TOKEN = "token"
-  )
-  provider <- chat_databricks(model = "databricks-claude-3-7-sonnet")$get_provider()
-
-  no_arguments <- tool(
-    function() format(Sys.Date()),
-    name = "current_date",
-    description = "Returns the current date in ISO 8601 format."
-  )
-  with_arguments <- tool(
-    function(person) "sage green",
-    name = "favourite_colour",
-    description = "Returns a person's favourite colour.",
-    arguments = list(person = type_string("Name of a person"))
-  )
-
-  for (x in list(no_arguments, with_arguments)) {
-    json <- as_json(provider, x)
-    expect_false("strict" %in% names(json$`function`))
-    # `parameters` must stay even with no arguments (#1084).
-    expect_true("parameters" %in% names(json$`function`))
-  }
-})
-
 test_that("chat_databricks() serializes tools correctly", {
   withr::local_envvar(
     DATABRICKS_HOST = "https://example.cloud.databricks.com",

--- a/tests/testthat/test-provider-databricks.R
+++ b/tests/testthat/test-provider-databricks.R
@@ -184,6 +184,36 @@ test_that("tokens can be requested from a Connect server", {
   expect_equal(credentials(), list(Authorization = "Bearer token"))
 })
 
+test_that("chat_databricks() never sends the unsupported `strict` tool field", {
+  # Regression test for #548: Databricks rejected `strict` outright, and now
+  # accepts it but compiles a sampling grammar that a large tool set cannot
+  # afford. Inheriting ProviderOpenAICompatible's method reintroduces both.
+  withr::local_envvar(
+    DATABRICKS_HOST = "https://example.cloud.databricks.com",
+    DATABRICKS_TOKEN = "token"
+  )
+  provider <- chat_databricks(model = "databricks-claude-3-7-sonnet")$get_provider()
+
+  no_arguments <- tool(
+    function() format(Sys.Date()),
+    name = "current_date",
+    description = "Returns the current date in ISO 8601 format."
+  )
+  with_arguments <- tool(
+    function(person) "sage green",
+    name = "favourite_colour",
+    description = "Returns a person's favourite colour.",
+    arguments = list(person = type_string("Name of a person"))
+  )
+
+  for (x in list(no_arguments, with_arguments)) {
+    json <- as_json(provider, x)
+    expect_false("strict" %in% names(json$`function`))
+    # `parameters` must stay even with no arguments (#1084).
+    expect_true("parameters" %in% names(json$`function`))
+  }
+})
+
 test_that("chat_databricks() serializes tools correctly", {
   withr::local_envvar(
     DATABRICKS_HOST = "https://example.cloud.databricks.com",
@@ -205,7 +235,6 @@ test_that("chat_databricks() serializes tools correctly", {
       "function" = list(
         name = "current_date",
         description = "Returns the current date in ISO 8601 format.",
-        strict = TRUE,
         parameters = list(
           type = "object",
           description = "",
@@ -233,7 +262,6 @@ test_that("chat_databricks() serializes tools correctly", {
       "function" = list(
         name = "favourite_colour",
         description = "Returns a person's favourite colour.",
-        strict = TRUE,
         parameters = list(
           type = "object",
           description = "",


### PR DESCRIPTION
## The problem

`chat_databricks()` sends `strict = TRUE` in tool definitions again, which Databricks does not support. Once enough tools are registered, **every** request fails with:

```
HTTP 400 Bad Request
Compiled grammar size (486.7MB) exceeds maximum allowed size (300MB)
```

This is a regression of #548. #1086 removed the `as_json(list(ProviderDatabricks, ToolDef))` method so that `parameters` is always sent (fixing #1084), but removing it made `ProviderDatabricks` inherit `ProviderOpenAICompatible`'s encoding, which hardcodes `strict = TRUE`. The removed method existed only to omit that field, and said so in a comment that went with it:

> It seems that Databricks doesn't support the "strict" field, despite what their documentation says. It *is* supported for structured outputs, though. I suspect a copy & paste error in their docs.

## Why this wasn't caught

**The failure changed shape since #548 was filed.** Back then Databricks rejected the field outright (`tools.0.custom.strict: Extra inputs are not permitted`). It now *accepts* it and compiles the tool schema into a sampling grammar instead.

So `strict = TRUE` looks harmless on a small tool set — #1086's updated snapshot expecting `strict = TRUE` passes, and so does everything in the test suite. The cost is per model-choosable property against a 300 MB grammar budget, so only a large enough tool set crosses the threshold. And because grammar compilation happens *before* generation, once you cross it every request fails, not just the ones using the offending tool. An agent with 20 tools / 30 properties went from working to answering nothing, with no failing test anywhere.

Measured against a real 20-tool, 30-property set on `databricks-claude-sonnet-4-6`:

| Tool encoding | Result |
|---|---|
| as shipped (`strict = TRUE`) | HTTP 400, 486.7 MB grammar |
| `strict = FALSE` | answers |
| `strict` omitted | answers |

For what it's worth, tool count is not the axis: 30 trivial synthetic tools compile fine, while 20 real ones do not. `ProviderVllm` and `ProviderGroq` already omit `strict`, so Databricks joining them is consistent with existing practice.

## The fix

Restores the method, **keeping #1086's behaviour**: `parameters` is always included, including for tools with no arguments (#1084). The only difference from the inherited encoding is the absent `strict`.

Also adds a regression test asserting `strict` is absent and `parameters` present, for both a zero-argument and an argument-taking tool — so the behaviour is pinned by a test rather than resting on a comment that can be removed along with the method. The comment now explains the newer failure mode too.

`testthat::test_file("tests/testthat/test-provider-databricks.R")`: 29 passed, 0 failed, 4 skipped.
