### PR TITLE
Don't map `top_k` to `top_logprobs`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * `chat_openrouter()` now correctly preserves provider error messages (@xmarquez, #1059).
 * New `models_update_prices()` downloads the latest model pricing data from GitHub and saves it to a local cache. Subsequent calls to `token_usage()` and related functions will use the updated prices (#968).
 * New `Model` class separates model configuration (name, parameters, extra arguments) from the `Provider` class, which now only captures API endpoint details. `Chat` gains a new `$get_model_object()` method to retrieve the `Model` object. `provider@model`, `provider@params`, and `provider@extra_args` are deprecated and will be removed in a future release; use the `Model` object instead (@thisisnic, #1098).
+* `params(top_k = )` is no longer sent as `top_logprobs` for OpenAI-based providers (@thisisnic, #1113).
 * `tool()` functions that return complex objects like data frames or lists now produce a deprecation warning. Tool functions should return a character vector, an atomic vector, a JSON string (from `jsonlite::toJSON()`), or a `Content` object. Use `jsonlite::toJSON()` to convert complex objects before returning (@thisisnic, #858).
 
 # ellmer 0.4.2

--- a/R/provider-deepseek.R
+++ b/R/provider-deepseek.R
@@ -82,8 +82,7 @@ method(chat_params, ProviderDeepSeek) <- function(provider, params) {
       stop = "stop_sequences",
       temperature = "temperature",
       top_p = "top_p",
-      logprobs = "log_probs",
-      top_logprobs = "top_k"
+      logprobs = "log_probs"
     )
   )
 }

--- a/R/provider-openai-compatible.R
+++ b/R/provider-openai-compatible.R
@@ -243,7 +243,7 @@ method(chat_params, ProviderOpenAICompatible) <- function(provider, params) {
       seed = "seed",
       stop = "stop_sequences",
       temperature = "temperature",
-      top_logprobs = "top_k",
+      top_k = "top_k",
       top_p = "top_p"
     )
   )

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -225,7 +225,6 @@ method(chat_params, ProviderOpenAI) <- function(provider, params) {
       frequency_penalty = "frequency_penalty",
       max_output_tokens = "max_tokens",
       log_probs = "log_probs",
-      top_logprobs = "top_k",
       reasoning_effort = "reasoning_effort"
     )
   )


### PR DESCRIPTION
Fixes #1113.

`params(top_k = )` was sent as `top_logprobs`, which is a different setting: it controls how many alternative token probabilities the API returns, not sampling. Users setting `top_k` got either a 400 or no sampling change.

`chat_openai_compatible()` and the providers built on it now pass `top_k` through unchanged, since many compatible backends accept it. `chat_openai()` and `chat_deepseek()` now warn that `top_k` is unsupported, since neither API has it.