### PR TITLE
Fix partial argument and element matches

### DIFF
--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -141,7 +141,7 @@ method(chat_params, ProviderDatabricks) <- function(provider, params) {
 # Some Databricks models (e.g. GPT-OSS) return message content as an array of
 # typed objects rather than a plain string (#1078). Normalize to the standard
 # OpenAI-compatible shape: text parts pasted into a string `content`, reasoning
-# summaries moved to `reasoning_content`.
+# summaries moved to `reasoning`.
 databricks_normalize_message <- function(message) {
   if (!is.list(message$content)) {
     return(message)
@@ -158,7 +158,7 @@ databricks_normalize_message <- function(message) {
     recursive = FALSE
   )
   if (length(summaries)) {
-    message$reasoning_content <- paste0(
+    message$reasoning <- paste0(
       map_chr(summaries, function(s) s$text),
       collapse = ""
     )

--- a/R/provider-databricks.R
+++ b/R/provider-databricks.R
@@ -141,7 +141,7 @@ method(chat_params, ProviderDatabricks) <- function(provider, params) {
 # Some Databricks models (e.g. GPT-OSS) return message content as an array of
 # typed objects rather than a plain string (#1078). Normalize to the standard
 # OpenAI-compatible shape: text parts pasted into a string `content`, reasoning
-# summaries moved to `reasoning`.
+# summaries moved to `reasoning_content`.
 databricks_normalize_message <- function(message) {
   if (!is.list(message$content)) {
     return(message)
@@ -158,7 +158,7 @@ databricks_normalize_message <- function(message) {
     recursive = FALSE
   )
   if (length(summaries)) {
-    message$reasoning <- paste0(
+    message$reasoning_content <- paste0(
       map_chr(summaries, function(s) s$text),
       collapse = ""
     )

--- a/R/provider-openai-compatible.R
+++ b/R/provider-openai-compatible.R
@@ -335,7 +335,7 @@ method(value_turn, ProviderOpenAICompatible) <- function(
   }
 
   thinking <- list()
-  reasoning <- message$reasoning %||% message$reasoning_content
+  reasoning <- message[["reasoning"]] %||% message[["reasoning_content"]]
   if (is_string(reasoning) && nzchar(reasoning)) {
     thinking <- list(ContentThinking(reasoning))
   }

--- a/tests/testthat/test-provider-posit.R
+++ b/tests/testthat/test-provider-posit.R
@@ -25,7 +25,7 @@ test_that("can derive the gateway url from a flavored base url", {
 
 test_that("gateway-specific errors get useful messages", {
   agreement <- response_json(
-    status = 403L,
+    status_code = 403L,
     body = list(error_type = "prism_account_not_found")
   )
   expect_match(
@@ -34,13 +34,13 @@ test_that("gateway-specific errors get useful messages", {
   )
 
   other <- response_json(
-    status = 400L,
+    status_code = 400L,
     body = list(error = list(message = "bad request"))
   )
   expect_equal(posit_error_body(other), "bad request")
 
   string_error <- response_json(
-    status = 400L,
+    status_code = 400L,
     body = list(error = "bad request")
   )
   expect_equal(posit_error_body(string_error), "bad request")


### PR DESCRIPTION
## Problem

`chat_posit(model = "zai-org/GLM-5.3-Flash")` (and any OpenAI-compatible model that returns `reasoning_content`) triggers:

```
In message$reasoning : partial match of 'reasoning' to 'reasoning_content'
```

The test suite had a similar warning: `partial argument match of 'status' to 'status_code'` in test helpers.

## Changes

- `R/provider-openai-compatible.R`: read `message[["reasoning"]] %||% message[["reasoning_content"]]` with exact matching instead of `$` partial matching.
- `tests/testthat/test-provider-posit.R`: `response_json()` is `httr2::response_json()`, whose argument is `status_code`; use the full argument name in all three calls.
