### PR TITLE
Make `chat$file_get()` return a reference you can pass to `$chat()`

### DIFF
--- a/R/provider-claude-files.R
+++ b/R/provider-claude-files.R
@@ -64,14 +64,17 @@ method(file_get, ProviderAnthropic) <- function(provider, id, ...) {
   req <- req_url_path_append(req, as_file_id(id))
   json <- resp_body_json(req_perform(req))
 
-  list(
-    id = json$id,
-    filename = json$filename,
+  ContentUploaded(
+    uri = json$id,
     mime_type = json$mime_type,
-    size_bytes = as.numeric(json$size_bytes),
-    created_at = parse_rfc3339(json$created_at),
-    expires_at = parse_rfc3339(json$expires_at %||% NA_character_),
-    downloadable = json$downloadable
+    provider = "anthropic",
+    extra = list(
+      filename = json$filename,
+      size_bytes = as.numeric(json$size_bytes),
+      created_at = parse_rfc3339(json$created_at),
+      expires_at = parse_rfc3339(json$expires_at %||% NA_character_),
+      downloadable = json$downloadable
+    )
   )
 }
 
@@ -159,15 +162,7 @@ claude_file_get <- function(
 ) {
   lifecycle::deprecate_warn("0.5.0", "claude_file_get()", "Chat$file_get()")
   provider <- anthropic_file_provider(base_url, beta_headers, credentials)
-  meta <- file_get(provider, file_id)
-
-  # Unlike Chat$file_get(), this wrapper keeps its released contract of
-  # returning an object that can be passed straight to $chat()
-  ContentUploaded(
-    uri = meta$id,
-    mime_type = meta$mime_type,
-    provider = "anthropic"
-  )
+  file_get(provider, file_id)
 }
 
 #' @export

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -777,18 +777,27 @@ method(file_get, ProviderOpenAI) <- function(provider, id, ...) {
   req <- req_url_path_append(req, "files", as_file_id(id))
   json <- resp_body_json(req_perform(req))
 
-  list(
-    id = json$id,
-    filename = json$filename,
-    mime_type = NA_character_,
-    size_bytes = as.numeric(json$bytes),
-    created_at = as.POSIXct(json$created_at, origin = "1970-01-01", tz = "UTC"),
-    expires_at = as.POSIXct(
-      json$expires_at %||% NA_real_,
-      origin = "1970-01-01",
-      tz = "UTC"
-    ),
-    purpose = json$purpose
+  # The OpenAI Files API doesn't report a mime type, so guess from the
+  # filename; an unknown extension gives "" which serializes as a document.
+  ContentUploaded(
+    uri = json$id,
+    mime_type = guess_mime_type(json$filename, default = ""),
+    provider = "openai",
+    extra = list(
+      filename = json$filename,
+      size_bytes = as.numeric(json$bytes),
+      created_at = as.POSIXct(
+        json$created_at,
+        origin = "1970-01-01",
+        tz = "UTC"
+      ),
+      expires_at = as.POSIXct(
+        json$expires_at %||% NA_real_,
+        origin = "1970-01-01",
+        tz = "UTC"
+      ),
+      purpose = json$purpose
+    )
   )
 }
 

--- a/tests/testthat/helper-provider.R
+++ b/tests/testthat/helper-provider.R
@@ -206,11 +206,17 @@ test_file_lifecycle <- function(chat_fun) {
   expect_s3_class(files$created_at, "POSIXct")
   expect_s3_class(files$expires_at, "POSIXct")
 
-  meta <- chat$file_get(upload)
-  expect_equal(meta$id, upload@uri)
-  expect_s3_class(meta$expires_at, "POSIXct")
+  file <- chat$file_get(upload@uri)
+  expect_s7_class(file, ContentUploaded)
+  expect_equal(file@uri, upload@uri)
+  expect_equal(file@mime_type, "application/pdf")
+  expect_s3_class(file@extra$expires_at, "POSIXct")
   expect_equal(
-    as.numeric(difftime(meta$expires_at, meta$created_at, units = "hours")),
+    as.numeric(difftime(
+      file@extra$expires_at,
+      file@extra$created_at,
+      units = "hours"
+    )),
     48,
     tolerance = 0.01
   )


### PR DESCRIPTION
Fixes #1116. `chat$file_get(id)` now returns a `ContentUploaded` that can be passed straight to `$chat()`, with the file metadata in `@extra`, so an upload from an earlier session can be reused from its id without hand-building the reference. `$file_list()` remains the place to browse metadata. OpenAI's Files API doesn't report a MIME type, so it's guessed from the filename and falls back to a plain document reference. Note that chatlas's `chat.files.get()` still returns `FileMetadata`, so this diverges from that.

Before:

```r
chat <- chat_anthropic()
report <- ContentUploaded(
  uri = "file_011CRabc...",
  mime_type = "application/pdf",
  provider = "anthropic"
)
chat$chat("Summarize the key findings.", report)
```

After:

```r
chat <- chat_anthropic()
report <- chat$file_get("file_011CRabc...")
report
#> [uploaded file]: [application/pdf]
chat$chat("Summarize the key findings.", report)

report@extra$filename
#> [1] "quarterly-report.pdf"
```
