### PR TITLE
Record request.stream, finish reasons, cache-read tokens, and errors on OpenTelemetry chat spans

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Streamed responses now record the time to first token (in seconds) as the `gen_ai.response.time_to_first_chunk` attribute on the OpenTelemetry `chat` span (@schloerke).
 * ellmer now records OpenTelemetry metrics following the GenAI semantic conventions whenever a meter is active: `gen_ai.client.operation.duration`, `gen_ai.client.operation.time_to_first_chunk`, `gen_ai.client.token.usage`, `gen_ai.execute_tool.duration`, `gen_ai.invoke_agent.duration`, `gen_ai.invoke_agent.inference_calls`, and `gen_ai.invoke_agent.tool_calls` (@schloerke).
+* The OpenTelemetry `chat` span now records `gen_ai.request.stream` for streamed requests, `gen_ai.response.finish_reasons`, and `gen_ai.usage.cache_read.input_tokens`. Failed model requests now set an error status and `error.type` on the `chat` and `invoke_agent` spans and on the `gen_ai.client.operation.duration` and `gen_ai.invoke_agent.duration` metrics (@schloerke).
 * The OpenTelemetry `invoke_agent` span now records total token usage across the tool loop, along with its duration, inference call count, and tool call count as `gen_ai.invoke_agent.*` attributes. Both it and the `chat` span record `params()` as `gen_ai.request.*` attributes (@schloerke).
 
 # ellmer 0.5.0

--- a/R/chat-tools.R
+++ b/R/chat-tools.R
@@ -222,7 +222,7 @@ invoke_tool <- function(
       new_tool_result(request, result)
     },
     error = function(e) {
-      record_tool_otel_span_error(tool_span, e)
+      record_otel_span_error(tool_span, e)
       new_tool_result(request, error = e)
     }
   )
@@ -258,7 +258,7 @@ on_load(
         new_tool_result(request, value)
       },
       error = function(e) {
-        record_tool_otel_span_error(tool_span, e)
+        record_otel_span_error(tool_span, e)
         new_tool_result(request, error = e)
       }
     )

--- a/R/chat.R
+++ b/R/chat.R
@@ -785,66 +785,74 @@ Chat <- R6::R6Class(
         agent_tally
       ))
 
-      while (!is.null(user_turn)) {
-        private$callback_on_request_start$invoke(c(
-          private$.turns,
-          list(user_turn)
-        ))
-        assistant_chunks <- private$submit_turns(
-          user_turn,
-          stream = stream,
-          echo = echo,
-          type = type,
-          yield_as_content = yield_as_content,
-          controller = controller,
-          otel_span = agent_span
-        )
-        for (chunk in assistant_chunks) {
-          yield(chunk)
-        }
-
-        assistant_turn <- self$last_turn()
-        tally_agent_otel_turn(agent_tally, assistant_turn)
-        private$callback_on_request_end$invoke(assistant_turn)
-        user_turn <- NULL
-
-        # Don't invoke tools if the stream was cancelled
-        if (controller$cancelled) {
-          break
-        }
-
-        if (turn_has_tool_request(assistant_turn)) {
-          turns <- self$get_turns(include_system_prompt = TRUE)
-          tool_calls <- invoke_tools(
-            assistant_turn,
-            echo = echo,
-            on_tool_request = private$callback_on_tool_request$invoke,
-            on_tool_result = private$callback_on_tool_result$invoke,
-            yield_request = yield_as_content,
-            otel_span = agent_span,
-            tool_context = \(request) new_tool_context(request, turns)
-          )
-
-          tool_results <- list()
-
-          for (tool_step in tool_calls) {
-            if (yield_as_content) {
-              yield(tool_step)
+      tryCatch(
+        {
+          while (!is.null(user_turn)) {
+            private$callback_on_request_start$invoke(c(
+              private$.turns,
+              list(user_turn)
+            ))
+            assistant_chunks <- private$submit_turns(
+              user_turn,
+              stream = stream,
+              echo = echo,
+              type = type,
+              yield_as_content = yield_as_content,
+              controller = controller,
+              otel_span = agent_span
+            )
+            for (chunk in assistant_chunks) {
+              yield(chunk)
             }
-            if (is_tool_result(tool_step)) {
-              tool_results <- c(tool_results, list(tool_step))
+
+            assistant_turn <- self$last_turn()
+            tally_agent_otel_turn(agent_tally, assistant_turn)
+            private$callback_on_request_end$invoke(assistant_turn)
+            user_turn <- NULL
+
+            # Don't invoke tools if the stream was cancelled
+            if (controller$cancelled) {
+              break
+            }
+
+            if (turn_has_tool_request(assistant_turn)) {
+              turns <- self$get_turns(include_system_prompt = TRUE)
+              tool_calls <- invoke_tools(
+                assistant_turn,
+                echo = echo,
+                on_tool_request = private$callback_on_tool_request$invoke,
+                on_tool_result = private$callback_on_tool_result$invoke,
+                yield_request = yield_as_content,
+                otel_span = agent_span,
+                tool_context = \(request) new_tool_context(request, turns)
+              )
+
+              tool_results <- list()
+
+              for (tool_step in tool_calls) {
+                if (yield_as_content) {
+                  yield(tool_step)
+                }
+                if (is_tool_result(tool_step)) {
+                  tool_results <- c(tool_results, list(tool_step))
+                }
+              }
+
+              user_turn <- tool_results_as_turn(tool_results)
+            }
+
+            if (echo == "all") {
+              cat(format(user_turn))
+            } else if (echo == "none") {
+              tool_errors <- c(tool_errors, turn_get_tool_errors(user_turn))
             }
           }
-
-          user_turn <- tool_results_as_turn(tool_results)
+        },
+        error = function(e) {
+          agent_tally$error <- e
+          stop(e)
         }
-
-        if (echo == "all") {
-          cat(format(user_turn))
-        } else if (echo == "none") {
-          tool_errors <- c(tool_errors, turn_get_tool_errors(user_turn))
-        }
-      }
+      )
     }),
 
     # If stream = TRUE, yields completion deltas. If stream = FALSE, yields
@@ -888,82 +896,92 @@ Chat <- R6::R6Class(
         agent_tally
       ))
 
-      while (!is.null(user_turn)) {
-        await(private$callback_on_request_start$invoke_async(c(
-          private$.turns,
-          list(user_turn)
-        )))
-        assistant_chunks <- private$submit_turns_async(
-          user_turn,
-          stream = stream,
-          echo = echo,
-          type = type,
-          yield_as_content = yield_as_content,
-          controller = controller,
-          otel_span = agent_span
-        )
-        for (chunk in await_each(assistant_chunks)) {
-          yield(chunk)
-        }
-
-        assistant_turn <- self$last_turn()
-        tally_agent_otel_turn(agent_tally, assistant_turn)
-        await(private$callback_on_request_end$invoke_async(assistant_turn))
-        user_turn <- NULL
-
-        # Don't invoke tools if the stream was cancelled
-        if (controller$cancelled) {
-          break
-        }
-
-        if (turn_has_tool_request(assistant_turn)) {
-          turns <- self$get_turns(include_system_prompt = TRUE)
-          tool_calls <- invoke_tools_async(
-            assistant_turn,
-            echo = echo,
-            on_tool_request = private$callback_on_tool_request$invoke_async,
-            on_tool_result = private$callback_on_tool_result$invoke_async,
-            yield_request = yield_as_content,
-            otel_span = agent_span,
-            tool_context = \(request) new_tool_context(request, turns)
-          )
-          if (tool_mode == "sequential") {
-            tool_results <- list()
-            for (tool_step in await_each(tool_calls)) {
-              if (yield_as_content) {
-                yield(tool_step)
-              }
-              if (is_tool_result(tool_step)) {
-                tool_results <- c(tool_results, list(tool_step))
-              }
+      tryCatch(
+        {
+          while (!is.null(user_turn)) {
+            await(private$callback_on_request_start$invoke_async(c(
+              private$.turns,
+              list(user_turn)
+            )))
+            assistant_chunks <- private$submit_turns_async(
+              user_turn,
+              stream = stream,
+              echo = echo,
+              type = type,
+              yield_as_content = yield_as_content,
+              controller = controller,
+              otel_span = agent_span
+            )
+            for (chunk in await_each(assistant_chunks)) {
+              yield(chunk)
             }
-          } else {
-            tool_results <- coro::collect(tool_calls)
-            if (yield_as_content) {
-              # Filter out and yield tool requests before awaiting tool results
-              is_request <- map_lgl(tool_results, is_tool_request)
-              for (tool_step in tool_results[is_request]) {
-                yield(tool_step)
-              }
-              tool_results <- tool_results[!is_request]
+
+            assistant_turn <- self$last_turn()
+            tally_agent_otel_turn(agent_tally, assistant_turn)
+            await(private$callback_on_request_end$invoke_async(assistant_turn))
+            user_turn <- NULL
+
+            # Don't invoke tools if the stream was cancelled
+            if (controller$cancelled) {
+              break
             }
-            tool_results <- await(promises::promise_all(.list = tool_results))
-            if (yield_as_content) {
-              for (tool_result in tool_results) {
-                yield(tool_result)
+
+            if (turn_has_tool_request(assistant_turn)) {
+              turns <- self$get_turns(include_system_prompt = TRUE)
+              tool_calls <- invoke_tools_async(
+                assistant_turn,
+                echo = echo,
+                on_tool_request = private$callback_on_tool_request$invoke_async,
+                on_tool_result = private$callback_on_tool_result$invoke_async,
+                yield_request = yield_as_content,
+                otel_span = agent_span,
+                tool_context = \(request) new_tool_context(request, turns)
+              )
+              if (tool_mode == "sequential") {
+                tool_results <- list()
+                for (tool_step in await_each(tool_calls)) {
+                  if (yield_as_content) {
+                    yield(tool_step)
+                  }
+                  if (is_tool_result(tool_step)) {
+                    tool_results <- c(tool_results, list(tool_step))
+                  }
+                }
+              } else {
+                tool_results <- coro::collect(tool_calls)
+                if (yield_as_content) {
+                  # Filter out and yield tool requests before awaiting tool results
+                  is_request <- map_lgl(tool_results, is_tool_request)
+                  for (tool_step in tool_results[is_request]) {
+                    yield(tool_step)
+                  }
+                  tool_results <- tool_results[!is_request]
+                }
+                tool_results <- await(promises::promise_all(
+                  .list = tool_results
+                ))
+                if (yield_as_content) {
+                  for (tool_result in tool_results) {
+                    yield(tool_result)
+                  }
+                }
               }
+
+              user_turn <- tool_results_as_turn(tool_results)
+            }
+
+            if (echo == "all") {
+              cat(format(user_turn))
+            } else if (echo == "none") {
+              tool_errors <- c(tool_errors, turn_get_tool_errors(user_turn))
             }
           }
-
-          user_turn <- tool_results_as_turn(tool_results)
+        },
+        error = function(e) {
+          agent_tally$error <- e
+          stop(e)
         }
-
-        if (echo == "all") {
-          cat(format(user_turn))
-        } else if (echo == "none") {
-          tool_errors <- c(tool_errors, turn_get_tool_errors(user_turn))
-        }
-      }
+      )
     }),
 
     # If stream = TRUE, yields completion deltas. If stream = FALSE, yields
@@ -991,135 +1009,150 @@ Chat <- R6::R6Class(
         turns = otel_input$turns,
         system_prompt = otel_input$system_prompt,
         parent = otel_span,
-        conversation_id = private$.conversation_id
+        conversation_id = private$.conversation_id,
+        stream = stream
       )
 
       request_start <- Sys.time()
-      response <- chat_perform(
-        provider = private$provider,
-        model = private$model,
-        mode = if (stream) "stream" else "value",
-        turns = request_turns,
-        tools = if (is.null(type)) private$tools,
-        type = type,
-        controller = controller,
-        otel_span = chat_span
-      )
+      tryCatch(
+        {
+          response <- chat_perform(
+            provider = private$provider,
+            model = private$model,
+            mode = if (stream) "stream" else "value",
+            turns = request_turns,
+            tools = if (is.null(type)) private$tools,
+            type = type,
+            controller = controller,
+            otel_span = chat_span
+          )
 
-      emit <- emitter(echo)
-      any_text <- FALSE
-      echo_ends_with_newline <- TRUE
-      citation_sources <- list()
-      turn <- NULL
-      acc <- TurnAccumulator$new(
-        self,
-        private,
-        controller,
-        turns = request_turns
-      )
-
-      if (stream) {
-        acc$begin_turn(user_turn)
-        on.exit(acc$finalize_turn(), add = TRUE)
-
-        stream_start <- request_start
-        result <- NULL
-        for (chunk in response) {
-          result <- stream_merge_chunks(private$provider, result, chunk)
-          contents <- stream_content_with_turns(
-            private$provider,
-            chunk,
-            result,
+          emit <- emitter(echo)
+          any_text <- FALSE
+          echo_ends_with_newline <- TRUE
+          citation_sources <- list()
+          turn <- NULL
+          acc <- TurnAccumulator$new(
+            self,
+            private,
+            controller,
             turns = request_turns
           )
-          if (
-            !is.null(stream_start) &&
-              stream_output_started(private$provider, chunk)
-          ) {
-            record_chat_otel_ttft(
+
+          if (stream) {
+            acc$begin_turn(user_turn)
+            on.exit(acc$finalize_turn(), add = TRUE)
+
+            stream_start <- request_start
+            result <- NULL
+            for (chunk in response) {
+              result <- stream_merge_chunks(private$provider, result, chunk)
+              contents <- stream_content_with_turns(
+                private$provider,
+                chunk,
+                result,
+                turns = request_turns
+              )
+              if (
+                !is.null(stream_start) &&
+                  stream_output_started(private$provider, chunk)
+              ) {
+                record_chat_otel_ttft(
+                  chat_span,
+                  private$provider,
+                  private$model,
+                  stream_start
+                )
+                stream_start <- NULL
+              }
+              for (content in contents) {
+                text <- content_text(content)
+                if (yield_as_content) {
+                  yield(content)
+                } else if (is_stream_text_content(content)) {
+                  yield(text)
+                }
+                acc$update_turn(content)
+                if (is_stream_text_content(content)) {
+                  any_text <- TRUE
+                }
+                if (S7_inherits(content, ContentText)) {
+                  emit(text)
+                  if (!identical(text, "")) {
+                    echo_ends_with_newline <- endsWith(text, "\n")
+                  }
+                } else if (S7_inherits(content, ContentCitation)) {
+                  recorded <- record_citation_source(citation_sources, content)
+                  citation_sources <- recorded$sources
+                  if (!is.null(recorded$number)) {
+                    emit(paste0("[", recorded$number, "]"))
+                    echo_ends_with_newline <- FALSE
+                  }
+                }
+              }
+            }
+
+            record_chat_otel_span_status(
               chat_span,
               private$provider,
               private$model,
-              stream_start
+              result,
+              request_start
             )
-            stream_start <- NULL
-          }
-          for (content in contents) {
-            text <- content_text(content)
-            if (yield_as_content) {
-              yield(content)
-            } else if (is_stream_text_content(content)) {
-              yield(text)
+            turn <- acc$complete_turn(result, type = type)
+            if (controller$cancelled) {
+              turn <- self$last_turn()
             }
-            acc$update_turn(content)
-            if (is_stream_text_content(content)) {
-              any_text <- TRUE
-            }
-            if (S7_inherits(content, ContentText)) {
+            record_chat_otel_span_output(chat_span, turn)
+          } else {
+            result <- resp_body_json(response)
+            duration <- resp_timing(response)[["total"]] %||% NA_real_
+            record_chat_otel_span_status(
+              chat_span,
+              private$provider,
+              private$model,
+              result,
+              request_start
+            )
+            turn <- acc$add_turn(user_turn, result, duration, type = type)
+            record_chat_otel_span_output(chat_span, turn)
+
+            text <- turn@text
+            if (!is.null(text)) {
               emit(text)
+              any_text <- TRUE
               if (!identical(text, "")) {
                 echo_ends_with_newline <- endsWith(text, "\n")
               }
-            } else if (S7_inherits(content, ContentCitation)) {
-              recorded <- record_citation_source(citation_sources, content)
-              citation_sources <- recorded$sources
-              if (!is.null(recorded$number)) {
-                emit(paste0("[", recorded$number, "]"))
-                echo_ends_with_newline <- FALSE
+              if (yield_as_content) {
+                yield(ContentText(text))
+              } else {
+                yield(text)
+              }
+            }
+            for (content in turn@contents) {
+              if (S7_inherits(content, ContentCitation)) {
+                recorded <- record_citation_source(citation_sources, content)
+                citation_sources <- recorded$sources
+                if (!is.null(recorded$number)) {
+                  emit(paste0("[", recorded$number, "]"))
+                  echo_ends_with_newline <- FALSE
+                }
               }
             }
           }
+        },
+        error = function(e) {
+          record_chat_otel_span_error(
+            chat_span,
+            private$provider,
+            private$model,
+            e,
+            request_start
+          )
+          stop(e)
         }
-
-        record_chat_otel_span_status(
-          chat_span,
-          private$provider,
-          private$model,
-          result,
-          request_start
-        )
-        turn <- acc$complete_turn(result, type = type)
-        if (controller$cancelled) {
-          turn <- self$last_turn()
-        }
-        record_chat_otel_span_output(chat_span, turn)
-      } else {
-        result <- resp_body_json(response)
-        duration <- resp_timing(response)[["total"]] %||% NA_real_
-        record_chat_otel_span_status(
-          chat_span,
-          private$provider,
-          private$model,
-          result,
-          request_start
-        )
-        turn <- acc$add_turn(user_turn, result, duration, type = type)
-        record_chat_otel_span_output(chat_span, turn)
-
-        text <- turn@text
-        if (!is.null(text)) {
-          emit(text)
-          any_text <- TRUE
-          if (!identical(text, "")) {
-            echo_ends_with_newline <- endsWith(text, "\n")
-          }
-          if (yield_as_content) {
-            yield(ContentText(text))
-          } else {
-            yield(text)
-          }
-        }
-        for (content in turn@contents) {
-          if (S7_inherits(content, ContentCitation)) {
-            recorded <- record_citation_source(citation_sources, content)
-            citation_sources <- recorded$sources
-            if (!is.null(recorded$number)) {
-              emit(paste0("[", recorded$number, "]"))
-              echo_ends_with_newline <- FALSE
-            }
-          }
-        }
-      }
+      )
 
       if (!is.null(turn)) {
         if (!echo_ends_with_newline) {
@@ -1178,136 +1211,151 @@ Chat <- R6::R6Class(
         turns = otel_input$turns,
         system_prompt = otel_input$system_prompt,
         parent = otel_span,
-        conversation_id = private$.conversation_id
+        conversation_id = private$.conversation_id,
+        stream = stream
       )
 
       request_start <- Sys.time()
-      response <- chat_perform(
-        provider = private$provider,
-        model = private$model,
-        mode = if (stream) "async-stream" else "async-value",
-        turns = request_turns,
-        tools = if (is.null(type)) private$tools,
-        type = type,
-        controller = controller,
-        otel_span = chat_span
-      )
+      tryCatch(
+        {
+          response <- chat_perform(
+            provider = private$provider,
+            model = private$model,
+            mode = if (stream) "async-stream" else "async-value",
+            turns = request_turns,
+            tools = if (is.null(type)) private$tools,
+            type = type,
+            controller = controller,
+            otel_span = chat_span
+          )
 
-      emit <- emitter(echo)
-      any_text <- FALSE
-      echo_ends_with_newline <- TRUE
-      citation_sources <- list()
-      turn <- NULL
-      acc <- TurnAccumulator$new(
-        self,
-        private,
-        controller,
-        turns = request_turns
-      )
-
-      if (stream) {
-        acc$begin_turn(user_turn)
-        on.exit(acc$finalize_turn(), add = TRUE)
-
-        stream_start <- request_start
-        result <- NULL
-        for (chunk in await_each(response)) {
-          result <- stream_merge_chunks(private$provider, result, chunk)
-          contents <- stream_content_with_turns(
-            private$provider,
-            chunk,
-            result,
+          emit <- emitter(echo)
+          any_text <- FALSE
+          echo_ends_with_newline <- TRUE
+          citation_sources <- list()
+          turn <- NULL
+          acc <- TurnAccumulator$new(
+            self,
+            private,
+            controller,
             turns = request_turns
           )
-          if (
-            !is.null(stream_start) &&
-              stream_output_started(private$provider, chunk)
-          ) {
-            record_chat_otel_ttft(
+
+          if (stream) {
+            acc$begin_turn(user_turn)
+            on.exit(acc$finalize_turn(), add = TRUE)
+
+            stream_start <- request_start
+            result <- NULL
+            for (chunk in await_each(response)) {
+              result <- stream_merge_chunks(private$provider, result, chunk)
+              contents <- stream_content_with_turns(
+                private$provider,
+                chunk,
+                result,
+                turns = request_turns
+              )
+              if (
+                !is.null(stream_start) &&
+                  stream_output_started(private$provider, chunk)
+              ) {
+                record_chat_otel_ttft(
+                  chat_span,
+                  private$provider,
+                  private$model,
+                  stream_start
+                )
+                stream_start <- NULL
+              }
+              for (content in contents) {
+                text <- content_text(content)
+                if (yield_as_content) {
+                  yield(content)
+                } else if (is_stream_text_content(content)) {
+                  yield(text)
+                }
+                acc$update_turn(content)
+                if (is_stream_text_content(content)) {
+                  any_text <- TRUE
+                }
+                if (S7_inherits(content, ContentText)) {
+                  emit(text)
+                  if (!identical(text, "")) {
+                    echo_ends_with_newline <- endsWith(text, "\n")
+                  }
+                } else if (S7_inherits(content, ContentCitation)) {
+                  recorded <- record_citation_source(citation_sources, content)
+                  citation_sources <- recorded$sources
+                  if (!is.null(recorded$number)) {
+                    emit(paste0("[", recorded$number, "]"))
+                    echo_ends_with_newline <- FALSE
+                  }
+                }
+              }
+            }
+
+            record_chat_otel_span_status(
               chat_span,
               private$provider,
               private$model,
-              stream_start
+              result,
+              request_start
             )
-            stream_start <- NULL
-          }
-          for (content in contents) {
-            text <- content_text(content)
-            if (yield_as_content) {
-              yield(content)
-            } else if (is_stream_text_content(content)) {
-              yield(text)
+            turn <- acc$complete_turn(result, type = type)
+            if (controller$cancelled) {
+              turn <- self$last_turn()
             }
-            acc$update_turn(content)
-            if (is_stream_text_content(content)) {
-              any_text <- TRUE
-            }
-            if (S7_inherits(content, ContentText)) {
+            record_chat_otel_span_output(chat_span, turn)
+          } else {
+            response <- await(response)
+            result <- resp_body_json(response)
+            duration <- resp_timing(response)[["total"]] %||% NA_real_
+            record_chat_otel_span_status(
+              chat_span,
+              private$provider,
+              private$model,
+              result,
+              request_start
+            )
+            turn <- acc$add_turn(user_turn, result, duration, type = type)
+            record_chat_otel_span_output(chat_span, turn)
+
+            text <- turn@text
+            if (!is.null(text)) {
               emit(text)
+              any_text <- TRUE
               if (!identical(text, "")) {
                 echo_ends_with_newline <- endsWith(text, "\n")
               }
-            } else if (S7_inherits(content, ContentCitation)) {
-              recorded <- record_citation_source(citation_sources, content)
-              citation_sources <- recorded$sources
-              if (!is.null(recorded$number)) {
-                emit(paste0("[", recorded$number, "]"))
-                echo_ends_with_newline <- FALSE
+              if (yield_as_content) {
+                yield(ContentText(text))
+              } else {
+                yield(text)
+              }
+            }
+            for (content in turn@contents) {
+              if (S7_inherits(content, ContentCitation)) {
+                recorded <- record_citation_source(citation_sources, content)
+                citation_sources <- recorded$sources
+                if (!is.null(recorded$number)) {
+                  emit(paste0("[", recorded$number, "]"))
+                  echo_ends_with_newline <- FALSE
+                }
               }
             }
           }
+        },
+        error = function(e) {
+          record_chat_otel_span_error(
+            chat_span,
+            private$provider,
+            private$model,
+            e,
+            request_start
+          )
+          stop(e)
         }
-
-        record_chat_otel_span_status(
-          chat_span,
-          private$provider,
-          private$model,
-          result,
-          request_start
-        )
-        turn <- acc$complete_turn(result, type = type)
-        if (controller$cancelled) {
-          turn <- self$last_turn()
-        }
-        record_chat_otel_span_output(chat_span, turn)
-      } else {
-        response <- await(response)
-        result <- resp_body_json(response)
-        duration <- resp_timing(response)[["total"]] %||% NA_real_
-        record_chat_otel_span_status(
-          chat_span,
-          private$provider,
-          private$model,
-          result,
-          request_start
-        )
-        turn <- acc$add_turn(user_turn, result, duration, type = type)
-        record_chat_otel_span_output(chat_span, turn)
-
-        text <- turn@text
-        if (!is.null(text)) {
-          emit(text)
-          any_text <- TRUE
-          if (!identical(text, "")) {
-            echo_ends_with_newline <- endsWith(text, "\n")
-          }
-          if (yield_as_content) {
-            yield(ContentText(text))
-          } else {
-            yield(text)
-          }
-        }
-        for (content in turn@contents) {
-          if (S7_inherits(content, ContentCitation)) {
-            recorded <- record_citation_source(citation_sources, content)
-            citation_sources <- recorded$sources
-            if (!is.null(recorded$number)) {
-              emit(paste0("[", recorded$number, "]"))
-              echo_ends_with_newline <- FALSE
-            }
-          }
-        }
-      }
+      )
 
       if (!is.null(turn)) {
         if (!echo_ends_with_newline) {

--- a/R/otel.R
+++ b/R/otel.R
@@ -99,6 +99,7 @@ local({
     system_prompt = NULL,
     parent = NULL,
     conversation_id = NULL,
+    stream = FALSE,
     local_envir = parent.frame()
   ) {
     if (!otel_is_tracing) {
@@ -119,7 +120,9 @@ local({
             "gen_ai.operation.name" = "chat",
             "gen_ai.provider.name" = tolower(provider@name),
             "gen_ai.request.model" = model@name,
-            "gen_ai.conversation.id" = conversation_id
+            "gen_ai.conversation.id" = conversation_id,
+            # Only set when streaming; unset means non-streaming per semconv.
+            "gen_ai.request.stream" = if (stream) TRUE
           )),
           otel_request_attributes(model)
         ),
@@ -332,8 +335,30 @@ record_chat_otel_span_status <- function(span, provider, model, result, start) {
     span$set_attribute("gen_ai.usage.input_tokens", input)
     span$set_attribute("gen_ai.usage.output_tokens", output)
   }
-  # TODO: Consider setting gen_ai.response.finish_reasons.
+  if (tokens$cached_input > 0) {
+    span$set_attribute(
+      "gen_ai.usage.cache_read.input_tokens",
+      as.integer(tokens$cached_input)
+    )
+  }
   span$set_status("ok")
+}
+
+otel_error_type <- function(error) {
+  class(error)[1L]
+}
+
+# Records a failed model request: the operation duration metric tagged with
+# `error.type`, plus the exception and error status on the chat span.
+record_chat_otel_span_error <- function(span, provider, model, error, start) {
+  attributes <- otel_metric_attributes(provider, model)
+  attributes[["error.type"]] <- otel_error_type(error)
+  otel_record_histogram(
+    "gen_ai.client.operation.duration",
+    elapsed_secs(start),
+    attributes
+  )
+  record_otel_span_error(span, error)
 }
 
 # Convert a single Content into a GenAI semconv "part", a named list emitted
@@ -423,10 +448,13 @@ record_chat_otel_span_output <- function(span, turn) {
   if (is.null(span) || !span_recording(span)) {
     return()
   }
-  if (!otel_capture_content_enabled()) {
+  if (!S7_inherits(turn, AssistantTurn)) {
     return()
   }
-  if (!S7_inherits(turn, AssistantTurn)) {
+  if (!is.na(turn@finish_reason)) {
+    span$set_attribute("gen_ai.response.finish_reasons", turn@finish_reason)
+  }
+  if (!otel_capture_content_enabled()) {
     return()
   }
   msg <- as_otel_message(turn)
@@ -442,7 +470,8 @@ new_agent_otel_tally <- function() {
     start = Sys.time(),
     inference_calls = 0L,
     tool_calls = 0L,
-    tokens = c(0, 0, 0)
+    tokens = c(0, 0, 0),
+    error = NULL
   )
 }
 
@@ -459,6 +488,9 @@ tally_agent_otel_turn <- function(tally, turn) {
 record_agent_otel <- function(span, provider, model, tally) {
   attributes <- otel_metric_attributes(provider, model)
   attributes[["gen_ai.operation.name"]] <- "invoke_agent"
+  if (!is.null(tally$error)) {
+    attributes[["error.type"]] <- otel_error_type(tally$error)
+  }
   values <- list(
     "gen_ai.invoke_agent.duration" = elapsed_secs(tally$start),
     "gen_ai.invoke_agent.inference_calls" = tally$inference_calls,
@@ -473,6 +505,9 @@ record_agent_otel <- function(span, provider, model, tally) {
   }
   for (name in names(values)) {
     span$set_attribute(name, values[[name]])
+  }
+  if (!is.null(tally$error)) {
+    record_otel_span_error(span, tally$error)
   }
   input <- as.integer(tally$tokens[[1]] + tally$tokens[[3]])
   output <- as.integer(tally$tokens[[2]])
@@ -499,13 +534,13 @@ tool_error_type <- function(result) {
   if (is.character(result@error)) "error" else class(result@error)[1L]
 }
 
-record_tool_otel_span_error <- function(span, error) {
+record_otel_span_error <- function(span, error) {
   if (is.null(span) || !span_recording(span)) {
     return()
   }
   span$record_exception(error)
   span$set_status("error")
-  span$set_attribute("error.type", class(error)[1L])
+  span$set_attribute("error.type", otel_error_type(error))
 }
 
 # Only activate the span if it is non-NULL. If

--- a/tests/testthat/_snaps/otel.md
+++ b/tests/testthat/_snaps/otel.md
@@ -1,0 +1,8 @@
+# request errors are recorded on spans and metrics
+
+    Code
+      chat$chat("hi")
+    Condition
+      Error in `chat_perform()`:
+      ! boom
+

--- a/tests/testthat/test-otel.R
+++ b/tests/testthat/test-otel.R
@@ -337,6 +337,7 @@ test_that("time to first token is recorded when output starts", {
   ttft <- chat_spans[[1L]]$attributes[["gen_ai.response.time_to_first_chunk"]]
   expect_type(ttft, "double")
   expect_gt(ttft, 0)
+  expect_equal(chat_spans[[1L]]$attributes[["gen_ai.request.stream"]], TRUE)
 
   points <- otel_metric_points(recorded$metrics)
   expect_setequal(
@@ -373,7 +374,12 @@ test_that("token usage and operation duration are recorded as metrics", {
       list(input = 3, cached_input = 1, output = 5)
     },
     value_turn = function(provider, model, result, has_type = FALSE) {
-      AssistantTurn(list(ContentText("hi")), tokens = c(3, 5, 1), cost = 0)
+      AssistantTurn(
+        list(ContentText("hi")),
+        tokens = c(3, 5, 1),
+        cost = 0,
+        finish_reason = "stop"
+      )
     }
   )
 
@@ -381,6 +387,14 @@ test_that("token usage and operation duration are recorded as metrics", {
     chat <- Chat$new(test_provider(), model = test_model())
     chat$chat("hi")
   })
+
+  chat_span <- recorded$traces[["chat "]]
+  expect_equal(
+    chat_span$attributes[["gen_ai.usage.cache_read.input_tokens"]],
+    1L
+  )
+  expect_equal(chat_span$attributes[["gen_ai.response.finish_reasons"]], "stop")
+  expect_null(chat_span$attributes[["gen_ai.request.stream"]])
 
   points <- otel_metric_points(recorded$metrics)
   expect_setequal(
@@ -419,6 +433,30 @@ test_that("token usage and operation duration are recorded as metrics", {
   )
   expect_equal(agent_span$attributes[["gen_ai.invoke_agent.tool_calls"]], 0L)
   expect_gt(agent_span$attributes[["gen_ai.invoke_agent.duration"]], 0)
+})
+
+test_that("request errors are recorded on spans and metrics", {
+  skip_if_not_installed("otelsdk")
+
+  local_mocked_bindings(chat_perform = function(...) stop("boom"))
+
+  recorded <- with_otel_record({
+    chat <- Chat$new(test_provider(), model = test_model())
+    expect_snapshot(chat$chat("hi"), error = TRUE)
+  })
+
+  for (span in recorded$traces[c("invoke_agent", "chat ")]) {
+    expect_equal(span$status, "error")
+    expect_equal(span$attributes[["error.type"]], "simpleError")
+  }
+
+  points <- otel_metric_points(recorded$metrics)
+  for (name in c(
+    "gen_ai.client.operation.duration",
+    "gen_ai.invoke_agent.duration"
+  )) {
+    expect_equal(points[[name]][[1L]]$attributes[["error.type"]], "simpleError")
+  }
 })
 
 test_that("request params are recorded as gen_ai.request.* attributes", {


### PR DESCRIPTION
Stacked on #1143.

Rounds out the `chat <model>` span with spec-recommended attributes and adds error reporting:

- `gen_ai.request.stream = TRUE` on streamed requests (unset otherwise, per semconv).
- `gen_ai.response.finish_reasons` from the assistant turn's `finish_reason`.
- `gen_ai.usage.cache_read.input_tokens` when the provider reports cached input tokens.
- Failed model requests now set an error status, record the exception, and set `error.type` on both the `chat` and `invoke_agent` spans. The `gen_ai.client.operation.duration` and `gen_ai.invoke_agent.duration` metrics carry `error.type` too, so error rates can be computed from either.

Implementation: the request/response section of `submit_turns()` / `submit_turns_async()` and the agent loop in `chat_impl()` / `chat_impl_async()` are wrapped in `tryCatch()` that records and rethrows. coro supports `yield()` / `await()` inside `tryCatch()`, verified before relying on it. Most of the diff is the resulting re-indentation.

Tests: mocked tests for each attribute and for the error path (both spans and both metrics).