### PR TITLE
Make test for Bedrock structured output streaming independent of credentials

### DIFF
--- a/tests/testthat/_snaps/chat.md
+++ b/tests/testthat/_snaps/chat.md
@@ -50,6 +50,16 @@
 ---
 
     Code
+      collect_stream(bedrock_chat, "Extract John", type = person, async = async)
+    Condition
+      Error:
+      ! Can't stream structured output with AWS/Bedrock model "us.anthropic.claude-haiku-4-5-20251001-v1:0".
+      i Streaming requires native structured output, but this provider and model fall back to tool calling.
+      i Use `$chat_structured()` instead.
+
+---
+
+    Code
       chat <- chat_anthropic_test(model = "claude-3-haiku-20240307")
       collect_stream(chat, "Extract John, age 15", type = person, async = async)
     Condition
@@ -77,6 +87,16 @@
     Condition
       Error:
       ! Can't stream structured output with Anthropic model "claude-sonnet-5".
+      i Streaming requires native structured output, but this provider and model fall back to tool calling.
+      i Use `$chat_structured()` instead.
+
+---
+
+    Code
+      collect_stream(bedrock_chat, "Extract John", type = person, async = async)
+    Condition
+      Error:
+      ! Can't stream structured output with AWS/Bedrock model "us.anthropic.claude-haiku-4-5-20251001-v1:0".
       i Streaming requires native structured output, but this provider and model fall back to tool calling.
       i Use `$chat_structured()` instead.
 

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -506,22 +506,21 @@ test_that("streaming structured output rejects unsupported providers and types",
         async = async
       )
     })
-    # chat_aws_bedrock_test() skips when AWS credentials aren't available;
-    # catch that here so the rest of the test still runs
-    bedrock_chat <- tryCatch(
-      chat_aws_bedrock_test(),
-      skip = function(cnd) NULL
+    # Built without credentials so the case runs everywhere; the error is
+    # raised before any request is made
+    bedrock_chat <- Chat$new(
+      provider = ProviderAWSBedrock(
+        name = "AWS/Bedrock",
+        base_url = "https://bedrock-runtime.us-east-1.amazonaws.com",
+        region = "us-east-1",
+        creds_cache = list(),
+        cache_point = "none"
+      ),
+      model = Model(name = "us.anthropic.claude-haiku-4-5-20251001-v1:0")
     )
-    if (!is.null(bedrock_chat)) {
-      expect_snapshot(error = TRUE, {
-        collect_stream(
-          bedrock_chat,
-          "Extract John",
-          type = person,
-          async = async
-        )
-      })
-    }
+    expect_snapshot(error = TRUE, {
+      collect_stream(bedrock_chat, "Extract John", type = person, async = async)
+    })
   }
 
   run_case(FALSE)


### PR DESCRIPTION
Fixes #1117 by making snapshot independent of credentials