### PR TITLE
Stream chunks as they arrive in `Chat$stream()`

### DIFF
--- a/R/httr2.R
+++ b/R/httr2.R
@@ -55,7 +55,7 @@ on_load(
   ) {
     setup_active_promise_otel_span(otel_span)
 
-    resp <- req_perform_connection(req)
+    resp <- req_perform_connection(req, blocking = FALSE)
     on.exit(close(resp))
 
     repeat {
@@ -63,6 +63,11 @@ on_load(
         break
       }
       event <- chat_resp_stream(provider, resp)
+      if (is.null(event) && !resp_stream_is_complete(resp)) {
+        Sys.sleep(0.05)
+        next
+      }
+
       data <- stream_parse(provider, event)
       if (is.null(data)) {
         break


### PR DESCRIPTION
Hi,

When using `Chat$stream` events arrive in bursts instead of a consistent stream. Something like:

```r
t0 <- Sys.time()

coro::loop(for (chunk in chat$stream("Write a long essay about R.")) {
  print(Sys.time() - t0)
})
```

with a slow endpoint (or model?) would show this, though I can make a nicer repro if needed ':)

This run delivered ~300 chunks at once multiple times, with silences of 1-12 seconds in between. I tested the same endpoint with `curl -N` and it showed the server trickling continuously at 5-7KB/s.

I had an agent chase the call stack (then verified):

```
chat_perform_stream
  └─ chat_resp_stream(provider, resp)
       └─ resp_stream_sse(resp)
            └─ stream_pull(resp, ...)
                 └─ resp$body$read(65536)
                      └─ readBin(conn, "raw", 65536)
```

With 65536 being `stream_chunk_bytes` in {`httr2`}. So when `chat_perform_stream` calls `req_perform_connection` with `blocking = TRUE` (by default), `readBin` waits for the full 64KB which seems too coarse for tokenized LLM streams.

This PR just changes the connection to be non-blocking (`Chat$stream` keeps being synchronous). Because non-blocking reads can find nothing, `NULL` in `chat_resp_stream` no longer implies end-of-stream so we check with `resp_stream_is_complete` following the pattern in the async generator. I thought `Sys.sleep(0.05)` was reasonable even if somewhat arbitrary since a sync consumer has nothing else to run while waiting.

Running the loop with these changes produces much smoother streaming with no significant silences.

Note I considered filing an issue to {`httr2`} instead but the surface here is much smaller. Though it might be worth a mention to the team whether the `stream_chunk_bytes` constant and related APIs are currently suitable for streaming functionality.

Happy to discuss any details,
Thanks!