### PR TITLE
`chat_posit()$set_model()` now switches model families

### DIFF
--- a/R/chat.R
+++ b/R/chat.R
@@ -156,6 +156,7 @@ Chat <- R6::R6Class(
     set_model = function(model) {
       check_string(model)
       private$model@name <- model
+      private$provider <- provider_set_model(private$provider, model)
       provider_model(private$provider) <- private$model
       invisible(self)
     },

--- a/R/provider-aws.R
+++ b/R/provider-aws.R
@@ -871,6 +871,12 @@ method(as_json, list(ProviderAWSBedrock, ContentThinking)) <- function(
     return()
   }
 
+  if (is.null(x@extra$signature) || !nzchar(x@extra$signature)) {
+    # Unsigned thinking blocks are rejected by Bedrock, so replay thinking
+    # from other providers as plain text.
+    return(as_json(provider, ContentText(format(x)), ...))
+  }
+
   list(
     reasoningContent = list(
       reasoningText = list(

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -967,6 +967,12 @@ method(as_json, list(ProviderAnthropic, ContentThinking)) <- function(
     return()
   }
 
+  if (is.null(x@extra$signature) || !nzchar(x@extra$signature)) {
+    # Unsigned thinking blocks are rejected by the Anthropic API, so replay
+    # thinking from other providers as plain text.
+    return(as_json(provider, ContentText(format(x)), ...))
+  }
+
   list(
     type = "thinking",
     thinking = x@thinking,

--- a/R/provider-posit.R
+++ b/R/provider-posit.R
@@ -1,3 +1,4 @@
+#' @include provider.R
 #' @include provider-claude.R
 #' @include provider-openai-compatible.R
 #' @include files.R
@@ -75,7 +76,8 @@ chat_posit <- function(
       name = "Posit",
       base_url = paste0(base_url, "/openai/v1"),
       extra_headers = api_headers,
-      credentials = credentials
+      credentials = credentials,
+      cache = cache
     )
   }
   model <- Model(name = model, params = params, extra_args = api_args)
@@ -123,7 +125,12 @@ ProviderPositAnthropic <- new_class(
 
 ProviderPositOpenAI <- new_class(
   "ProviderPositOpenAI",
-  parent = ProviderOpenAICompatible
+  parent = ProviderOpenAICompatible,
+  properties = list(
+    # Inert on OpenAI models; carried over from/to ProviderPositAnthropic so
+    # it survives switching model families (#1138).
+    cache = prop_string(default = "5m")
+  )
 )
 
 method(base_request, ProviderPositAnthropic) <- function(provider) {
@@ -177,6 +184,41 @@ method(models_list, ProviderPositOpenAI) <- function(provider) {
     base_url = posit_gateway_url(provider@base_url),
     credentials = provider@credentials
   )
+}
+
+method(provider_set_model, ProviderPositAnthropic) <- function(provider, name) {
+  if (is_claude_model(name)) {
+    provider
+  } else {
+    ProviderPositOpenAI(
+      name = provider@name,
+      base_url = paste0(posit_gateway_url(provider@base_url), "/openai/v1"),
+      extra_headers = provider@extra_headers,
+      credentials = provider@credentials,
+      cache = provider@cache
+    )
+  }
+}
+
+# `cache` is inert on OpenAI models; it's only carried so it survives a switch
+# to Claude models (#1138). Hide it from print() to avoid suggesting it's used.
+method(print, ProviderPositOpenAI) <- function(x, ...) {
+  provider_print(x, hide = "cache")
+  invisible(x)
+}
+
+method(provider_set_model, ProviderPositOpenAI) <- function(provider, name) {
+  if (is_claude_model(name)) {
+    ProviderPositAnthropic(
+      name = provider@name,
+      base_url = paste0(posit_gateway_url(provider@base_url), "/anthropic/v1"),
+      extra_headers = provider@extra_headers,
+      credentials = provider@credentials,
+      cache = provider@cache
+    )
+  } else {
+    provider
+  }
 }
 
 is_claude_model <- function(model) {

--- a/R/provider.R
+++ b/R/provider.R
@@ -44,7 +44,13 @@ Provider <- new_class(
 # Default S7 print calls every getter, which would trigger the deprecation
 # warnings. Remove along with the deprecated properties (#1098).
 method(print, Provider) <- function(x, ...) {
-  names <- setdiff(prop_names(x), c("model", "params", "extra_args"))
+  provider_print(x)
+  invisible(x)
+}
+
+provider_print <- function(x, hide = character()) {
+  hide <- c(hide, "model", "params", "extra_args")
+  names <- setdiff(prop_names(x), hide)
   props <- set_names(lapply(names, \(name) prop(x, name)), names)
   cat("<", class(x)[[1]], ">\n", sep = "")
   str(
@@ -355,6 +361,19 @@ method(models_list, Provider) <- function(provider) {
 
 method(models_list, new_S3_class("Chat")) <- function(provider) {
   models_list(provider$get_provider())
+}
+
+# Give a provider the chance to react to a model change, e.g. to swap in
+# a sibling provider with a different wire format. Returns a provider.
+provider_set_model <- new_generic(
+  "provider_set_model",
+  "provider",
+  function(provider, name) {
+    S7_dispatch()
+  }
+)
+method(provider_set_model, Provider) <- function(provider, name) {
+  provider
 }
 
 # Batch AI ---------------------------------------------------------------

--- a/tests/testthat/test-provider-aws.R
+++ b/tests/testthat/test-provider-aws.R
@@ -259,6 +259,31 @@ test_that("can use extended thinking", {
   expect_match(resp, "\\S")
 })
 
+test_that("as_json() replays unsigned thinking blocks as text", {
+  provider <- chat_aws_bedrock_test()$get_provider()
+
+  expect_equal(
+    as_json(provider, ContentThinking("Internal reasoning.")),
+    list(text = "<thinking>\nInternal reasoning.\n</thinking>\n")
+  )
+
+  signed <- ContentThinking(
+    "Internal reasoning.",
+    extra = list(signature = "sig")
+  )
+  expect_equal(
+    as_json(provider, signed),
+    list(
+      reasoningContent = list(
+        reasoningText = list(
+          text = "Internal reasoning.",
+          signature = "sig"
+        )
+      )
+    )
+  )
+})
+
 # Provider idiosynchronies -----------------------------------------------
 
 test_that("continues to work after whitespace only outputs (#376)", {

--- a/tests/testthat/test-provider-claude.R
+++ b/tests/testthat/test-provider-claude.R
@@ -683,6 +683,31 @@ test_that("as_json() serializes uploaded file references", {
   )
 })
 
+test_that("as_json() replays unsigned thinking blocks as text", {
+  provider <- chat_anthropic_test()$get_provider()
+
+  expect_equal(
+    as_json(provider, ContentThinking("Internal reasoning.")),
+    list(
+      type = "text",
+      text = "<thinking>\nInternal reasoning.\n</thinking>\n"
+    )
+  )
+
+  signed <- ContentThinking(
+    "Internal reasoning.",
+    extra = list(signature = "sig")
+  )
+  expect_equal(
+    as_json(provider, signed),
+    list(
+      type = "thinking",
+      thinking = "Internal reasoning.",
+      signature = "sig"
+    )
+  )
+})
+
 test_that("value_turn() preserves unresolved Anthropic document slots", {
   provider <- chat_anthropic_test()$get_provider()
   turns <- list(UserTurn(list(

--- a/tests/testthat/test-provider-posit.R
+++ b/tests/testthat/test-provider-posit.R
@@ -12,6 +12,76 @@ test_that("uses the OpenAI-compatible API for other models", {
   expect_equal(provider@base_url, "https://gateway.posit.ai/openai/v1")
 })
 
+test_that("set_model() swaps the provider when switching model families", {
+  chat <- chat_posit(model = "claude-sonnet-4-6")
+  chat$set_model("google/gemma-4-26B-A4B-it")
+  provider <- chat$get_provider()
+  expect_true(S7_inherits(provider, ProviderPositOpenAI))
+  expect_equal(provider@base_url, "https://gateway.posit.ai/openai/v1")
+  expect_equal(chat$get_model(), "google/gemma-4-26B-A4B-it")
+
+  chat$set_model("claude-sonnet-4-6")
+  provider <- chat$get_provider()
+  expect_true(S7_inherits(provider, ProviderPositAnthropic))
+  expect_equal(provider@base_url, "https://gateway.posit.ai/anthropic/v1")
+
+  chat$set_model("claude-sonnet-4-6")
+  expect_true(S7_inherits(chat$get_provider(), ProviderPositAnthropic))
+})
+
+test_that("set_model() keeps the same provider within a family", {
+  chat <- chat_posit(model = "google/gemma-4-26B-A4B-it")
+  provider <- chat$get_provider()
+  chat$set_model("zai-org/GLM-4-6")
+  expect_equal(chat$get_provider()@base_url, provider@base_url)
+  expect_true(S7_inherits(chat$get_provider(), ProviderPositOpenAI))
+
+  cache_chat <- chat_posit(model = "claude-sonnet-4-6", cache = "none")
+  claude_provider <- cache_chat$get_provider()
+  cache_chat$set_model("claude-opus-4-6")
+  expect_equal(cache_chat$get_provider()@base_url, claude_provider@base_url)
+  expect_equal(cache_chat$get_provider()@cache, "none")
+})
+
+test_that("set_model() carries over credentials and headers", {
+  headers <- c("X-Test" = "yes")
+  credentials <- function() list(Authorization = "Bearer test")
+  chat <- chat_posit(
+    model = "claude-sonnet-4-6",
+    credentials = credentials,
+    api_headers = headers
+  )
+  chat$set_model("google/gemma-4-26B-A4B-it")
+  provider <- chat$get_provider()
+  expect_equal(provider@extra_headers, headers)
+  expect_equal(provider@credentials, credentials)
+})
+
+test_that("set_model() preserves cache across model family switches", {
+  chat <- chat_posit(model = "claude-sonnet-4-6", cache = "1h")
+  expect_no_warning(chat$set_model("google/gemma-4-26B-A4B-it"))
+  expect_equal(chat$get_provider()@cache, "1h")
+
+  expect_no_warning(chat$set_model("claude-sonnet-4-6"))
+  expect_equal(chat$get_provider()@cache, "1h")
+
+  expect_no_warning(chat$set_model("claude-opus-4-6"))
+  expect_equal(chat$get_provider()@cache, "1h")
+})
+
+test_that("set_model() defaults cache when arriving at Claude", {
+  chat <- chat_posit(model = "google/gemma-4-26B-A4B-it")
+  chat$set_model("claude-sonnet-4-6")
+  expect_equal(chat$get_provider()@cache, "5m")
+
+  explicit <- chat_posit(
+    model = "google/gemma-4-26B-A4B-it",
+    cache = "none"
+  )
+  explicit$set_model("claude-sonnet-4-6")
+  expect_equal(explicit$get_provider()@cache, "none")
+})
+
 test_that("can derive the gateway url from a flavored base url", {
   expect_equal(
     posit_gateway_url("https://gateway.posit.ai/anthropic/v1"),

--- a/tests/testthat/test-provider-posit.R
+++ b/tests/testthat/test-provider-posit.R
@@ -12,34 +12,31 @@ test_that("uses the OpenAI-compatible API for other models", {
   expect_equal(provider@base_url, "https://gateway.posit.ai/openai/v1")
 })
 
-test_that("set_model() swaps the provider when switching model families", {
+test_that("set_model() swaps to the OpenAI provider for non-Claude models", {
   chat <- chat_posit(model = "claude-sonnet-4-6")
   chat$set_model("google/gemma-4-26B-A4B-it")
   provider <- chat$get_provider()
   expect_true(S7_inherits(provider, ProviderPositOpenAI))
   expect_equal(provider@base_url, "https://gateway.posit.ai/openai/v1")
   expect_equal(chat$get_model(), "google/gemma-4-26B-A4B-it")
+})
 
+test_that("set_model() swaps back to the Anthropic provider for Claude models", {
+  chat <- chat_posit(model = "google/gemma-4-26B-A4B-it")
   chat$set_model("claude-sonnet-4-6")
   provider <- chat$get_provider()
   expect_true(S7_inherits(provider, ProviderPositAnthropic))
   expect_equal(provider@base_url, "https://gateway.posit.ai/anthropic/v1")
-
-  chat$set_model("claude-sonnet-4-6")
-  expect_true(S7_inherits(chat$get_provider(), ProviderPositAnthropic))
 })
 
 test_that("set_model() keeps the same provider within a family", {
   chat <- chat_posit(model = "google/gemma-4-26B-A4B-it")
-  provider <- chat$get_provider()
   chat$set_model("zai-org/GLM-4-6")
-  expect_equal(chat$get_provider()@base_url, provider@base_url)
   expect_true(S7_inherits(chat$get_provider(), ProviderPositOpenAI))
 
   cache_chat <- chat_posit(model = "claude-sonnet-4-6", cache = "none")
-  claude_provider <- cache_chat$get_provider()
   cache_chat$set_model("claude-opus-4-6")
-  expect_equal(cache_chat$get_provider()@base_url, claude_provider@base_url)
+  expect_true(S7_inherits(cache_chat$get_provider(), ProviderPositAnthropic))
   expect_equal(cache_chat$get_provider()@cache, "none")
 })
 
@@ -59,13 +56,13 @@ test_that("set_model() carries over credentials and headers", {
 
 test_that("set_model() preserves cache across model family switches", {
   chat <- chat_posit(model = "claude-sonnet-4-6", cache = "1h")
-  expect_no_warning(chat$set_model("google/gemma-4-26B-A4B-it"))
+  chat$set_model("google/gemma-4-26B-A4B-it")
   expect_equal(chat$get_provider()@cache, "1h")
 
-  expect_no_warning(chat$set_model("claude-sonnet-4-6"))
+  chat$set_model("claude-sonnet-4-6")
   expect_equal(chat$get_provider()@cache, "1h")
 
-  expect_no_warning(chat$set_model("claude-opus-4-6"))
+  chat$set_model("claude-opus-4-6")
   expect_equal(chat$get_provider()@cache, "1h")
 })
 

--- a/tests/testthat/test-provider-posit.R
+++ b/tests/testthat/test-provider-posit.R
@@ -79,6 +79,29 @@ test_that("set_model() defaults cache when arriving at Claude", {
   expect_equal(explicit$get_provider()@cache, "none")
 })
 
+test_that("unsigned thinking is replayed as text after switching to Claude", {
+  # The specific models don't matter, only that they resolve to the
+  # OpenAI-compatible and Anthropic provider paths; no API is called.
+  chat <- chat_posit(model = "google/gemma-4-26B-A4B-it")
+  chat$set_turns(list(
+    UserTurn("Hi"),
+    AssistantTurn(list(
+      ContentThinking("Internal reasoning.", extra = list(reasoning = "raw")),
+      ContentText("Hello!")
+    ))
+  ))
+  chat$set_model("claude-sonnet-4-6")
+
+  turns_json <- as_json(chat$get_provider(), chat$get_turns())
+  content <- turns_json[[2]]$content
+  expect_equal(content[[1]]$type, "text")
+  expect_match(
+    content[[1]]$text,
+    "<thinking>\nInternal reasoning.\n</thinking>"
+  )
+  expect_equal(content[[2]], list(type = "text", text = "Hello!"))
+})
+
 test_that("can derive the gateway url from a flavored base url", {
   expect_equal(
     posit_gateway_url("https://gateway.posit.ai/anthropic/v1"),


### PR DESCRIPTION
Fixes #1138

## Summary

`chat_posit()` picks its provider class from the model name: Claude models get `ProviderPositAnthropic` (pointing at `{base_url}/anthropic/v1`), everything else gets `ProviderPositOpenAI` (pointing at `{base_url}/openai/v1`). But `Chat$set_model()` only updated the model name, so switching to a model from the other family sent a request with the wrong wire format to the wrong endpoint.

This adds a `provider_set_model(provider, name)` S7 hook that `Chat$set_model()` consults. The default method returns the provider unchanged, so no other provider is affected. `ProviderPositAnthropic` and `ProviderPositOpenAI` override it to swap in their sibling class when the new model name belongs to the other family, carrying over credentials, `extra_headers`, and the gateway base URL (recovered via `posit_gateway_url()`).

Design notes:

- The `params()` argument of `chat_posit()` is provider-agnostic (each provider's `chat_params()` translates standard names to API-specific ones), so the `Model` object carries over untouched.
- The Claude-only `cache` setting survives family switches via an inert `cache` property on `ProviderPositOpenAI`, so `cache = "1h"` still applies after a round trip through OpenAI models. A chat that starts on an OpenAI model stores its `cache` argument too, so switching to Claude honors it. The property is hidden from `print()` for `ProviderPositOpenAI` since it's unused there.
- A unified `ProviderPosit` class that picks the wire format per request was considered, but S7 dispatches on class and it would need ~30 thin wrapper methods that can drift from upstream; the hook gives the same result in ~20 lines.

## Verification

```r
chat <- chat_posit(model = "claude-sonnet-5")
chat$chat("Hi")  # works

chat$set_model("zai-org/GLM-5.3-Flash")
chat$chat("Hi")  # now works: request goes to /openai/v1
```

New tests in `test-provider-posit.R` cover family swaps in both directions, no-op within a family, credentials/header carryover, cache preservation, and the hidden print field.