### PR TITLE
Update tests and docs referring to Mantle/Converse

### DIFF
--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -31,14 +31,23 @@ NULL
 #'   endpoint. Only Claude models are available here, but it includes some (like
 #'   Claude Mythos) that Converse does not serve at all.
 #' * `"responses"` uses the OpenAI Responses API on the `bedrock-mantle`
-#'   endpoint. This is the only way to reach the GPT-5 family and Grok on
-#'   Bedrock. Note that mantle serves newer models from `/openai/v1` and older
-#'   open-weight models like gpt-oss from `/v1`; ellmer uses the former, so
-#'   reaching the latter needs an explicit `base_url`. They're all available
-#'   through `"converse"` anyway.
+#'   endpoint. This reaches OpenAI and xAI models that Converse can't serve,
+#'   typically newer models that Converse hasn't picked up yet. Note that mantle
+#'   serves newer models from `/openai/v1` and older open-weight models like
+#'   gpt-oss from `/v1`; ellmer uses the former, so reaching the latter needs
+#'   an explicit `base_url`. They're all available through `"converse"` anyway.
 #'
-#' By default ellmer picks the API from `model`, falling back to `"converse"`
-#' for models it doesn't recognize. Set `api` explicitly to override this.
+#' By default ellmer picks the API from `model`, using `"converse"` whenever
+#' it can serve the model and for any model ellmer doesn't recognize. Set `api`
+#' explicitly to override this.
+#'
+#' The set of models that need mantle shrinks over time as AWS adds them to
+#' Converse, so a model that needs `"responses"` today may route to
+#' `"converse"` in a later ellmer release. Note also that Converse usually
+#' needs an inference profile ID (`"us.openai.gpt-5.6-sol"`) while mantle wants
+#' the bare model ID (`"openai.gpt-5.6-sol"`); ellmer strips the prefix for
+#' mantle, so the inference profile ID works with either and is the safer
+#' choice.
 #'
 #' Note that the two endpoints have separate token quotas, so moving a model
 #' from one to the other changes which quota it consumes.
@@ -303,6 +312,16 @@ method(base_request_error, ProviderAWSBedrock) <- function(provider, req) {
         i = paste0(
           "If this model is only available on the bedrock-mantle endpoint, ",
           "set `api` to \"messages\" or \"responses\"."
+        )
+      )
+    } else if (grepl("inference profile", msg %||% "")) {
+      # Converse needs an inference profile ID for many models, but the bare
+      # model ID is what users see on mantle and in the AWS console.
+      msg <- c(
+        msg,
+        i = paste0(
+          "Try adding a region prefix to the model ID, ",
+          "e.g. \"us.\" or \"global.\"."
         )
       )
     }

--- a/man/chat_aws_bedrock.Rd
+++ b/man/chat_aws_bedrock.Rd
@@ -116,15 +116,24 @@ used.
 endpoint. Only Claude models are available here, but it includes some (like
 Claude Mythos) that Converse does not serve at all.
 \item \code{"responses"} uses the OpenAI Responses API on the \code{bedrock-mantle}
-endpoint. This is the only way to reach the GPT-5 family and Grok on
-Bedrock. Note that mantle serves newer models from \verb{/openai/v1} and older
-open-weight models like gpt-oss from \verb{/v1}; ellmer uses the former, so
-reaching the latter needs an explicit \code{base_url}. They're all available
-through \code{"converse"} anyway.
+endpoint. This reaches OpenAI and xAI models that Converse can't serve,
+typically newer models that Converse hasn't picked up yet. Note that mantle
+serves newer models from \verb{/openai/v1} and older open-weight models like
+gpt-oss from \verb{/v1}; ellmer uses the former, so reaching the latter needs
+an explicit \code{base_url}. They're all available through \code{"converse"} anyway.
 }
 
-By default ellmer picks the API from \code{model}, falling back to \code{"converse"}
-for models it doesn't recognize. Set \code{api} explicitly to override this.
+By default ellmer picks the API from \code{model}, using \code{"converse"} whenever
+it can serve the model and for any model ellmer doesn't recognize. Set \code{api}
+explicitly to override this.
+
+The set of models that need mantle shrinks over time as AWS adds them to
+Converse, so a model that needs \code{"responses"} today may route to
+\code{"converse"} in a later ellmer release. Note also that Converse usually
+needs an inference profile ID (\code{"us.openai.gpt-5.6-sol"}) while mantle wants
+the bare model ID (\code{"openai.gpt-5.6-sol"}); ellmer strips the prefix for
+mantle, so the inference profile ID works with either and is the safer
+choice.
 
 Note that the two endpoints have separate token quotas, so moving a model
 from one to the other changes which quota it consumes.

--- a/tests/testthat/_snaps/provider-aws.md
+++ b/tests/testthat/_snaps/provider-aws.md
@@ -31,7 +31,7 @@
 # invalid api and cache combinations are rejected
 
     Code
-      chat_aws_bedrock(model = "openai.gpt-5.4", cache = "5m")
+      chat_aws_bedrock(model = "openai.gpt-5.4", api = "responses", cache = "5m")
     Condition
       Error in `chat_aws_bedrock()`:
       ! `cache` is not supported when `api = "responses"`.

--- a/tests/testthat/test-provider-aws.R
+++ b/tests/testthat/test-provider-aws.R
@@ -235,14 +235,26 @@ test_that("continues to work after whitespace only outputs (#376)", {
 # APIs --------------------------------------------------------------------
 
 test_that("aws_bedrock_api() guesses the api from the model", {
-  expect_equal(aws_bedrock_api("us.anthropic.claude-sonnet-4-6"), "converse")
-  expect_equal(aws_bedrock_api("anthropic.claude-mythos-5"), "messages")
-  expect_equal(aws_bedrock_api("openai.gpt-5.4"), "responses")
+  local_mocked_bindings(
+    aws_bedrock_model_apis = c(
+      "anthropic.mantle-only" = "messages",
+      "openai.mantle-only" = "responses"
+    )
+  )
+  expect_equal(aws_bedrock_api("us.anthropic.claude-sonnet-5"), "converse")
+  expect_equal(aws_bedrock_api("anthropic.mantle-only"), "messages")
+  expect_equal(aws_bedrock_api("openai.mantle-only"), "responses")
 })
 
 test_that("aws_bedrock_api() ignores cross-region inference prefixes", {
-  expect_equal(aws_bedrock_api("us.anthropic.claude-mythos-5"), "messages")
-  expect_equal(aws_bedrock_api("eu.openai.gpt-5.5"), "responses")
+  local_mocked_bindings(
+    aws_bedrock_model_apis = c(
+      "anthropic.mantle-only" = "messages",
+      "openai.mantle-only" = "responses"
+    )
+  )
+  expect_equal(aws_bedrock_api("us.anthropic.mantle-only"), "messages")
+  expect_equal(aws_bedrock_api("eu.openai.mantle-only"), "responses")
 })
 
 test_that("aws_bedrock_api() falls back to converse for unknown models", {
@@ -333,6 +345,22 @@ test_that("converse suggests mantle when it doesn't recognise the model", {
   expect_length(body("Nope."), 1)
 })
 
+test_that("converse suggests a region prefix when given a bare model ID", {
+  req <- base_request_error(
+    test_aws_bedrock_provider(),
+    request("http://example.com")
+  )
+  body <- function(message) {
+    req$policies$error_body(response_json(400, body = list(message = message)))
+  }
+
+  hint <- body(
+    "Invocation of model ID openai.gpt-5.6-sol with on-demand throughput isn't supported. Retry your request with the ID or ARN of an inference profile that contains this model."
+  )
+  expect_length(hint, 2)
+  expect_match(hint[[2]], "adding a region prefix")
+})
+
 test_that("cross-region prefix is stripped for mantle but kept for converse", {
   local_mocked_aws_credentials()
 
@@ -356,7 +384,7 @@ test_that("invalid api and cache combinations are rejected", {
   local_mocked_aws_credentials()
 
   expect_snapshot(error = TRUE, {
-    chat_aws_bedrock(model = "openai.gpt-5.4", cache = "5m")
+    chat_aws_bedrock(model = "openai.gpt-5.4", api = "responses", cache = "5m")
     chat_aws_bedrock(model = "openai.gpt-5.4", api = "mantle")
   })
 })


### PR DESCRIPTION
Fixes #1110 

A change to which endpoint served a particular model led to a failing test; this PR updates tests to use local mocked bindings to prevent this happening again, and also updates the docs so that we're not mentioning particular models only being available on Mantle/Converse, as this changes.