### PR TITLE
Record time to first token on the OpenTelemetry chat span

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ellmer (development version)
 
+* Streamed responses now emit an OpenTelemetry `stream` span, nested inside the `chat` span, that starts when the first text token arrives. The gap between the two span starts gives the time to first token (@schloerke).
+
 # ellmer 0.5.0
 
 ## Lifecycle changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # ellmer (development version)
 
-* Streamed responses now emit an OpenTelemetry `stream` span, nested inside the `chat` span, that starts when the first text token arrives. The gap between the two span starts gives the time to first token (@schloerke).
+* Streamed responses now record the time to first token (in seconds) as the `gen_ai.server.time_to_first_token` attribute on the OpenTelemetry `chat` span (@schloerke).
 
 # ellmer 0.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # ellmer (development version)
 
-* Streamed responses now record the time to first token (in seconds) as the `gen_ai.server.time_to_first_token` attribute on the OpenTelemetry `chat` span (@schloerke).
+* Streamed responses now record the time to first token (in seconds) as the `gen_ai.response.time_to_first_chunk` attribute on the OpenTelemetry `chat` span (@schloerke).
 
 # ellmer 0.5.0
 

--- a/R/chat.R
+++ b/R/chat.R
@@ -1005,7 +1005,7 @@ Chat <- R6::R6Class(
         acc$begin_turn(user_turn)
         on.exit(acc$finalize_turn(), add = TRUE)
 
-        stream_span <- NULL
+        stream_start <- Sys.time()
         result <- NULL
         for (chunk in response) {
           result <- stream_merge_chunks(private$provider, result, chunk)
@@ -1018,14 +1018,12 @@ Chat <- R6::R6Class(
           for (content in contents) {
             text <- content_text(content)
             if (
-              is.null(stream_span) &&
+              !is.null(stream_start) &&
                 is_stream_text_content(content) &&
                 nzchar(text)
             ) {
-              stream_span <- local_stream_otel_span(
-                private$model,
-                parent = chat_span
-              )
+              record_chat_otel_span_ttft(chat_span, stream_start)
+              stream_start <- NULL
             }
             if (yield_as_content) {
               yield(content)
@@ -1177,7 +1175,7 @@ Chat <- R6::R6Class(
         acc$begin_turn(user_turn)
         on.exit(acc$finalize_turn(), add = TRUE)
 
-        stream_span <- NULL
+        stream_start <- Sys.time()
         result <- NULL
         for (chunk in await_each(response)) {
           result <- stream_merge_chunks(private$provider, result, chunk)
@@ -1190,14 +1188,12 @@ Chat <- R6::R6Class(
           for (content in contents) {
             text <- content_text(content)
             if (
-              is.null(stream_span) &&
+              !is.null(stream_start) &&
                 is_stream_text_content(content) &&
                 nzchar(text)
             ) {
-              stream_span <- local_stream_otel_span(
-                private$model,
-                parent = chat_span
-              )
+              record_chat_otel_span_ttft(chat_span, stream_start)
+              stream_start <- NULL
             }
             if (yield_as_content) {
               yield(content)

--- a/R/chat.R
+++ b/R/chat.R
@@ -1005,6 +1005,7 @@ Chat <- R6::R6Class(
         acc$begin_turn(user_turn)
         on.exit(acc$finalize_turn(), add = TRUE)
 
+        stream_span <- NULL
         result <- NULL
         for (chunk in response) {
           result <- stream_merge_chunks(private$provider, result, chunk)
@@ -1016,6 +1017,16 @@ Chat <- R6::R6Class(
           )
           for (content in contents) {
             text <- content_text(content)
+            if (
+              is.null(stream_span) &&
+                is_stream_text_content(content) &&
+                nzchar(text)
+            ) {
+              stream_span <- local_stream_otel_span(
+                private$model,
+                parent = chat_span
+              )
+            }
             if (yield_as_content) {
               yield(content)
             } else if (is_stream_text_content(content)) {
@@ -1166,6 +1177,7 @@ Chat <- R6::R6Class(
         acc$begin_turn(user_turn)
         on.exit(acc$finalize_turn(), add = TRUE)
 
+        stream_span <- NULL
         result <- NULL
         for (chunk in await_each(response)) {
           result <- stream_merge_chunks(private$provider, result, chunk)
@@ -1177,6 +1189,16 @@ Chat <- R6::R6Class(
           )
           for (content in contents) {
             text <- content_text(content)
+            if (
+              is.null(stream_span) &&
+                is_stream_text_content(content) &&
+                nzchar(text)
+            ) {
+              stream_span <- local_stream_otel_span(
+                private$model,
+                parent = chat_span
+              )
+            }
             if (yield_as_content) {
               yield(content)
             } else if (is_stream_text_content(content)) {

--- a/R/chat.R
+++ b/R/chat.R
@@ -1022,7 +1022,7 @@ Chat <- R6::R6Class(
                 is_stream_text_content(content) &&
                 nzchar(text)
             ) {
-              record_chat_otel_span_ttft(chat_span, stream_start)
+              record_chat_otel_span_ttft_attr(chat_span, stream_start)
               stream_start <- NULL
             }
             if (yield_as_content) {
@@ -1192,7 +1192,7 @@ Chat <- R6::R6Class(
                 is_stream_text_content(content) &&
                 nzchar(text)
             ) {
-              record_chat_otel_span_ttft(chat_span, stream_start)
+              record_chat_otel_span_ttft_attr(chat_span, stream_start)
               stream_start <- NULL
             }
             if (yield_as_content) {

--- a/R/otel.R
+++ b/R/otel.R
@@ -277,7 +277,7 @@ otel_chat_input <- function(private, user_turn) {
 
 # Records the time to first token (in seconds) on the chat span, following
 # the unit of the `gen_ai.server.time_to_first_token` semconv metric.
-record_chat_otel_span_ttft <- function(span, start) {
+record_chat_otel_span_ttft_attr <- function(span, start) {
   if (is.null(span) || !span_recording(span)) {
     return()
   }

--- a/R/otel.R
+++ b/R/otel.R
@@ -275,14 +275,14 @@ otel_chat_input <- function(private, user_turn) {
   )
 }
 
-# Records the time to first token (in seconds) on the chat span, following
-# the unit of the `gen_ai.server.time_to_first_token` semconv metric.
+# Records the time to first token (in seconds) on the chat span as the
+# `gen_ai.response.time_to_first_chunk` semconv attribute.
 record_chat_otel_span_ttft_attr <- function(span, start) {
   if (is.null(span) || !span_recording(span)) {
     return()
   }
   span$set_attribute(
-    "gen_ai.server.time_to_first_token",
+    "gen_ai.response.time_to_first_chunk",
     as.numeric(Sys.time() - start, units = "secs")
   )
 }

--- a/R/otel.R
+++ b/R/otel.R
@@ -5,7 +5,6 @@ otel_capture_content_enabled <- NULL
 local_chat_otel_span <- NULL
 local_tool_otel_span <- NULL
 local_agent_otel_span <- NULL
-local_stream_otel_span <- NULL
 
 local({
   otel_is_tracing <- FALSE
@@ -169,29 +168,6 @@ local({
 
     agent_span
   }
-
-  # Starts a child span of a chat span covering the streamed portion of the
-  # response. Call it when the first text token arrives: the gap between the
-  # chat span start and this span's start is the time to first token.
-  local_stream_otel_span <<- function(
-    model,
-    parent = NULL,
-    local_envir = parent.frame()
-  ) {
-    if (!otel_is_tracing) {
-      return()
-    }
-    stream_span <-
-      otel::start_span(
-        sprintf("stream %s", model@name),
-        options = list(parent = parent),
-        tracer = otel_tracer
-      )
-
-    defer(otel::end_span(stream_span), envir = local_envir)
-
-    stream_span
-  }
 })
 
 tracer_enabled <- function(tracer) {
@@ -296,6 +272,18 @@ otel_chat_input <- function(private, user_turn) {
   list(
     turns = c(history, list(user_turn)),
     system_prompt = sys_turn
+  )
+}
+
+# Records the time to first token (in seconds) on the chat span, following
+# the unit of the `gen_ai.server.time_to_first_token` semconv metric.
+record_chat_otel_span_ttft <- function(span, start) {
+  if (is.null(span) || !span_recording(span)) {
+    return()
+  }
+  span$set_attribute(
+    "gen_ai.server.time_to_first_token",
+    as.numeric(Sys.time() - start, units = "secs")
   )
 }
 

--- a/R/otel.R
+++ b/R/otel.R
@@ -5,6 +5,7 @@ otel_capture_content_enabled <- NULL
 local_chat_otel_span <- NULL
 local_tool_otel_span <- NULL
 local_agent_otel_span <- NULL
+local_stream_otel_span <- NULL
 
 local({
   otel_is_tracing <- FALSE
@@ -167,6 +168,29 @@ local({
     defer(otel::end_span(agent_span), envir = local_envir)
 
     agent_span
+  }
+
+  # Starts a child span of a chat span covering the streamed portion of the
+  # response. Call it when the first text token arrives: the gap between the
+  # chat span start and this span's start is the time to first token.
+  local_stream_otel_span <<- function(
+    model,
+    parent = NULL,
+    local_envir = parent.frame()
+  ) {
+    if (!otel_is_tracing) {
+      return()
+    }
+    stream_span <-
+      otel::start_span(
+        sprintf("stream %s", model@name),
+        options = list(parent = parent),
+        tracer = otel_tracer
+      )
+
+    defer(otel::end_span(stream_span), envir = local_envir)
+
+    stream_span
   }
 })
 

--- a/tests/testthat/test-otel.R
+++ b/tests/testthat/test-otel.R
@@ -96,12 +96,11 @@ test_that("tracing works as expected for synchronous streams", {
   expect_length(chat_spans, 1L)
   expect_equal(chat_spans[[1L]]$parent, spans[["invoke_agent"]]$span_id)
 
-  # And one "stream" span, starting at the first text token, nested in the
-  # chat span so the gap between their starts gives the time to first token.
-  stream_spans <- Filter(function(x) startsWith(x$name, "stream"), spans)
-  expect_length(stream_spans, 1L)
-  expect_equal(stream_spans[[1L]]$parent, chat_spans[[1L]]$span_id)
-  expect_gte(stream_spans[[1L]]$start_time, chat_spans[[1L]]$start_time)
+  # Time to first token is recorded on the streamed chat span.
+  expect_gt(
+    chat_spans[[1L]]$attributes[["gen_ai.server.time_to_first_token"]],
+    0
+  )
 
   # Token usage attributes are recorded on the streamed chat span.
   expect_true(all(vapply(
@@ -284,11 +283,11 @@ test_that("tracing works as expected for asynchronous streams", {
   expect_length(chat_spans, 1L)
   expect_equal(chat_spans[[1L]]$parent, spans[["invoke_agent"]]$span_id)
 
-  # And one "stream" span nested in the chat span.
-  stream_spans <- Filter(function(x) startsWith(x$name, "stream"), spans)
-  expect_length(stream_spans, 1L)
-  expect_equal(stream_spans[[1L]]$parent, chat_spans[[1L]]$span_id)
-  expect_gte(stream_spans[[1L]]$start_time, chat_spans[[1L]]$start_time)
+  # Time to first token is recorded on the streamed chat span.
+  expect_gt(
+    chat_spans[[1L]]$attributes[["gen_ai.server.time_to_first_token"]],
+    0
+  )
 
   # Verify that the spans started when the stream was suspended are not part of
   # the agent trace.
@@ -305,7 +304,7 @@ test_that("tracing works as expected for asynchronous streams", {
   )))
 })
 
-test_that("stream span starts at the first non-empty text token", {
+test_that("time to first token is recorded at the first non-empty text token", {
   skip_if_not_installed("otelsdk")
 
   make_response <- function() {
@@ -335,10 +334,9 @@ test_that("stream span starts at the first non-empty text token", {
   })[["traces"]]
 
   chat_spans <- Filter(function(x) startsWith(x$name, "chat"), spans)
-  stream_spans <- Filter(function(x) startsWith(x$name, "stream"), spans)
-  expect_length(stream_spans, 1L)
-  expect_equal(stream_spans[[1L]]$parent, chat_spans[[1L]]$span_id)
-  expect_gte(stream_spans[[1L]]$start_time, chat_spans[[1L]]$start_time)
+  ttft <- chat_spans[[1L]]$attributes[["gen_ai.server.time_to_first_token"]]
+  expect_type(ttft, "double")
+  expect_gt(ttft, 0)
 })
 
 test_that("captures content when OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT is set", {

--- a/tests/testthat/test-otel.R
+++ b/tests/testthat/test-otel.R
@@ -96,6 +96,13 @@ test_that("tracing works as expected for synchronous streams", {
   expect_length(chat_spans, 1L)
   expect_equal(chat_spans[[1L]]$parent, spans[["invoke_agent"]]$span_id)
 
+  # And one "stream" span, starting at the first text token, nested in the
+  # chat span so the gap between their starts gives the time to first token.
+  stream_spans <- Filter(function(x) startsWith(x$name, "stream"), spans)
+  expect_length(stream_spans, 1L)
+  expect_equal(stream_spans[[1L]]$parent, chat_spans[[1L]]$span_id)
+  expect_gte(stream_spans[[1L]]$start_time, chat_spans[[1L]]$start_time)
+
   # Token usage attributes are recorded on the streamed chat span.
   expect_true(all(vapply(
     chat_spans,
@@ -277,6 +284,12 @@ test_that("tracing works as expected for asynchronous streams", {
   expect_length(chat_spans, 1L)
   expect_equal(chat_spans[[1L]]$parent, spans[["invoke_agent"]]$span_id)
 
+  # And one "stream" span nested in the chat span.
+  stream_spans <- Filter(function(x) startsWith(x$name, "stream"), spans)
+  expect_length(stream_spans, 1L)
+  expect_equal(stream_spans[[1L]]$parent, chat_spans[[1L]]$span_id)
+  expect_gte(stream_spans[[1L]]$start_time, chat_spans[[1L]]$start_time)
+
   # Verify that the spans started when the stream was suspended are not part of
   # the agent trace.
   expect_equal(spans[["concurrent"]]$parent, spans[["invoke_agent"]]$parent)
@@ -290,6 +303,42 @@ test_that("tracing works as expected for asynchronous streams", {
     function(x) x$parent %in% chat_span_ids,
     logical(1)
   )))
+})
+
+test_that("stream span starts at the first non-empty text token", {
+  skip_if_not_installed("otelsdk")
+
+  make_response <- function() {
+    coro::generator(function() {
+      yield(list(type = "chunk"))
+      yield(list(type = "chunk"))
+      yield(list(type = "chunk"))
+    })()
+  }
+  n <- 0
+  local_mocked_bindings(
+    chat_perform = function(...) make_response(),
+    stream_merge_chunks = function(provider, result, chunk) list(),
+    stream_content = function(provider, event, completion) {
+      n <<- n + 1
+      switch(n, list(ContentText("")), list(ContentText("hi")), list())
+    },
+    value_finish_reason = function(provider, result) "success",
+    value_turn = function(provider, model, result, has_type = FALSE) {
+      AssistantTurn(list(ContentText("hi")), tokens = c(0, 0, 0), cost = 0)
+    }
+  )
+
+  spans <- with_otel_record({
+    chat <- Chat$new(test_provider(), model = test_model())
+    coro::collect(chat$stream("hi"))
+  })[["traces"]]
+
+  chat_spans <- Filter(function(x) startsWith(x$name, "chat"), spans)
+  stream_spans <- Filter(function(x) startsWith(x$name, "stream"), spans)
+  expect_length(stream_spans, 1L)
+  expect_equal(stream_spans[[1L]]$parent, chat_spans[[1L]]$span_id)
+  expect_gte(stream_spans[[1L]]$start_time, chat_spans[[1L]]$start_time)
 })
 
 test_that("captures content when OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT is set", {

--- a/tests/testthat/test-otel.R
+++ b/tests/testthat/test-otel.R
@@ -98,7 +98,7 @@ test_that("tracing works as expected for synchronous streams", {
 
   # Time to first token is recorded on the streamed chat span.
   expect_gt(
-    chat_spans[[1L]]$attributes[["gen_ai.server.time_to_first_token"]],
+    chat_spans[[1L]]$attributes[["gen_ai.response.time_to_first_chunk"]],
     0
   )
 
@@ -285,7 +285,7 @@ test_that("tracing works as expected for asynchronous streams", {
 
   # Time to first token is recorded on the streamed chat span.
   expect_gt(
-    chat_spans[[1L]]$attributes[["gen_ai.server.time_to_first_token"]],
+    chat_spans[[1L]]$attributes[["gen_ai.response.time_to_first_chunk"]],
     0
   )
 
@@ -334,7 +334,7 @@ test_that("time to first token is recorded at the first non-empty text token", {
   })[["traces"]]
 
   chat_spans <- Filter(function(x) startsWith(x$name, "chat"), spans)
-  ttft <- chat_spans[[1L]]$attributes[["gen_ai.server.time_to_first_token"]]
+  ttft <- chat_spans[[1L]]$attributes[["gen_ai.response.time_to_first_chunk"]]
   expect_type(ttft, "double")
   expect_gt(ttft, 0)
 })


### PR DESCRIPTION
Streamed responses now record the time to first token (seconds) as the `gen_ai.response.time_to_first_chunk` attribute on the `chat <model>` span.

- `R/otel.R`: `record_chat_otel_span_ttft_attr()` sets the attribute from a start timestamp captured just before the stream begins.
- `R/chat.R`: both sync and async streaming loops call it once, on the first non-empty text/thinking chunk.
- Tests: offline mocked test plus assertions in the live stream tests.

Follow-up in #1143 (stacked on this) broadens the trigger to tool calls and adds GenAI metrics.