### PR TITLE
Record GenAI semantic convention metrics and agent attributes via OpenTelemetry

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Streamed responses now record the time to first token (in seconds) as the `gen_ai.response.time_to_first_chunk` attribute on the OpenTelemetry `chat` span (@schloerke).
 * ellmer now records OpenTelemetry metrics following the GenAI semantic conventions whenever a meter is active: `gen_ai.client.operation.duration`, `gen_ai.client.operation.time_to_first_chunk`, `gen_ai.client.token.usage`, `gen_ai.execute_tool.duration`, `gen_ai.invoke_agent.duration`, `gen_ai.invoke_agent.inference_calls`, and `gen_ai.invoke_agent.tool_calls` (@schloerke).
-* The OpenTelemetry `invoke_agent` span is now of kind `internal` (it was `client`) and records total token usage across the tool loop. Both it and the `chat` span record `params()` as `gen_ai.request.*` attributes (@schloerke).
+* The OpenTelemetry `invoke_agent` span now records total token usage across the tool loop. Both it and the `chat` span record `params()` as `gen_ai.request.*` attributes (@schloerke).
 
 # ellmer 0.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # ellmer (development version)
 
 * Streamed responses now record the time to first token (in seconds) as the `gen_ai.response.time_to_first_chunk` attribute on the OpenTelemetry `chat` span (@schloerke).
+* ellmer now records OpenTelemetry metrics following the GenAI semantic conventions whenever a meter is active: `gen_ai.client.operation.duration`, `gen_ai.client.token.usage`, and `gen_ai.server.time_to_first_token` (@schloerke).
 
 # ellmer 0.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Streamed responses now record the time to first token (in seconds) as the `gen_ai.response.time_to_first_chunk` attribute on the OpenTelemetry `chat` span (@schloerke).
 * ellmer now records OpenTelemetry metrics following the GenAI semantic conventions whenever a meter is active: `gen_ai.client.operation.duration`, `gen_ai.client.operation.time_to_first_chunk`, `gen_ai.client.token.usage`, `gen_ai.execute_tool.duration`, `gen_ai.invoke_agent.duration`, `gen_ai.invoke_agent.inference_calls`, and `gen_ai.invoke_agent.tool_calls` (@schloerke).
-* The OpenTelemetry `invoke_agent` span now records total token usage across the tool loop. Both it and the `chat` span record `params()` as `gen_ai.request.*` attributes (@schloerke).
+* The OpenTelemetry `invoke_agent` span now records total token usage across the tool loop, along with its duration, inference call count, and tool call count as `gen_ai.invoke_agent.*` attributes. Both it and the `chat` span record `params()` as `gen_ai.request.*` attributes (@schloerke).
 
 # ellmer 0.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # ellmer (development version)
 
 * Streamed responses now record the time to first token (in seconds) as the `gen_ai.response.time_to_first_chunk` attribute on the OpenTelemetry `chat` span (@schloerke).
-* ellmer now records OpenTelemetry metrics following the GenAI semantic conventions whenever a meter is active: `gen_ai.client.operation.duration`, `gen_ai.client.operation.time_to_first_chunk`, `gen_ai.client.token.usage`, and `gen_ai.execute_tool.duration` (@schloerke).
+* ellmer now records OpenTelemetry metrics following the GenAI semantic conventions whenever a meter is active: `gen_ai.client.operation.duration`, `gen_ai.client.operation.time_to_first_chunk`, `gen_ai.client.token.usage`, `gen_ai.execute_tool.duration`, `gen_ai.invoke_agent.duration`, `gen_ai.invoke_agent.inference_calls`, and `gen_ai.invoke_agent.tool_calls` (@schloerke).
+* The OpenTelemetry `invoke_agent` span is now of kind `internal` (it was `client`) and records total token usage across the tool loop. Both it and the `chat` span record `params()` as `gen_ai.request.*` attributes (@schloerke).
 
 # ellmer 0.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # ellmer (development version)
 
 * Streamed responses now record the time to first token (in seconds) as the `gen_ai.response.time_to_first_chunk` attribute on the OpenTelemetry `chat` span (@schloerke).
-* ellmer now records OpenTelemetry metrics following the GenAI semantic conventions whenever a meter is active: `gen_ai.client.operation.duration`, `gen_ai.client.token.usage`, and `gen_ai.server.time_to_first_token` (@schloerke).
+* ellmer now records OpenTelemetry metrics following the GenAI semantic conventions whenever a meter is active: `gen_ai.client.operation.duration`, `gen_ai.client.operation.time_to_first_chunk`, `gen_ai.client.token.usage`, and `gen_ai.execute_tool.duration` (@schloerke).
 
 # ellmer 0.5.0
 

--- a/R/chat-tools.R
+++ b/R/chat-tools.R
@@ -215,7 +215,8 @@ invoke_tool <- function(
 
   tool_span <- local_tool_otel_span(request, parent = otel_span)
 
-  tryCatch(
+  start <- Sys.time()
+  result <- tryCatch(
     {
       result <- do.call(request@tool, args)
       new_tool_result(request, result)
@@ -225,6 +226,8 @@ invoke_tool <- function(
       new_tool_result(request, error = e)
     }
   )
+  record_tool_otel_duration(request, start, result)
+  result
 }
 
 on_load(
@@ -248,7 +251,8 @@ on_load(
     tool_span <- local_tool_otel_span(request, parent = otel_span)
     context <- tool_context(request)
 
-    tryCatch(
+    start <- Sys.time()
+    result <- tryCatch(
       {
         value <- await(with_tool_context(context, do.call(request@tool, args)))
         new_tool_result(request, value)
@@ -258,6 +262,8 @@ on_load(
         new_tool_result(request, error = e)
       }
     )
+    record_tool_otel_duration(request, start, result)
+    result
   })
 )
 

--- a/R/chat.R
+++ b/R/chat.R
@@ -978,6 +978,7 @@ Chat <- R6::R6Class(
         conversation_id = private$.conversation_id
       )
 
+      request_start <- Sys.time()
       response <- chat_perform(
         provider = private$provider,
         model = private$model,
@@ -1005,7 +1006,7 @@ Chat <- R6::R6Class(
         acc$begin_turn(user_turn)
         on.exit(acc$finalize_turn(), add = TRUE)
 
-        stream_start <- Sys.time()
+        stream_start <- request_start
         result <- NULL
         for (chunk in response) {
           result <- stream_merge_chunks(private$provider, result, chunk)
@@ -1022,7 +1023,12 @@ Chat <- R6::R6Class(
                 is_stream_text_content(content) &&
                 nzchar(text)
             ) {
-              record_chat_otel_span_ttft_attr(chat_span, stream_start)
+              record_chat_otel_ttft(
+                chat_span,
+                private$provider,
+                private$model,
+                stream_start
+              )
               stream_start <- NULL
             }
             if (yield_as_content) {
@@ -1050,7 +1056,13 @@ Chat <- R6::R6Class(
           }
         }
 
-        record_chat_otel_span_status(chat_span, private$provider, result)
+        record_chat_otel_span_status(
+          chat_span,
+          private$provider,
+          private$model,
+          result,
+          request_start
+        )
         turn <- acc$complete_turn(result, type = type)
         if (controller$cancelled) {
           turn <- self$last_turn()
@@ -1059,7 +1071,13 @@ Chat <- R6::R6Class(
       } else {
         result <- resp_body_json(response)
         duration <- resp_timing(response)[["total"]] %||% NA_real_
-        record_chat_otel_span_status(chat_span, private$provider, result)
+        record_chat_otel_span_status(
+          chat_span,
+          private$provider,
+          private$model,
+          result,
+          request_start
+        )
         turn <- acc$add_turn(user_turn, result, duration, type = type)
         record_chat_otel_span_output(chat_span, turn)
 
@@ -1148,6 +1166,7 @@ Chat <- R6::R6Class(
         conversation_id = private$.conversation_id
       )
 
+      request_start <- Sys.time()
       response <- chat_perform(
         provider = private$provider,
         model = private$model,
@@ -1175,7 +1194,7 @@ Chat <- R6::R6Class(
         acc$begin_turn(user_turn)
         on.exit(acc$finalize_turn(), add = TRUE)
 
-        stream_start <- Sys.time()
+        stream_start <- request_start
         result <- NULL
         for (chunk in await_each(response)) {
           result <- stream_merge_chunks(private$provider, result, chunk)
@@ -1192,7 +1211,12 @@ Chat <- R6::R6Class(
                 is_stream_text_content(content) &&
                 nzchar(text)
             ) {
-              record_chat_otel_span_ttft_attr(chat_span, stream_start)
+              record_chat_otel_ttft(
+                chat_span,
+                private$provider,
+                private$model,
+                stream_start
+              )
               stream_start <- NULL
             }
             if (yield_as_content) {
@@ -1220,7 +1244,13 @@ Chat <- R6::R6Class(
           }
         }
 
-        record_chat_otel_span_status(chat_span, private$provider, result)
+        record_chat_otel_span_status(
+          chat_span,
+          private$provider,
+          private$model,
+          result,
+          request_start
+        )
         turn <- acc$complete_turn(result, type = type)
         if (controller$cancelled) {
           turn <- self$last_turn()
@@ -1230,7 +1260,13 @@ Chat <- R6::R6Class(
         response <- await(response)
         result <- resp_body_json(response)
         duration <- resp_timing(response)[["total"]] %||% NA_real_
-        record_chat_otel_span_status(chat_span, private$provider, result)
+        record_chat_otel_span_status(
+          chat_span,
+          private$provider,
+          private$model,
+          result,
+          request_start
+        )
         turn <- acc$add_turn(user_turn, result, duration, type = type)
         record_chat_otel_span_output(chat_span, turn)
 

--- a/R/chat.R
+++ b/R/chat.R
@@ -777,6 +777,13 @@ Chat <- R6::R6Class(
         activate = FALSE,
         conversation_id = private$.conversation_id
       )
+      agent_tally <- new_agent_otel_tally()
+      defer(record_agent_otel(
+        agent_span,
+        private$provider,
+        private$model,
+        agent_tally
+      ))
 
       while (!is.null(user_turn)) {
         private$callback_on_request_start$invoke(c(
@@ -797,6 +804,7 @@ Chat <- R6::R6Class(
         }
 
         assistant_turn <- self$last_turn()
+        tally_agent_otel_turn(agent_tally, assistant_turn)
         private$callback_on_request_end$invoke(assistant_turn)
         user_turn <- NULL
 
@@ -872,6 +880,13 @@ Chat <- R6::R6Class(
         activate = FALSE,
         conversation_id = private$.conversation_id
       )
+      agent_tally <- new_agent_otel_tally()
+      defer(record_agent_otel(
+        agent_span,
+        private$provider,
+        private$model,
+        agent_tally
+      ))
 
       while (!is.null(user_turn)) {
         await(private$callback_on_request_start$invoke_async(c(
@@ -892,6 +907,7 @@ Chat <- R6::R6Class(
         }
 
         assistant_turn <- self$last_turn()
+        tally_agent_otel_turn(agent_tally, assistant_turn)
         await(private$callback_on_request_end$invoke_async(assistant_turn))
         user_turn <- NULL
 

--- a/R/chat.R
+++ b/R/chat.R
@@ -1016,21 +1016,20 @@ Chat <- R6::R6Class(
             result,
             turns = request_turns
           )
+          if (
+            !is.null(stream_start) &&
+              stream_output_started(private$provider, chunk)
+          ) {
+            record_chat_otel_ttft(
+              chat_span,
+              private$provider,
+              private$model,
+              stream_start
+            )
+            stream_start <- NULL
+          }
           for (content in contents) {
             text <- content_text(content)
-            if (
-              !is.null(stream_start) &&
-                is_stream_text_content(content) &&
-                nzchar(text)
-            ) {
-              record_chat_otel_ttft(
-                chat_span,
-                private$provider,
-                private$model,
-                stream_start
-              )
-              stream_start <- NULL
-            }
             if (yield_as_content) {
               yield(content)
             } else if (is_stream_text_content(content)) {
@@ -1204,21 +1203,20 @@ Chat <- R6::R6Class(
             result,
             turns = request_turns
           )
+          if (
+            !is.null(stream_start) &&
+              stream_output_started(private$provider, chunk)
+          ) {
+            record_chat_otel_ttft(
+              chat_span,
+              private$provider,
+              private$model,
+              stream_start
+            )
+            stream_start <- NULL
+          }
           for (content in contents) {
             text <- content_text(content)
-            if (
-              !is.null(stream_start) &&
-                is_stream_text_content(content) &&
-                nzchar(text)
-            ) {
-              record_chat_otel_ttft(
-                chat_span,
-                private$provider,
-                private$model,
-                stream_start
-              )
-              stream_start <- NULL
-            }
             if (yield_as_content) {
               yield(content)
             } else if (is_stream_text_content(content)) {

--- a/R/otel.R
+++ b/R/otel.R
@@ -217,9 +217,8 @@ local({
     agent_span <-
       otel::start_span(
         "invoke_agent",
-        # ellmer's agent loop runs in-process, so the span is "internal" per
-        # the GenAI semantic conventions.
-        options = list(kind = "internal"),
+        # TODO: "client" vs "internal" is under discussion, see #1146.
+        options = list(kind = "client"),
         attributes = c(
           compact(list(
             "gen_ai.operation.name" = "invoke_agent",

--- a/R/otel.R
+++ b/R/otel.R
@@ -18,8 +18,12 @@ otel_histogram_specs <- list(
     description = "Number of input and output tokens used",
     unit = "{token}"
   ),
-  "gen_ai.server.time_to_first_token" = list(
-    description = "Time to generate first token for successful responses",
+  "gen_ai.client.operation.time_to_first_chunk" = list(
+    description = "Time to receive the first chunk of a streamed response",
+    unit = "s"
+  ),
+  "gen_ai.execute_tool.duration" = list(
+    description = "The duration of a single tool execution",
     unit = "s"
   )
 )
@@ -367,11 +371,11 @@ otel_chat_input <- function(private, user_turn) {
 }
 
 # Records the time to first token (in seconds) as a chat span attribute and
-# as the `gen_ai.server.time_to_first_token` histogram.
+# as the `gen_ai.client.operation.time_to_first_chunk` histogram.
 record_chat_otel_ttft <- function(span, provider, model, start) {
   ttft <- elapsed_secs(start)
   otel_record_histogram(
-    "gen_ai.server.time_to_first_token",
+    "gen_ai.client.operation.time_to_first_chunk",
     ttft,
     otel_metric_attributes(provider, model)
   )
@@ -396,6 +400,23 @@ record_chat_otel_span_output <- function(span, turn) {
     "gen_ai.output.messages",
     jsonlite::toJSON(list(msg), auto_unbox = TRUE, null = "null")
   )
+}
+
+record_tool_otel_duration <- function(request, start, result) {
+  otel_record_histogram(
+    "gen_ai.execute_tool.duration",
+    elapsed_secs(start),
+    list(
+      "gen_ai.operation.name" = "execute_tool",
+      "gen_ai.tool.name" = request@tool@name,
+      "gen_ai.tool.type" = "function",
+      "error.type" = if (tool_errored(result)) tool_error_type(result)
+    )
+  )
+}
+
+tool_error_type <- function(result) {
+  if (is.character(result@error)) "error" else class(result@error)[1L]
 }
 
 record_tool_otel_span_error <- function(span, error) {

--- a/R/otel.R
+++ b/R/otel.R
@@ -454,27 +454,25 @@ tally_agent_otel_turn <- function(tally, turn) {
   invisible(tally)
 }
 
+# Records the invoke_agent metrics and, mirroring the chat span, also sets
+# them as attributes on the invoke_agent span.
 record_agent_otel <- function(span, provider, model, tally) {
   attributes <- otel_metric_attributes(provider, model)
   attributes[["gen_ai.operation.name"]] <- "invoke_agent"
-  otel_record_histogram(
-    "gen_ai.invoke_agent.duration",
-    elapsed_secs(tally$start),
-    attributes
+  values <- list(
+    "gen_ai.invoke_agent.duration" = elapsed_secs(tally$start),
+    "gen_ai.invoke_agent.inference_calls" = tally$inference_calls,
+    "gen_ai.invoke_agent.tool_calls" = tally$tool_calls
   )
-  otel_record_histogram(
-    "gen_ai.invoke_agent.inference_calls",
-    tally$inference_calls,
-    attributes
-  )
-  otel_record_histogram(
-    "gen_ai.invoke_agent.tool_calls",
-    tally$tool_calls,
-    attributes
-  )
+  for (name in names(values)) {
+    otel_record_histogram(name, values[[name]], attributes)
+  }
 
   if (is.null(span) || !span_recording(span)) {
     return()
+  }
+  for (name in names(values)) {
+    span$set_attribute(name, values[[name]])
   }
   input <- as.integer(tally$tokens[[1]] + tally$tokens[[3]])
   output <- as.integer(tally$tokens[[2]])

--- a/R/otel.R
+++ b/R/otel.R
@@ -25,8 +25,35 @@ otel_histogram_specs <- list(
   "gen_ai.execute_tool.duration" = list(
     description = "The duration of a single tool execution",
     unit = "s"
+  ),
+  "gen_ai.invoke_agent.duration" = list(
+    description = "The end-to-end duration of a single agent invocation",
+    unit = "s"
+  ),
+  "gen_ai.invoke_agent.inference_calls" = list(
+    description = "The number of inference calls made during an agent invocation",
+    unit = "{inference_call}"
+  ),
+  "gen_ai.invoke_agent.tool_calls" = list(
+    description = "The number of tool calls made during an agent invocation",
+    unit = "{tool_call}"
   )
 )
+
+# Map `params()` onto the `gen_ai.request.*` span attributes.
+otel_request_attributes <- function(model) {
+  p <- model@params
+  compact(list(
+    "gen_ai.request.temperature" = p$temperature,
+    "gen_ai.request.top_p" = p$top_p,
+    "gen_ai.request.top_k" = p$top_k,
+    "gen_ai.request.frequency_penalty" = p$frequency_penalty,
+    "gen_ai.request.presence_penalty" = p$presence_penalty,
+    "gen_ai.request.seed" = p$seed,
+    "gen_ai.request.max_tokens" = p$max_tokens,
+    "gen_ai.request.stop_sequences" = p$stop_sequences
+  ))
+}
 
 local({
   otel_is_tracing <- FALSE
@@ -87,12 +114,15 @@ local({
         # Per the GenAI semantic conventions, gen_ai.conversation.id is only
         # set when the caller has a conversation identifier readily available;
         # never invent a fallback value.
-        attributes = compact(list(
-          "gen_ai.operation.name" = "chat",
-          "gen_ai.provider.name" = tolower(provider@name),
-          "gen_ai.request.model" = model@name,
-          "gen_ai.conversation.id" = conversation_id
-        )),
+        attributes = c(
+          compact(list(
+            "gen_ai.operation.name" = "chat",
+            "gen_ai.provider.name" = tolower(provider@name),
+            "gen_ai.request.model" = model@name,
+            "gen_ai.conversation.id" = conversation_id
+          )),
+          otel_request_attributes(model)
+        ),
         tracer = otel_tracer
       )
 
@@ -187,13 +217,18 @@ local({
     agent_span <-
       otel::start_span(
         "invoke_agent",
-        options = list(kind = "client"),
-        attributes = compact(list(
-          "gen_ai.operation.name" = "invoke_agent",
-          "gen_ai.provider.name" = tolower(provider@name),
-          "gen_ai.request.model" = model@name,
-          "gen_ai.conversation.id" = conversation_id
-        )),
+        # ellmer's agent loop runs in-process, so the span is "internal" per
+        # the GenAI semantic conventions.
+        options = list(kind = "internal"),
+        attributes = c(
+          compact(list(
+            "gen_ai.operation.name" = "invoke_agent",
+            "gen_ai.provider.name" = tolower(provider@name),
+            "gen_ai.request.model" = model@name,
+            "gen_ai.conversation.id" = conversation_id
+          )),
+          otel_request_attributes(model)
+        ),
         tracer = otel_tracer
       )
 
@@ -400,6 +435,54 @@ record_chat_otel_span_output <- function(span, turn) {
     "gen_ai.output.messages",
     jsonlite::toJSON(list(msg), auto_unbox = TRUE, null = "null")
   )
+}
+
+# Per-invocation counts backing the invoke_agent span attributes and metrics.
+new_agent_otel_tally <- function() {
+  env(
+    start = Sys.time(),
+    inference_calls = 0L,
+    tool_calls = 0L,
+    tokens = c(0, 0, 0)
+  )
+}
+
+tally_agent_otel_turn <- function(tally, turn) {
+  tally$inference_calls <- tally$inference_calls + 1L
+  tally$tool_calls <- tally$tool_calls + length(extract_tool_requests(turn))
+  # tokens are c(input, output, cached_input)
+  tally$tokens <- tally$tokens + ifelse(is.na(turn@tokens), 0, turn@tokens)
+  invisible(tally)
+}
+
+record_agent_otel <- function(span, provider, model, tally) {
+  attributes <- otel_metric_attributes(provider, model)
+  attributes[["gen_ai.operation.name"]] <- "invoke_agent"
+  otel_record_histogram(
+    "gen_ai.invoke_agent.duration",
+    elapsed_secs(tally$start),
+    attributes
+  )
+  otel_record_histogram(
+    "gen_ai.invoke_agent.inference_calls",
+    tally$inference_calls,
+    attributes
+  )
+  otel_record_histogram(
+    "gen_ai.invoke_agent.tool_calls",
+    tally$tool_calls,
+    attributes
+  )
+
+  if (is.null(span) || !span_recording(span)) {
+    return()
+  }
+  input <- as.integer(tally$tokens[[1]] + tally$tokens[[3]])
+  output <- as.integer(tally$tokens[[2]])
+  if (input > 0L || output > 0L) {
+    span$set_attribute("gen_ai.usage.input_tokens", input)
+    span$set_attribute("gen_ai.usage.output_tokens", output)
+  }
 }
 
 record_tool_otel_duration <- function(request, start, result) {

--- a/R/otel.R
+++ b/R/otel.R
@@ -5,11 +5,31 @@ otel_capture_content_enabled <- NULL
 local_chat_otel_span <- NULL
 local_tool_otel_span <- NULL
 local_agent_otel_span <- NULL
+otel_record_histogram <- NULL
+
+# Histograms from the GenAI semantic conventions for metrics.
+# See: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/
+otel_histogram_specs <- list(
+  "gen_ai.client.operation.duration" = list(
+    description = "GenAI operation duration",
+    unit = "s"
+  ),
+  "gen_ai.client.token.usage" = list(
+    description = "Number of input and output tokens used",
+    unit = "{token}"
+  ),
+  "gen_ai.server.time_to_first_token" = list(
+    description = "Time to generate first token for successful responses",
+    unit = "s"
+  )
+)
 
 local({
   otel_is_tracing <- FALSE
   otel_tracer <- NULL
   otel_capture_content <- FALSE
+  otel_is_measuring <- FALSE
+  otel_histograms <- list()
 
   otel_cache_tracer <<- function() {
     if (!requireNamespace("otel", quietly = TRUE)) {
@@ -21,9 +41,25 @@ local({
       val <- Sys.getenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT")
       tolower(val) %in% c("true", "1")
     }
+
+    otel_meter <- otel::get_meter(otel_tracer_name)
+    otel_is_measuring <<- otel::is_measuring_enabled(otel_meter)
+    otel_histograms <<- if (otel_is_measuring) {
+      imap(otel_histogram_specs, function(spec, name) {
+        otel_meter$create_histogram(name, spec$description, unit = spec$unit)
+      })
+    }
   }
 
   otel_capture_content_enabled <<- function() otel_capture_content
+
+  otel_record_histogram <<- function(name, value, attributes) {
+    if (!otel_is_measuring) {
+      return()
+    }
+    otel_histograms[[name]]$record(value, attributes = compact(attributes))
+    invisible()
+  }
 
   local_chat_otel_span <<- function(
     provider,
@@ -182,11 +218,69 @@ with_otel_record <- function(expr) {
   on.exit(otel_cache_tracer())
   otelsdk::with_otel_record({
     otel_cache_tracer()
-    expr
+    value <- expr
+    # otelsdk (<= 0.2.4) only exports in-memory metrics on shutdown, which
+    # happens after they are collected. Shut down early so they are returned.
+    meter_provider <- otel::get_default_meter_provider()
+    meter_provider$flush()
+    meter_provider$shutdown()
+    value
   })
 }
 
-record_chat_otel_span_status <- function(span, provider, result) {
+# Flatten recorded metrics into a list of data points named by instrument.
+otel_metric_points <- function(metrics) {
+  scopes <- unlist(lapply(metrics, \(x) x$scope_metric_data), recursive = FALSE)
+  data <- unlist(lapply(scopes, \(x) x$metric_data), recursive = FALSE)
+  points <- lapply(data, function(metric) {
+    lapply(metric$point_data_attr, function(point) {
+      list(
+        attributes = unclass(point$attributes),
+        count = point$value$count,
+        sum = point$value$sum
+      )
+    })
+  })
+  set_names(points, map_chr(data, \(x) x$instrument_name))
+}
+
+otel_metric_attributes <- function(provider, model, result = NULL) {
+  list(
+    "gen_ai.operation.name" = "chat",
+    "gen_ai.provider.name" = tolower(provider@name),
+    "gen_ai.request.model" = model@name,
+    "gen_ai.response.model" = result$model
+  )
+}
+
+elapsed_secs <- function(start) {
+  as.numeric(Sys.time() - start, units = "secs")
+}
+
+record_chat_otel_span_status <- function(span, provider, model, result, start) {
+  attributes <- otel_metric_attributes(provider, model, result)
+  otel_record_histogram(
+    "gen_ai.client.operation.duration",
+    elapsed_secs(start),
+    attributes
+  )
+
+  tokens <- value_tokens(provider, result)
+  input <- as.integer(tokens$input + tokens$cached_input)
+  output <- as.integer(tokens$output)
+  if (input > 0L || output > 0L) {
+    otel_record_histogram(
+      "gen_ai.client.token.usage",
+      input,
+      c(attributes, "gen_ai.token.type" = "input")
+    )
+    otel_record_histogram(
+      "gen_ai.client.token.usage",
+      output,
+      c(attributes, "gen_ai.token.type" = "output")
+    )
+  }
+
   if (is.null(span) || !span_recording(span)) {
     return()
   }
@@ -196,9 +290,6 @@ record_chat_otel_span_status <- function(span, provider, result) {
   if (!is.null(result$id)) {
     span$set_attribute("gen_ai.response.id", result$id)
   }
-  tokens <- value_tokens(provider, result)
-  input <- as.integer(tokens$input + tokens$cached_input)
-  output <- as.integer(tokens$output)
   if (input > 0L || output > 0L) {
     span$set_attribute("gen_ai.usage.input_tokens", input)
     span$set_attribute("gen_ai.usage.output_tokens", output)
@@ -275,16 +366,19 @@ otel_chat_input <- function(private, user_turn) {
   )
 }
 
-# Records the time to first token (in seconds) on the chat span as the
-# `gen_ai.response.time_to_first_chunk` semconv attribute.
-record_chat_otel_span_ttft_attr <- function(span, start) {
+# Records the time to first token (in seconds) as a chat span attribute and
+# as the `gen_ai.server.time_to_first_token` histogram.
+record_chat_otel_ttft <- function(span, provider, model, start) {
+  ttft <- elapsed_secs(start)
+  otel_record_histogram(
+    "gen_ai.server.time_to_first_token",
+    ttft,
+    otel_metric_attributes(provider, model)
+  )
   if (is.null(span) || !span_recording(span)) {
     return()
   }
-  span$set_attribute(
-    "gen_ai.response.time_to_first_chunk",
-    as.numeric(Sys.time() - start, units = "secs")
-  )
+  span$set_attribute("gen_ai.response.time_to_first_chunk", ttft)
 }
 
 record_chat_otel_span_output <- function(span, turn) {

--- a/R/provider-claude.R
+++ b/R/provider-claude.R
@@ -380,6 +380,9 @@ method(stream_content_with_turns, ProviderAnthropic) <- function(
   }
   list()
 }
+method(stream_output_started, ProviderAnthropic) <- function(provider, chunk) {
+  identical(chunk$type, "content_block_start")
+}
 method(stream_merge_chunks, ProviderAnthropic) <- function(
   provider,
   result,

--- a/R/provider-openai.R
+++ b/R/provider-openai.R
@@ -273,6 +273,9 @@ method(stream_content, ProviderOpenAI) <- function(
     list()
   }
 }
+method(stream_output_started, ProviderOpenAI) <- function(provider, chunk) {
+  identical(chunk$type, "response.output_item.added")
+}
 method(stream_merge_chunks, ProviderOpenAI) <- function(
   provider,
   result,

--- a/R/provider.R
+++ b/R/provider.R
@@ -180,6 +180,19 @@ stream_content <- new_generic(
     S7_dispatch()
   }
 )
+# Does this streamed chunk mark the start of the model's output (text,
+# thinking, or a tool call)? Used to measure time to first token. By default
+# the first chunk counts; providers that send preamble events override this.
+stream_output_started <- new_generic(
+  "stream_output_started",
+  "provider",
+  function(provider, chunk) {
+    S7_dispatch()
+  }
+)
+method(stream_output_started, Provider) <- function(provider, chunk) {
+  TRUE
+}
 stream_content_with_turns <- new_generic(
   "stream_content_with_turns",
   "provider",

--- a/tests/testthat/test-otel.R
+++ b/tests/testthat/test-otel.R
@@ -304,7 +304,7 @@ test_that("tracing works as expected for asynchronous streams", {
   )))
 })
 
-test_that("time to first token is recorded at the first non-empty text token", {
+test_that("time to first token is recorded when output starts", {
   skip_if_not_installed("otelsdk")
 
   make_response <- function() {

--- a/tests/testthat/test-otel.R
+++ b/tests/testthat/test-otel.R
@@ -409,10 +409,16 @@ test_that("token usage and operation duration are recorded as metrics", {
     "invoke_agent"
   )
 
-  # Token usage is also totalled on the invoke_agent span.
+  # Token usage and the agent metrics are also set on the invoke_agent span.
   agent_span <- recorded$traces[["invoke_agent"]]
   expect_equal(agent_span$attributes[["gen_ai.usage.input_tokens"]], 4L)
   expect_equal(agent_span$attributes[["gen_ai.usage.output_tokens"]], 5L)
+  expect_equal(
+    agent_span$attributes[["gen_ai.invoke_agent.inference_calls"]],
+    1L
+  )
+  expect_equal(agent_span$attributes[["gen_ai.invoke_agent.tool_calls"]], 0L)
+  expect_gt(agent_span$attributes[["gen_ai.invoke_agent.duration"]], 0)
 })
 
 test_that("request params are recorded as gen_ai.request.* attributes", {

--- a/tests/testthat/test-otel.R
+++ b/tests/testthat/test-otel.R
@@ -12,7 +12,7 @@ test_that("tracing works as expected for synchronous chats", {
   agent_spans <- Filter(function(x) x$name == "invoke_agent", spans)
   expect_length(agent_spans, 2L)
   expect_equal(agent_spans[[1L]]$parent, agent_spans[[2L]]$parent)
-  expect_equal(agent_spans[[1L]]$kind, "internal")
+  expect_equal(agent_spans[[1L]]$kind, "client")
   agent_span_ids <- sapply(agent_spans, function(x) x$span_id)
 
   # We should have (at least) two "execute_tool" spans

--- a/tests/testthat/test-otel.R
+++ b/tests/testthat/test-otel.R
@@ -12,7 +12,7 @@ test_that("tracing works as expected for synchronous chats", {
   agent_spans <- Filter(function(x) x$name == "invoke_agent", spans)
   expect_length(agent_spans, 2L)
   expect_equal(agent_spans[[1L]]$parent, agent_spans[[2L]]$parent)
-  expect_equal(agent_spans[[1L]]$kind, "client")
+  expect_equal(agent_spans[[1L]]$kind, "internal")
   agent_span_ids <- sapply(agent_spans, function(x) x$span_id)
 
   # We should have (at least) two "execute_tool" spans
@@ -343,7 +343,10 @@ test_that("time to first token is recorded when output starts", {
     names(points),
     c(
       "gen_ai.client.operation.duration",
-      "gen_ai.client.operation.time_to_first_chunk"
+      "gen_ai.client.operation.time_to_first_chunk",
+      "gen_ai.invoke_agent.duration",
+      "gen_ai.invoke_agent.inference_calls",
+      "gen_ai.invoke_agent.tool_calls"
     )
   )
   ttft_point <- points[["gen_ai.client.operation.time_to_first_chunk"]][[1L]]
@@ -370,7 +373,7 @@ test_that("token usage and operation duration are recorded as metrics", {
       list(input = 3, cached_input = 1, output = 5)
     },
     value_turn = function(provider, model, result, has_type = FALSE) {
-      AssistantTurn(list(ContentText("hi")), tokens = c(0, 0, 0), cost = 0)
+      AssistantTurn(list(ContentText("hi")), tokens = c(3, 5, 1), cost = 0)
     }
   )
 
@@ -382,7 +385,13 @@ test_that("token usage and operation duration are recorded as metrics", {
   points <- otel_metric_points(recorded$metrics)
   expect_setequal(
     names(points),
-    c("gen_ai.client.operation.duration", "gen_ai.client.token.usage")
+    c(
+      "gen_ai.client.operation.duration",
+      "gen_ai.client.token.usage",
+      "gen_ai.invoke_agent.duration",
+      "gen_ai.invoke_agent.inference_calls",
+      "gen_ai.invoke_agent.tool_calls"
+    )
   )
   usage <- points[["gen_ai.client.token.usage"]]
   usage <- set_names(
@@ -391,6 +400,44 @@ test_that("token usage and operation duration are recorded as metrics", {
   )
   expect_equal(usage, c(input = 4, output = 5))
   expect_equal(points[["gen_ai.client.operation.duration"]][[1L]]$count, 1L)
+  expect_equal(points[["gen_ai.invoke_agent.inference_calls"]][[1L]]$sum, 1)
+  expect_equal(points[["gen_ai.invoke_agent.tool_calls"]][[1L]]$sum, 0)
+  expect_equal(
+    points[["gen_ai.invoke_agent.duration"]][[1L]]$attributes[[
+      "gen_ai.operation.name"
+    ]],
+    "invoke_agent"
+  )
+
+  # Token usage is also totalled on the invoke_agent span.
+  agent_span <- recorded$traces[["invoke_agent"]]
+  expect_equal(agent_span$attributes[["gen_ai.usage.input_tokens"]], 4L)
+  expect_equal(agent_span$attributes[["gen_ai.usage.output_tokens"]], 5L)
+})
+
+test_that("request params are recorded as gen_ai.request.* attributes", {
+  skip_if_not_installed("otelsdk")
+
+  local_mocked_bindings(
+    chat_perform = function(...) list(),
+    resp_body_json = function(...) list(),
+    resp_timing = function(...) list(total = 1),
+    value_turn = function(provider, model, result, has_type = FALSE) {
+      AssistantTurn(list(ContentText("hi")), tokens = c(0, 0, 0), cost = 0)
+    }
+  )
+
+  spans <- with_otel_record({
+    model <- test_model(params = params(temperature = 0.5, max_tokens = 10))
+    chat <- Chat$new(test_provider(), model = model)
+    chat$chat("hi")
+  })[["traces"]]
+
+  for (span in spans[c("invoke_agent", "chat ")]) {
+    expect_equal(span$attributes[["gen_ai.request.temperature"]], 0.5)
+    expect_equal(span$attributes[["gen_ai.request.max_tokens"]], 10)
+    expect_null(span$attributes[["gen_ai.request.top_p"]])
+  }
 })
 
 test_that("captures content when OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT is set", {

--- a/tests/testthat/test-otel.R
+++ b/tests/testthat/test-otel.R
@@ -328,15 +328,66 @@ test_that("time to first token is recorded at the first non-empty text token", {
     }
   )
 
-  spans <- with_otel_record({
-    chat <- Chat$new(test_provider(), model = test_model())
+  recorded <- with_otel_record({
+    chat <- Chat$new(test_provider("Test"), model = test_model("test-model"))
     coro::collect(chat$stream("hi"))
-  })[["traces"]]
+  })
 
-  chat_spans <- Filter(function(x) startsWith(x$name, "chat"), spans)
+  chat_spans <- Filter(function(x) startsWith(x$name, "chat"), recorded$traces)
   ttft <- chat_spans[[1L]]$attributes[["gen_ai.response.time_to_first_chunk"]]
   expect_type(ttft, "double")
   expect_gt(ttft, 0)
+
+  points <- otel_metric_points(recorded$metrics)
+  expect_setequal(
+    names(points),
+    c("gen_ai.client.operation.duration", "gen_ai.server.time_to_first_token")
+  )
+  ttft_point <- points[["gen_ai.server.time_to_first_token"]][[1L]]
+  expect_equal(ttft_point$count, 1L)
+  expect_equal(ttft_point$sum, ttft)
+  expect_equal(
+    ttft_point$attributes,
+    list(
+      "gen_ai.operation.name" = "chat",
+      "gen_ai.provider.name" = "test",
+      "gen_ai.request.model" = "test-model"
+    )
+  )
+})
+
+test_that("token usage and operation duration are recorded as metrics", {
+  skip_if_not_installed("otelsdk")
+
+  local_mocked_bindings(
+    chat_perform = function(...) list(),
+    resp_body_json = function(...) list(),
+    resp_timing = function(...) list(total = 1),
+    value_tokens = function(provider, result) {
+      list(input = 3, cached_input = 1, output = 5)
+    },
+    value_turn = function(provider, model, result, has_type = FALSE) {
+      AssistantTurn(list(ContentText("hi")), tokens = c(0, 0, 0), cost = 0)
+    }
+  )
+
+  recorded <- with_otel_record({
+    chat <- Chat$new(test_provider(), model = test_model())
+    chat$chat("hi")
+  })
+
+  points <- otel_metric_points(recorded$metrics)
+  expect_setequal(
+    names(points),
+    c("gen_ai.client.operation.duration", "gen_ai.client.token.usage")
+  )
+  usage <- points[["gen_ai.client.token.usage"]]
+  usage <- set_names(
+    map_dbl(usage, \(x) x$sum),
+    map_chr(usage, \(x) x$attributes[["gen_ai.token.type"]])
+  )
+  expect_equal(usage, c(input = 4, output = 5))
+  expect_equal(points[["gen_ai.client.operation.duration"]][[1L]]$count, 1L)
 })
 
 test_that("captures content when OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT is set", {

--- a/tests/testthat/test-otel.R
+++ b/tests/testthat/test-otel.R
@@ -341,9 +341,12 @@ test_that("time to first token is recorded when output starts", {
   points <- otel_metric_points(recorded$metrics)
   expect_setequal(
     names(points),
-    c("gen_ai.client.operation.duration", "gen_ai.server.time_to_first_token")
+    c(
+      "gen_ai.client.operation.duration",
+      "gen_ai.client.operation.time_to_first_chunk"
+    )
   )
-  ttft_point <- points[["gen_ai.server.time_to_first_token"]][[1L]]
+  ttft_point <- points[["gen_ai.client.operation.time_to_first_chunk"]][[1L]]
   expect_equal(ttft_point$count, 1L)
   expect_equal(ttft_point$sum, ttft)
   expect_equal(
@@ -515,4 +518,33 @@ test_that("conversation id attribute is absent when unset", {
   expect_length(chat_spans, 1L)
   # Per the GenAI semantic conventions, no fallback identifier is invented
   expect_null(chat_spans[[1]]$attributes[["gen_ai.conversation.id"]])
+})
+
+test_that("tool execution duration is recorded as a metric", {
+  skip_if_not_installed("otelsdk")
+
+  request <- function(tool_f) {
+    ContentToolRequest(id = "x", name = "t", arguments = list(), tool = tool_f)
+  }
+  ok <- tool(function() 1, name = "t", description = "A tool")
+  bad <- tool(function() stop("boom"), name = "t", description = "A tool")
+
+  recorded <- with_otel_record({
+    invoke_tool(request(ok))
+    sync(invoke_tool_async(request(bad)))
+  })
+
+  points <- otel_metric_points(recorded$metrics)
+  expect_equal(names(points), "gen_ai.execute_tool.duration")
+  points <- points[["gen_ai.execute_tool.duration"]]
+  expect_length(points, 2L)
+  expect_all_equal(map_int(points, \(x) x$count), 1L)
+  expect_equal(
+    map(points, \(x) x$attributes[["gen_ai.tool.name"]]),
+    list("t", "t")
+  )
+  expect_equal(
+    map(points, \(x) x$attributes[["error.type"]]),
+    list(NULL, "simpleError")
+  )
 })

--- a/tests/testthat/test-provider-claude.R
+++ b/tests/testthat/test-provider-claude.R
@@ -809,3 +809,12 @@ test_that("value_turn() handles empty content (#1070)", {
   turn <- value_turn(provider, test_model("claude-sonnet-5"), result)
   expect_equal(turn@contents, list())
 })
+
+test_that("stream_output_started() detects the first content block", {
+  provider <- chat_anthropic(credentials = \() "key")$get_provider()
+  expect_false(stream_output_started(provider, list(type = "message_start")))
+  expect_true(stream_output_started(
+    provider,
+    list(type = "content_block_start")
+  ))
+})

--- a/tests/testthat/test-provider-openai.R
+++ b/tests/testthat/test-provider-openai.R
@@ -430,3 +430,12 @@ test_that("as_json() serializes uploaded file references", {
     )
   )
 })
+
+test_that("stream_output_started() detects the first output item", {
+  provider <- chat_openai(credentials = \() "key")$get_provider()
+  expect_false(stream_output_started(provider, list(type = "response.created")))
+  expect_true(stream_output_started(
+    provider,
+    list(type = "response.output_item.added")
+  ))
+})


### PR DESCRIPTION
Stacked on #1142.

ellmer now records OpenTelemetry metrics whenever a meter is active, following the [GenAI semconv metrics](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/metrics.yaml):

| Metric | Unit | When |
|---|---|---|
| `gen_ai.client.operation.duration` | s | each model request |
| `gen_ai.client.operation.time_to_first_chunk` | s | streamed requests, when the model starts producing output |
| `gen_ai.client.token.usage` | `{token}` | each model request, split by `gen_ai.token.type` |
| `gen_ai.execute_tool.duration` | s | each tool call, with `error.type` on failure |
| `gen_ai.invoke_agent.duration` | s | each `$chat()` / `$stream()` invocation |
| `gen_ai.invoke_agent.inference_calls` | `{inference_call}` | per invocation |
| `gen_ai.invoke_agent.tool_calls` | `{tool_call}` | per invocation |

Points carry `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, and `gen_ai.response.model` when known.

Span changes:

- Time to first token now fires when the model starts producing any output, including a tool call, via a new internal `stream_output_started()` generic (OpenAI: `response.output_item.added`; Anthropic: `content_block_start`; default: first chunk).
- `invoke_agent` span totals `gen_ai.usage.*_tokens` across the tool loop and sets `gen_ai.invoke_agent.duration`, `gen_ai.invoke_agent.inference_calls`, and `gen_ai.invoke_agent.tool_calls` as attributes (mirroring the metrics). Its kind stays `client`; whether it should be `internal` is being discussed in #1146.
- `chat` and `invoke_agent` spans record `params()` as `gen_ai.request.*` attributes.

Testing: the internal `with_otel_record()` helper now shuts the meter provider down before collecting, since otelsdk <= 0.2.4 only exports in-memory metrics on shutdown. Offline mocked tests cover streamed, non-streamed, tool, and agent paths. Live otel tests were skipped locally (no API keys).