### PR TITLE
Implement `file_get()` for Google

### DIFF
--- a/R/chat.R
+++ b/R/chat.R
@@ -333,9 +333,15 @@ Chat <- R6::R6Class(
     #' @description
     #' `r lifecycle::badge("experimental")`
     #'
-    #' Get metadata for a file previously uploaded to the chat's provider.
+    #' Get a reference to a file previously uploaded to the chat's provider,
+    #' e.g. to reuse an upload from an earlier session. Use `$file_list()` to
+    #' find the id.
     #' @param id A file id string, or a [ContentUploaded].
-    #' @return A named list of file metadata.
+    #' @return A [ContentUploaded] that can be passed to `$chat()` and
+    #'   friends, with file metadata (`filename`, `size_bytes`, `created_at`,
+    #'   `expires_at`, and any provider-specific fields) in its `extra`
+    #'   property. OpenAI doesn't report a file's MIME type, so it's guessed
+    #'   from the filename.
     file_get = function(id) {
       file_get(private$provider, id)
     },

--- a/R/provider-google-upload.R
+++ b/R/provider-google-upload.R
@@ -224,15 +224,18 @@ method(file_get, ProviderGoogleGemini) <- function(provider, id, ...) {
   req <- req_url_path_append(req, google_file_name(id))
   json <- resp_body_json(req_perform(req))
 
-  list(
-    id = json$uri %||% json$name,
-    filename = json$displayName,
+  ContentUploaded(
+    uri = json$uri %||% json$name,
     mime_type = json$mimeType,
-    size_bytes = as.numeric(json$sizeBytes),
-    created_at = parse_rfc3339(json$createTime),
-    expires_at = parse_rfc3339(json$expirationTime),
-    name = json$name,
-    state = json$state
+    provider = "google",
+    extra = list(
+      filename = json$displayName,
+      size_bytes = as.numeric(json$sizeBytes),
+      created_at = parse_rfc3339(json$createTime),
+      expires_at = parse_rfc3339(json$expirationTime),
+      name = json$name,
+      state = json$state
+    )
   )
 }
 

--- a/man/Chat.Rd
+++ b/man/Chat.Rd
@@ -440,7 +440,9 @@ List files previously uploaded to the chat's provider.
 \subsection{\code{Chat$file_get()}}{
   \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
-Get metadata for a file previously uploaded to the chat's provider.
+Get a reference to a file previously uploaded to the chat's provider,
+e.g. to reuse an upload from an earlier session. Use \verb{$file_list()} to
+find the id.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Chat$file_get(id)}
@@ -454,7 +456,11 @@ Get metadata for a file previously uploaded to the chat's provider.
     \if{html}{\out{</div>}}
   }
   \subsection{Returns}{
-    A named list of file metadata.
+    A \link{ContentUploaded} that can be passed to \verb{$chat()} and
+friends, with file metadata (\code{filename}, \code{size_bytes}, \code{created_at},
+\code{expires_at}, and any provider-specific fields) in its \code{extra}
+property. OpenAI doesn't report a file's MIME type, so it's guessed
+from the filename.
   }
 }
 


### PR DESCRIPTION
Follow-up to #1119, oops - forgot a couple of things being a bit trigger happy with merging!

Makes Google's `file_get()` return a `ContentUploaded` like the other providers and updates the `$file_get()` docs to match.
